### PR TITLE
docs: SECURITY/PITFALLS ルール追記 + pu.sh 教訓 memory 追加

### DIFF
--- a/rules/development/PITFALLS.md
+++ b/rules/development/PITFALLS.md
@@ -2,13 +2,19 @@
 
 Edge-case constraints from external tools and languages. Before implementation, verify naming and format rules for the target. On error, suspect a constraint violation first and scan for similar cases.
 
-| #   | Tool/Context     | Pitfall                                               | Verification                                |
-| --- | ---------------- | ----------------------------------------------------- | ------------------------------------------- |
-| 1   | Git branch/tag   | `[` `]` `~` `^` `:` `\` `..` space prohibited         | `git check-ref-format --branch "name"`      |
-| 2   | npm package name | max 214 chars, lowercase enforced, `@scope/` format   | `npm info package-name`                     |
-| 3   | Docker image/tag | lowercase only, `/` is namespace, `:` is tag          | Check official documentation                |
-| 4   | Regex engine     | PCRE vs ERE vs BRE vs JavaScript differences          | Check `--help` for engine used              |
-| 5   | macOS filename   | `:` prohibited, case-insensitive by default           | `touch "test:file"` to verify error         |
-| 6   | semver version   | `MAJOR.MINOR.PATCH` required, leading `v` is separate | `npx semver "version"` to validate          |
-| 7   | Env var name     | Alphanumeric and `_` only, no leading digit           | `export` to check existing, POSIX-compliant |
-| 8   | JSON key name    | Double quotes required, trailing comma prohibited     | `jq . file.json` to check parse error       |
+Also covers backend runtime hazards (N+1, missing pagination, optimistic-lock skew) where missing safeguards regularly cause production incidents.
+
+| #   | Tool/Context      | Pitfall                                                                                                                              | Verification                                                |
+| --- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| 1   | Git branch/tag    | `[` `]` `~` `^` `:` `\` `..` space prohibited                                                                                        | `git check-ref-format --branch "name"`                      |
+| 2   | npm package name  | max 214 chars, lowercase enforced, `@scope/` format                                                                                  | `npm info package-name`                                     |
+| 3   | Docker image/tag  | lowercase only, `/` is namespace, `:` is tag                                                                                         | Check official documentation                                |
+| 4   | Regex engine      | PCRE vs ERE vs BRE vs JavaScript differences                                                                                         | Check `--help` for engine used                              |
+| 5   | macOS filename    | `:` prohibited, case-insensitive by default                                                                                          | `touch "test:file"` to verify error                         |
+| 6   | semver version    | `MAJOR.MINOR.PATCH` required, leading `v` is separate                                                                                | `npx semver "version"` to validate                          |
+| 7   | Env var name      | Alphanumeric and `_` only, no leading digit                                                                                          | `export` to check existing, POSIX-compliant                 |
+| 8   | JSON key name     | Double quotes required, trailing comma prohibited                                                                                    | `jq . file.json` to check parse error                       |
+| 9   | DB query in loop  | N+1 pattern. Batch fetch + `Map` group instead. Drop unused `include`                                                                | `EXPLAIN ANALYZE` and query log for repeat patterns         |
+| 10  | `await` chain     | Independent `await`s run serially. Use `Promise.all()`; `Promise.allSettled()` for partial-failure tolerance                         | Grep consecutive `await`, check profiler timeline           |
+| 11  | List endpoint     | Missing pagination. Require `limit`/`offset` plus upper-bound validation (default 100)                                               | Inspect handler and OpenAPI; reject unbounded list returns  |
+| 12  | Concurrent update | No optimistic lock. Add `version` column, include in `WHERE`, return 409 on mismatch. Check `version === undefined` (not `!version`) | Inspect schema and `UPDATE ... WHERE` clause                |

--- a/rules/development/SECURITY.md
+++ b/rules/development/SECURITY.md
@@ -7,6 +7,9 @@ Complements guardrails (static detection). Covers missing validations, absent au
 - MUST validate all API endpoint inputs with a schema, on client and server
 - MUST apply length limits to search queries and free-text fields
 - MUST NOT pass client-supplied type information directly to the DB or other trust boundaries
+- MUST validate `Content-Length` and reject `NaN` to prevent payload-size bypass
+- MUST validate redirect targets such as `returnUrl` against a host allowlist; reject `javascript:` and `data:` schemes
+- MUST NOT build request objects with `...body` spread; assign explicit fields to prevent prototype pollution
 
 ## Access Control
 
@@ -16,13 +19,22 @@ Complements guardrails (static detection). Covers missing validations, absent au
 - MUST NOT reveal resource existence to unauthenticated users (prefer 404 over 403)
 - MUST apply rate limiting to auth endpoints (login, register, password-reset)
 - MUST apply request limits to endpoints that trigger external API calls
+- MUST verify CSRF tokens on state-changing requests (POST/PUT/PATCH/DELETE) using Double Submit Cookie
 
 ## Secrets
 
 - MUST throw an error when a required env var is missing. Do not fall back to a hardcoded value
 - MUST use a cryptographically secure random source for session IDs, tokens, and one-time codes
+- MUST use constant-time comparison for tokens and signatures (XOR all bytes, decide last); never use `===`
+- MUST verify webhook signatures with HMAC-SHA256 plus constant-time comparison
+
+## Outbound Requests
+
+- MUST validate webhook destination URLs against a host allowlist; reject private IP ranges (127.0.0.0/8, 10.0.0.0/8, etc.) to prevent SSRF
 
 ## Output
 
 - MUST NOT include stack traces, internal paths, or DB details in responses. Return a generic message; log details server-side only
 - MUST NOT distinguish auth failure reasons (for example, "wrong password" vs "email not found")
+- MUST set CSP, `X-Frame-Options: DENY`, HSTS (`max-age=63072000`), `X-Content-Type-Options: nosniff`, and `Permissions-Policy` from middleware
+- MUST NOT set `Access-Control-Allow-Origin: *`; specify allowed origins explicitly


### PR DESCRIPTION
## 概要

軽量バックログ 3 件を 1 PR にまとめた docs-only 変更。

- #11 SECURITY.md: 未記載 8 ルール (CSRF, redirect allowlist, prototype pollution, timing attack, webhook signature, SSRF, security headers, payload-size NaN) を追記。既存の Input / Access Control / Secrets / Output に配分し、SSRF 用に Outbound Requests セクションを新設。
- #12 PITFALLS.md: backend ランタイム hazard 4 件 (N+1 in loop, serial `await`, missing pagination, optimistic-lock skew) を表行で追加。元 issue は PERFORMANCE.md 新設を想定していたが、構造制約より実装の落とし穴に近いので PITFALLS.md に統合。preamble 1 行で scope を runtime hazards へ拡張。
- #15 (PR diff 対象外): pu.sh の harness 設計教訓 11 件を `~/.claude/projects/-Users-thkt--claude/memory/reference_pu-sh-lessons.md` に配置し `MEMORY.md` から参照。`projects/` は `.gitignore` 管理なので git には乗らない。マージ後に memory パスをコメント付きで手動 close 予定。

## 確認事項

- [x] `git diff` で SECURITY.md と PITFALLS.md を確認
- [x] em-dash 撤廃と「コロン止めでテーブル導入しない」規約を遵守
- [x] inline code は識別子とコマンドリテラルに限定
- [ ] マージ後に #15 へ memory ファイルパスを記載してクローズ

Closes #11
Closes #12