### PR TITLE
feat: skill/template に 4 ルール追記 (#30 #31 #32 #34)

### DIFF
--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -26,6 +26,24 @@ Use `$ARGUMENTS` to capture full input. `$N` is 0-indexed split (`$0` first word
 
 If "Update existing" → list recent ADRs in `<git-root>/docs/decisions/` for selection via AskUserQuestion.
 
+## Adoption Gate
+
+Before starting the 6-Phase Process, confirm all three conditions hold. If any one is missing, skip the ADR and record the decision somewhere lighter.
+
+| # | Condition                                                                                            | Failing example                                          |
+| - | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| 1 | Hard to reverse. Changing the decision later carries meaningful cost                                 | Library swap with one isolated import boundary           |
+| 2 | Surprising without context. A future reader will ask "why this way?"                                 | Choosing the only option the framework supports          |
+| 3 | Result of a real trade-off. Genuine alternatives existed and one was picked for specific reasons     | Following an established team convention by default      |
+
+| Outcome                  | Demote to                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| Conditions 1 or 2 fail   | `CONTEXT.md` entry (or equivalent project glossary / design notes)                   |
+| Only condition 3 fails   | Commit message body (record the rationale alongside the change)                      |
+| All three pass           | Proceed to the 6-Phase Process below                                                 |
+
+Reference: mattpocock/skills `grill-with-docs` SKILL.md `Offer ADRs sparingly`.
+
 ## 6-Phase Process
 
 | Phase         | Actions                                                                                                                            |

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code
-description: Implement code following TDD/RGRC cycle with real-time test feedback. Do NOT use for small bug fixes or error resolution (use /fix instead).
+description: Implement code following TDD/RGRC cycle with real-time test feedback. Vertical slices only (one test then one impl, never bulk tests then bulk impl). Do NOT use for small bug fixes or error resolution (use /fix instead).
 when_to_use: 実装して, コード書いて, implement, coding
 allowed-tools: Bash(npm run) Bash(npm run:*) Bash(yarn run) Bash(yarn run:*) Bash(yarn:*) Bash(pnpm run) Bash(pnpm run:*) Bash(pnpm:*) Bash(bun run) Bash(bun run:*) Bash(bun:*) Bash(cargo:*) Bash(make:*) Bash(git status:*) Bash(git log:*) Bash(which:*) Edit MultiEdit Write Read LS Task AskUserQuestion Bash(ugrep:*) Bash(bfs:*)
 model: opus

--- a/skills/issue/templates/feature.md
+++ b/skills/issue/templates/feature.md
@@ -21,6 +21,13 @@
 ## Constraints (optional)
 
 - [Technical constraints, prohibited approaches, dependencies]
+
+## Testing Decisions
+
+- [Definition of "good" for this issue: external behavior only, not implementation details]
+- [Modules under test: which module/component/function gets tested]
+- [Prior art: link or filename for the most similar existing test]
+- [Skip rationale (optional): if no test is added, state why explicitly]
 ```
 
 ## Guidelines
@@ -31,3 +38,4 @@
 | Acceptance Criteria | "When user clicks Export, a .csv downloads"   | "CSV export works correctly"               |
 | Scope - Out of      | "Excel format is out of scope"                | (omitted)                                  |
 | Constraints         | "Must not add new dependencies"               | (omitted when there are known constraints) |
+| Testing Decisions   | "Test the CSV serializer; mirror tests/orders.test.ts" | "TBD" or skipped without rationale |

--- a/skills/think/references/step-7-8-document-generation.md
+++ b/skills/think/references/step-7-8-document-generation.md
@@ -16,6 +16,7 @@ Apply before writing each section.
 | Why     | 5 fields all filled. Outcome = measurable result, not deliverable                                                                 |
 | AC      | Each traces to Why Outcome. Observable signal column filled (HTTP 200, state X). No orphan ACs, no scope creep beyond Why Problem |
 | Scope   | Out of Scope traces Why field or constraint. In Scope Observable outcome column filled (concrete signal)                          |
+| Bound   | Boundaries section is optional. When present, at least one Never row required. Enforced by column names a concrete mechanism      |
 | Impl    | Files < 5 per Phase. Steps describe concrete changes                                                                              |
 | Test    | Every AC has ≥1 test. Verification states what is checked concretely                                                              |
 | Risks   | ≥1 risk identified. Probability column filled. Mitigation required when Impact = HIGH                                             |

--- a/skills/think/templates/sow.md
+++ b/skills/think/templates/sow.md
@@ -46,6 +46,16 @@ Observable outcome: concrete signal that the change landed (new endpoint returns
 
 Out of Scope rule: list anything that does not contribute to the Why Outcome but might be assumed. Each entry must trace to a Why field (Problem, Outcome, Urgency) or an explicit constraint. No fixed checklist.
 
+### Boundaries
+
+<!-- Optional. Three-Tier (Always / Ask first / Never). When present, at least one Never row is required. Enforced by names the mechanism so reviewers can spot duplicates with shields/guardrails coverage. -->
+
+| Tier      | Item                                                       | Enforced by                              |
+| --------- | ---------------------------------------------------------- | ---------------------------------------- |
+| Always    | [behavior the agent should always perform]                 | [hook / spec only / manual review]       |
+| Ask first | [action that requires confirmation before execution]       | [hook / spec only / manual review]       |
+| Never     | Never commit secrets                                       | shields hook                             |
+
 ## Acceptance Criteria
 
 <!-- Each AC must trace to the Why Outcome. ACs that don't serve the Outcome are scope creep. -->

--- a/skills/think/templates/spec.md
+++ b/skills/think/templates/spec.md
@@ -67,6 +67,18 @@ Attributes: semantic descriptions ("list of authors", "optional thread origin").
 
 Depends: list prior Phase IDs this phase requires, or `none` for parallel-executable. Enables agents to schedule independent phases concurrently.
 
+## Testing Decisions
+
+<!-- Strategy-level. Concrete scenarios go in Test Scenarios below. -->
+
+| Decision               | Value                                                                |
+| ---------------------- | -------------------------------------------------------------------- |
+| Definition of "good"   | [external behavior only, not implementation details]                 |
+| Modules under test     | [which modules / components / pure functions]                        |
+| Mock boundary          | [what is real, what is mocked, why]                                  |
+| Prior art              | [link or filename for the closest existing test, if any]             |
+| Skip rationale         | [if some FRs intentionally have no T-NNN, state why]                 |
+
 ## Test Scenarios
 
 | ID    | Type        | FR     | Given          | When     | Then     |

--- a/skills/use-workflow-tdd-cycle/SKILL.md
+++ b/skills/use-workflow-tdd-cycle/SKILL.md
@@ -69,6 +69,30 @@ Test behavior via public API. Mock only at system boundaries.
 
 30s: Write failing test → 1min: Make pass → 10s: Run tests → 30s: Tiny refactor → 20s: Commit if green. Bugs are always in the last 2-minute change.
 
+## Vertical Slices Only
+
+Stack RGRC cycles vertically per behavior. Never expand horizontally by writing all tests first and all implementations later.
+
+```
+Wrong (horizontal):
+  Red:   test1, test2, test3, test4, test5
+  Green: impl1, impl2, impl3, impl4, impl5
+
+Right (vertical):
+  Red → Green: test1 → impl1
+  Red → Green: test2 → impl2
+  ...
+```
+
+| # | Hazard from horizontal slices                                                |
+| - | ---------------------------------------------------------------------------- |
+| 1 | Bulk-written tests verify imagined behavior instead of real behavior         |
+| 2 | Tests degrade into structural assertions (data shape, signature) only        |
+| 3 | Sensitivity to behavior change drops (pass when broken, fail when correct)   |
+| 4 | Implementation knowledge follows test structure instead of guiding it        |
+
+Reference: mattpocock/skills `tdd` SKILL.md.
+
 ## Test Failure Judgment
 
 When a test fails, decide whether to fix the test or the implementation.


### PR DESCRIPTION
## 概要

軽量バックログ 4 件を 1 PR にまとめた skill/template 追記。`source:mattpocock-skills` 由来 3 件 + AI agent spec 分析由来 1 件。

- #30 `skills/adr/SKILL.md`: 6-Phase Process の前に Adoption Gate を追加。`Hard to reverse` / `Surprising without context` / `Result of a real trade-off` の 3 条件 AND ゲート。1〜2 件失敗で `CONTEXT.md` 降格、3 件目だけ失敗なら commit message 降格。出典: mattpocock/skills `grill-with-docs`
- #31 `skills/use-workflow-tdd-cycle/SKILL.md` + `skills/code/SKILL.md`: RGRC Cycle に Vertical Slices Only セクション追加。bulk Red → bulk Green の horizontal slices で発生する 4 ハザード (imagined behavior, structural assertion, behavior insensitivity, structure-first knowledge) を表で禁止。`/code` description に "vertical slices only" 強調を追加。出典: mattpocock/skills `tdd`
- #32 `skills/issue/templates/feature.md` + `skills/think/templates/spec.md`: Testing Decisions セクション追加。`/think` Spec は戦略レベル (mock boundary, modules under test, skip rationale)、`/issue` feature は実装単位の合意 (definition of good, prior art) で粒度を分ける。出典: mattpocock/skills `to-prd`
- #34 `skills/think/templates/sow.md` + `skills/think/references/step-7-8-document-generation.md`: Out of Scope 直後に Three-Tier Boundaries (`Always` / `Ask first` / `Never`) を任意追加。`Never commit secrets` を例として記載。Quality Gate に Bound 行追加 (Never 最低 1 行必須)。出典: GitHub agent-config 2,500 件分析 (Six Core Areas)

## 確認事項

- [x] 各 commit の diff を確認
- [x] em-dash 撤廃と「コロン止めでテーブル導入しない」規約を遵守
- [x] inline code は識別子と外部参照のみ
- [x] /code skill description が 200 文字以内 (新規 description 追記後)
- [x] sow.md の Boundaries は optional 扱い (空でも spec validation を通す)

Closes #30
Closes #31
Closes #32
Closes #34