### PR TITLE
fix: 誤ったディレクトリ参照を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,8 @@ This repository contains personal configurations for Claude AI, including:
 ├── CLAUDE.md              # Main configuration (AI reads this)
 ├── README.md              # This file - Quick start guide
 ├── docs/                  # Documentation
-│   ├── ARCHITECTURE.md   # System architecture
 │   ├── COMMANDS.md       # Command reference (English)
-│   ├── MODEL_SELECTION.md # Model selection guidelines
-│   ├── AGENT_USAGE.md    # Agent usage documentation
-│   └── PROJECT_SETUP.md  # Project setup guide
+│   └── DOCUMENTATION_RULES.md # Documentation standards
 ├── commands/              # Command definitions
 │   ├── code.md           # TDD/RGRC implementation
 │   ├── fix.md            # Quick bug fixes
@@ -230,11 +227,8 @@ For using this as your personal `.claude` configuration:
 
 ### Development Guides
 
-- [Principles Guide](./docs/PRINCIPLES_GUIDE.md) - Complete overview of all development principles
+- [Principles Guide](./rules/PRINCIPLES_GUIDE.md) - Complete overview of all development principles
 - [Documentation Rules](./docs/DOCUMENTATION_RULES.md) - Standards for documentation
-- [Project Setup](./docs/PROJECT_SETUP.md) - Getting started guide
-- [Model Selection](./docs/MODEL_SELECTION.md) - AI model usage guidelines
-- [Agent Usage](./docs/AGENT_USAGE.md) - Working with specialized agents
 
 ## 🤝 Contributing
 

--- a/ja/README.md
+++ b/ja/README.md
@@ -18,11 +18,8 @@
 ├── CLAUDE.md              # メイン設定（AIが読む）
 ├── README.md              # クイックスタートガイド（英語版）
 ├── docs/                  # ドキュメント
-│   ├── ARCHITECTURE.md   # システムアーキテクチャ
 │   ├── COMMANDS.md       # コマンドリファレンス（英語）
-│   ├── MODEL_SELECTION.md # モデル選択ガイドライン
-│   ├── AGENT_USAGE.md    # エージェント使用ドキュメント
-│   └── PROJECT_SETUP.md  # プロジェクトセットアップガイド
+│   └── DOCUMENTATION_RULES.md # ドキュメント標準
 ├── commands/              # コマンド定義
 │   ├── code.md           # TDD/RGRC実装
 │   ├── fix.md            # クイックバグ修正
@@ -229,11 +226,8 @@
 
 ### 開発ガイド
 
-- [原則ガイド](../docs/PRINCIPLES_GUIDE.md) - すべての開発原則の完全な概要
+- [原則ガイド](../rules/PRINCIPLES_GUIDE.md) - すべての開発原則の完全な概要
 - [ドキュメントルール](../docs/DOCUMENTATION_RULES.md) - ドキュメントの標準
-- [プロジェクトセットアップ](../docs/PROJECT_SETUP.md) - はじめ方ガイド
-- [モデル選択](../docs/MODEL_SELECTION.md) - AIモデル使用ガイドライン
-- [エージェント使用](../docs/AGENT_USAGE.md) - 専門エージェントとの作業
 
 ## 🤝 貢献
 


### PR DESCRIPTION
- PRINCIPLES_GUIDE.mdへのパスを./docs/から./rules/に修正
- 存在しないファイル（AGENT_USAGE.md、ARCHITECTURE.md、MODEL_SELECTION.md、PROJECT_SETUP.md）への参照を削除
- 構造図を実際のファイル構造に合わせて簡潔化

🤖 Generated with [Claude Code](https://claude.com/claude-code)