### PR TITLE
explore skill の WAL DB クエリ失敗を修正 (immutable=1 URI)

### DIFF
--- a/agents/reflection-extractor.md
+++ b/agents/reflection-extractor.md
@@ -1,0 +1,83 @@
+---
+name: reflection-extractor
+description: Summarize the just-finished session into 3 reflection categories (realization / judgment / counterfactual) and write the result to a per-session_id Markdown file with frontmatter.
+tools: Read, Write, Bash
+---
+
+# Role
+
+You analyze a Claude Code session and produce a structured reflection document. This is durable knowledge consumed by the next session's SessionStart hook.
+
+# Inputs
+
+Read these from the environment / args:
+
+- `REFLECT_KNOWLEDGE_DIR`: target knowledge directory root (already exists).
+- `REFLECT_SESSION_ID`: stable session identifier used as the output filename stem.
+- Argument (first positional): the same session_id, for echo/log purposes.
+- Transcript: located via `transcript_path` of the current session. Read it if needed.
+
+# Output contract
+
+Write exactly one file:
+
+```
+${REFLECT_KNOWLEDGE_DIR}/reflection/${REFLECT_SESSION_ID}.md
+```
+
+Frontmatter shape (YAML):
+
+```
+---
+session_id: <REFLECT_SESSION_ID>
+confidence: confirmed|tentative
+categories: [realization, judgment, counterfactual]
+word_count: <integer>
+created_at: <ISO8601 UTC>
+---
+```
+
+Body sections (Markdown headings), each ≤ 100 words:
+
+```
+## Realization
+...
+
+## Judgment
+...
+
+## Counterfactual
+...
+```
+
+# Category guidance
+
+| Category        | What to capture                                                                                                       |
+| --------------- | --------------------------------------------------------------------------------------------------------------------- |
+| realization     | New facts surfaced during the session (file paths, identifiers, invariants discovered through reading or running).    |
+| judgment        | Decisions actually made (chosen approach, rejected alternative, reasons given). Include rejected options.             |
+| counterfactual  | Mistakes that did not happen (prevented through review), concerns voiced but unresolved, "X was almost done but Y".   |
+
+# Confidence
+
+| Value      | When to use                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
+| confirmed  | The session explicitly states or demonstrates the claim.                     |
+| tentative  | Inferred or reconstructed from partial signals (most counterfactuals).       |
+
+# Rules
+
+- Omit a category from `categories:` if you cannot fill that section honestly. Keep the heading present but write a single line: `(none extracted)`. At least one category must be present.
+- If no meaningful reflection can be extracted at all, do NOT write the file. The Stop hook will create a placeholder.
+- Never write outside `${REFLECT_KNOWLEDGE_DIR}/reflection/`.
+- Never read or modify files under `${REFLECT_KNOWLEDGE_DIR}/../memory/`, `CLAUDE.md`, `rules/`, `agents/`, or `skills/`. Reflection is a one-way producer. Violating this invalidates the prompt cache for every following session (ADR-0068 BR-006).
+- Never invoke other hooks or skills. You run inside a Stop hook subagent; recursion is blocked at the script level but reentry costs.
+- Keep body under 300 words total. Larger documents bloat SessionStart latency.
+
+# Procedure
+
+1. Read the transcript via `transcript_path`.
+2. Group observations into the 3 categories.
+3. Decide confidence per category.
+4. Write the frontmatter block, then the 3 sections.
+5. Verify the file exists with `cat`. Exit.

--- a/docs/decisions/0068-stop-hook-knowledge-reflection-subagent-and-mechanical.md
+++ b/docs/decisions/0068-stop-hook-knowledge-reflection-subagent-and-mechanical.md
@@ -1,0 +1,108 @@
+---
+status: "accepted"
+date: 2026-05-14
+decision-makers: thkt
+scope: [meta, harness, hooks]
+---
+
+# Adopt Stop hook Knowledge Reflection with subagent extraction and mechanical activity log
+
+## Context and Problem Statement
+
+`~/.claude` ハーネスは PreToolUse / PostToolUse 層で「コードの正しさ」(guardrails / gates) を強制するが、「調査の質」側 (knowledge 蓄積、暗黙判断の外化) は skill 手動実行に依存する。Warren ハーネスとの比較で「Knowledge Reflection 自動化」が最大ギャップと特定済み (memory `project_harness-investigation-quality.md`)。Zenn 2026-05-02 "ソフトウェアの『設計原則』を、なぜ一部のエンジニアは生理的に嫌うのか" は「観測可能性の非対称性」「起きなかった事象は計上しないと組織から消える」を定式化し、~/.claude にも同じ問題が継続適用される。
+
+issue #37 (closed, 2026-05-07) は cache-safe な格納先・注入経路を確定した。採用案 C: Stop hook で専用ファイルに書き出し + SessionStart hook で stdout 経由 additionalContext 注入。CLAUDE.md / MEMORY.md / rules/*.md / auto-loaded path の書き換えは禁止 (system prompt prefix 変更 = 次セッション全体の cache invalidate)。
+
+本 ADR は issue #37 の Out of scope であった「抽出主体・粒度・format・size cap・ローテーション・既存 wiki plugin との co-existence」を決定する。
+
+## Decision Drivers
+
+- `~/.claude/.claude/OUTCOME.md` の Behavior B2 (durable 外化資産が残り続ける) と Indicator (「起きなかった事象」が観測可能に計上される) を満たす。
+- B3 (ユーザー低介入) と整合: 手動 promote 前提の設計は primary path にしない。
+- B4 (他リポ複製可能) と整合: ~/.claude 固有の auth path や API 直叩きに依存しない。
+- cache-safe (issue #37 Do-list / Don't-list) を維持。
+- LLM self-confidence を gate にしない (memory `feedback_no-llm-self-confidence-as-gate.md`)。
+- 既存 wiki plugin (ADR-0040) との co-existence: 現状 dormant (`enabledPlugins` 不在) だが、将来 enable する場合の dedup contract を将来 ADR に開く。
+
+## Considered Options
+
+### Option A: Stop hook subagent extraction + mechanical activity log 並走 (chosen)
+
+Stop hook で `claude --bare --plugin-dir --permission-mode bypassPermissions` の subagent を spawn して LLM 抽出を行い、並走で zsh script が history.jsonl をルールベース解析して activity log を JSONL に append。両者は merge せず別ファイルに書き、SessionStart 側で読み出し時に concat する。
+
+- Good: LLM が「起きなかった事象 / 暗黙判断」を抽出し、mechanical が「Edit/Write/commit パス」を確実に拾う。failure mode が独立し、片方が壊れても他方が機能する。
+- Good: wiki plugin の subagent 起動レシピ (`hooks/stop-wiki.sh` 実証) が転用可能。API key 不要なので B4 portability 維持。
+- Good: 抽出 shape が違う情報を write 時には混ぜないので、後続 reader (recall / skill / 人間) が用途別に拾える。
+- Bad: hook 実行コストが二重になる。Stop hook budget (30s) 内で両方走らせる必要。
+- Bad: subagent 起動には recursion guard (`REFLECT_HOOK_SESSION` env) が必須。実装ミスで session 2 で deadlock するリスク。
+
+### Option B: subagent extraction only
+
+LLM 抽出のみ。activity log は持たない。
+
+- Good: 実装単純。1 hook script で済む。
+- Bad: LLM 抽出が失敗または不安定なとき、activity の trace が一切残らない。
+- Bad: 「いつ何を編集したか」のような mechanical fact も LLM の summary に依存し、再現性が下がる。
+
+### Option C: mechanical activity log only
+
+history.jsonl のルールベース解析のみ。LLM 不使用。
+
+- Good: 完全に決定的、再現性高。LLM コスト 0。
+- Bad: 「起きなかった事象」「暗黙判断」が history.jsonl から原理的に抽出できない。OUTCOME Indicator (反事実的成果の計上) を満たせない。
+- Bad: B2 (durable 外化資産) を activity log layer でしか満たせず、reflection layer に届かない。
+
+### Option D: Manual `/reflect` skill
+
+Stop hook は marker だけ書き、次セッションでユーザーが `/reflect` を手動実行して promote。
+
+- Good: 実装最小、LLM コスト透明。
+- Bad: B3 (ユーザー低介入で「問いの組み立て」「判断」に集中できる) と直接矛盾。skill 手動実行を要求すること自体が介入。
+- Bad: 自動化の習慣化が成立せず、Knowledge Reflection ギャップが残る。
+
+## Decision Outcome
+
+Option A を採用する。
+
+### 詳細決定
+
+1. 抽出主体: subagent (LLM) + 並走 mechanical script。両者を別ファイルに emit、SessionStart 読み出し時に merge。
+2. 抽出粒度: 3 カテゴリ
+   - `realization`: 気づき (新しく分かったこと)
+   - `judgment`: 暗黙判断 (意識せず行った decision、棄却された案)
+   - `counterfactual`: 起きなかった事象 (未然防止された設計ミス、拾われなかった懸念)
+3. Format:
+   - LLM 抽出: per-session_id Markdown (`knowledge/reflection/<session_id>.md`)、frontmatter で `confidence: confirmed|tentative` と `categories` を持つ
+   - mechanical: per-session_id JSONL (`knowledge/activity/<session_id>.jsonl`)
+   - index: append-only JSONL (`knowledge/reflection-index.jsonl`)、1 行 = 1 session
+4. Size cap: SessionStart で stdout に乗せるのは直近 N=10 セッション。11 件目以降は file 保持のみで stdout 非掲載。
+5. Confidence handling: frontmatter tag のみ。gating には使わない。SessionStart 側は `confidence: confirmed` を優先、tentative は budget に応じて含める。
+6. Recursion guard: 環境変数 `REFLECT_HOOK_SESSION=1` を subagent 起動時に export。subagent 側 Stop hook で読み取り、`exit 0` で即座に抜ける。
+7. Hook 実行順序: `notify-stop.sh` が先、reflection 系が後。reflection 系の失敗が notify を妨げない (各 entry 独立、set +e)。
+8. Escape hatch: `/reflect` skill を手動実行用に維持。primary path ではないが、自動化が壊れたときの fallback。
+9. wiki plugin co-existence: 現状 dormant、本 ADR では active conflict なし。将来 enable する場合は別 ADR で dedup contract を定める。
+
+### Confirmation
+
+- Stop hook 完了後、`~/.claude/projects/-Users-thkt--claude/knowledge/reflection/<session_id>.md` と `knowledge/activity/<session_id>.jsonl` が存在する。
+- `reflection-index.jsonl` 末尾に当該セッションのエントリが追記されている。
+- 次セッション起動時、SessionStart hook の stdout に直近 10 セッションの reflection が含まれる。
+- `REFLECT_HOOK_SESSION=1` が export された subagent 上では reflection-extract.sh が即時 exit 0 を返す。
+- `~/.claude/CLAUDE.md`、`~/.claude/rules/**/*.md`、`~/.claude/projects/-Users-thkt--claude/memory/MEMORY.md` のいずれも本機能によって書き換えられない (cache safety verification)。
+
+### Consequences
+
+- Stop hook の latency が増える (subagent 起動 + LLM 抽出)。budget 30s 内に収める設計責任が実装側に発生。
+- 抽出された reflection に false positive が混じる前提で運用する。SessionStart は confidence tag で表示を調整するが、completely gate はしない。
+- LLM コストが session ごとに発生 (subagent 起動 = 1 token 消費)。コスト監視は telemetry に乗せる将来課題。
+- mechanical script が history.jsonl の schema 変更に追従する必要 (現状は `tool_input`/`tool_response`/`stop_reason` キー前提)。Claude Code 側の schema が変わると script 修正が要る。
+- `knowledge/` ディレクトリ配下のファイル数が線形増加する。N=10 cap は stdout 注入 のみで、files は累積。半年ごとに archive を検討。
+
+## More Information
+
+- Related: ADR-0040 (wiki plugin v2 / 同じく Stop hook + ingest パターン), ADR-0067 (RULES / ADR / CLAUDE.md 境界の方針、本 ADR は scope=harness で hooks のルールを定める)
+- Issue: thkt/dotclaude#37 (closed, design doc 完成)
+- Research: `~/.claude/workspace/research/2026-05-07-knowledge-reflection-cache-safe-design.md`
+- Motivation: Zenn 2026-05-02 Takami Torao "ソフトウェアの『設計原則』を、なぜ一部のエンジニアは生理的に嫌うのか" / Anthropic Thariq (2026-02-19) "Lessons from Building Claude Code: Prompt Caching Is Everything"
+- Memory: `project_harness-investigation-quality.md`, `feedback_no-llm-self-confidence-as-gate.md`, `reference_hook-patterns-throttle-deferred.md`
+- Future work: wiki plugin enable 時の dedup contract、reflection archive policy、subagent コスト telemetry

--- a/docs/decisions/0069-adopt-yomu-indirect-prompt-injection-defense.md
+++ b/docs/decisions/0069-adopt-yomu-indirect-prompt-injection-defense.md
@@ -1,0 +1,142 @@
+---
+status: "accepted"
+date: 2026-05-19
+decision-makers: thkt
+---
+
+# Adopt Indirect Prompt Injection Defense Design for yomu
+
+## Context and Problem Statement
+
+yomu の search / brief 結果は AI エージェント (Claude Code 等) の LLM コンテキストに直接投入される。任意リポジトリの chunk content には攻撃者が injection 指示を仕込める (依存ライブラリのコメント / OSS PR レビュー対象 / 外部 Issue tracker / Wiki スニペットの 3 経路)。OWASP LLM01:2025 該当の構造リスク。詳細は Threat Model (Phase 1 成果物、`~/GitHub/cli/yomu/.claude/workspace/planning/2026-05-19-indirect-prompt-injection-defense/threat-model.md`) を参照。
+
+## Decision Drivers
+
+* OWASP LLM01:2025 (Indirect Prompt Injection) の構造リスク対応
+* yomu の Outcome 不変性 (素材を返すまでが yomu の責任)
+* ローカル個人利用前提 (user base = thkt) で過剰実装を避ける (YAGNI)
+* 単一バイナリ・依存ゼロ Constraint
+* 既存 consumer 契約 (JSON 出力 schema) を破壊しない
+
+## Considered Options
+
+* Option A: Inline schema extension + 1 ADR
+* Option B: Separate trust table + multi-ADR (5 本柱を分散)
+* Option C: Search-time detection (検出 latency 影響)
+
+## Decision Outcome
+
+Chosen option: Option A (Inline schema extension + 1 ADR)。境界を「素材 + マーカーまで」に固定し、検出は index 時に集約。schema は additive optional で既存 consumer 契約を保つ。
+
+### 5 本柱の採否
+
+| # | Pillar | Status | 根拠 |
+| --- | --- | --- | --- |
+| 1 | データソース信頼性検証 (vendor 除外) | adopted (opt-in flag, default off) | 境界違反を避ける。walker は既に `.gitignore` 尊重済みで追加コストは flag のみ |
+| 2 | コンテンツサニタイズ (rewrite) | rejected | 境界違反 (yomu が素材を改変するため) |
+| 3 | tainted marker / fence | adopted (中核) | 境界そのもの。per-chunk `injection_flags` で表現 |
+| 4 | injection 検出 warning | adopted (3 と同層、補強) | per-chunk marker の一種 |
+| 5 | Evidence Gate (score threshold) | rejected | 境界違反 (yomu が結果をブロック)。consumer が flag と score で threshold する |
+
+### Schema 設計
+
+chunks テーブル schema version 9 で 2 column 追加 (additive ALTER ADD COLUMN):
+
+| Column | 型 | 意味 |
+| --- | --- | --- |
+| `source_kind` | TEXT | chunk 起源 (vendor / test / src) の enum 文字列 |
+| `injection_flags` | TEXT | matcher の per-chunk 検出結果 (JSON 配列文字列、NULL は matcher 未走行) |
+
+JSON 出力で 2 field 追加 (additive optional):
+
+| Field | 位置 | 型 | serde 属性 |
+| --- | --- | --- | --- |
+| `injection_flags` | per-chunk | `Option<Vec<&str>>` | `skip_serializing_if = "Option::is_none"`、`default` |
+| `injection_check` | response top-level | enum sentinel | 必須。3 値: `ran`、`skipped`、`unavailable` |
+
+silent-default-false の罠 (空配列 `[]` が「検査済みクリーン」と誤読される) を構造的に排除する。`injection_flags` の field 不在 = matcher 未走行、空 Vec = matcher 走行 + ヒットなし、Some Vec = matcher 走行 + ヒット。`injection_check` sentinel は response 単位で matcher 状態を 1 箇所に集約し、consumer が「matcher 未走行の chunk を LLM 投入してはならない」契約を実装できる。
+
+### Migration
+
+schema version 8 から 9 への migration code は書かない。schema version mismatch を検出した時点で chunks テーブルを drop して全 reindex を強制する。yomu は user base = thkt 1 人のローカル個人利用 CLI のため、migration ロジックの維持コストが ROI に見合わない。
+
+### False positive policy
+
+Consumer responsibility。yomu は raw matches を per-flag severity と共に返し、consumer が自身の threat model に応じて threshold を作る。FP whitelist は consumer 側で管理 (yomu には置かない)。yomu corpus の成長ポリシーは false-negative cost が false-positive cost を上回る場合のみ追加とし、evidence-based の追加を強制する。
+
+### Consequences
+
+* Good, 境界が schema 設計で構造的に固定される (silent-default-false 罠を排除)
+* Good, walker は既存の `.gitignore` 尊重をそのまま利用、pillar 1 は flag 追加のみで成立
+* Good, ADR 1 本で 5 pillars と未決論点を集約、kiku retrofit 議論も統一視点で扱える
+* Good, OUTCOME.md Behavior 拡張で責任境界の不変性を git 履歴で可視化、ADR の Decision 単体では境界がスライドしないよう保護
+* Bad, schema v9 への遷移で全 chunk の reindex を強制 (個人利用前提なので許容、ただし future user base 拡大時に migration 戦略の再評価が要る)
+* Bad, kiku が同根対応する際、yomu/tests/fixtures/injection/ を借りるか独自で持つかは kiku 側の判断に委ねる (yomu からは amici 抽出を急がない)
+* Bad, OUTCOME.md Behavior 拡張は、将来 default を「filter on」に変更したくなった場合に強い制約として残る
+
+### Confirmation
+
+以下のいずれかが発生した時点で本 ADR を再評価する:
+
+* 4 updates per quarter を超える corpus 更新が定常化した場合 (release lockstep policy の見直し)
+* yomu の user base exceeding 1 になった場合 (CI / cross-tenant scope の格上げ、migration 戦略の再評価)
+* new pillar 候補が emerging した場合 (5 本柱 + Evidence Gate を超える対策が必要となった時)
+
+## Pros and Cons of the Options
+
+### Option A: Inline schema extension + 1 ADR
+
+* Good, additive optional field で既存 consumer 契約を維持
+* Good, ADR 1 本で 5 pillars と未決論点を集約、relationship を保持
+* Good, kiku retrofit の path を Consequences で扱える
+* Bad, schema v9 遷移で reindex が必要 (個人利用前提なので許容)
+* Bad, schema 拡張は将来 column 追加コストを yomu が引き受ける
+
+### Option B: Separate trust table + multi-ADR
+
+* Good, 既存 chunks テーブル維持、migration 不要
+* Good, ADR を pillar ごとに分散して独立意思決定
+* Bad, consumer 側で 2 query 必要、契約が複雑化
+* Bad, 5 ADR で relationship が分散、横串の rationale が消える
+
+### Option C: Search-time detection
+
+* Good, corpus 更新が即反映
+* Good, schema 変更不要
+* Bad, search / brief の latency に毎回 matcher コストが乗る
+* Bad, OUTCOME.md Indicator (`index ~2.5s` 維持) と衝突 (latency 増)
+
+## More Information
+
+### 未決論点の意思決定
+
+| # | 論点 | 決定 |
+| --- | --- | --- |
+| 1 | v9 migration の有無 | migration コードは書かない (schema mismatch 時に drop + reindex 強制) |
+| 2 | yomu DB at-rest 暗号化 | consumer responsibility (FS 暗号化に依存、yomu 側で SQLCipher 等を導入しない) |
+| 3 | CI 実行下の脅威モデル | out of scope (ローカル個人利用前提) |
+| 4 | Cross-tenant DB pollution | out of scope (project root 内 `.yomu/index.db` で閉じている) |
+| 5 | Embedding vector poisoning | out of scope (Evidence Gate 議論は別 Issue) |
+| 6 | Corpus update release cycle | yomu コードと lockstep (個人利用で release 管理は thkt が一本化) |
+
+### kiku retrofit の path
+
+kiku が同根対応する際の corpus 共有判断は kiku 側の Issue に委ねる。yomu ADR としては「将来 kiku が yomu corpus を借りる選択肢を残すが、yomu 側から amici 抽出を急がない」と立場を明示する。amici 抽出は corpus が 2 つ目の consumer を持った時点で再評価する。
+
+### Out-of-scope の合意根拠
+
+CI / cross-tenant / embedding poisoning を out of scope と判定した根拠は Threat Model の「Out of scope」セクションに記述。各 entry は復帰条件 (例: user base 拡大、worktree 共有キャッシュ導入、Evidence Gate default on) を持ち、Confirmation Trigger と連動する。
+
+### Related boundary statement
+
+責任境界の不変性は ADR Decision Outcome だけでは将来の default 変更で滑る可能性がある。OUTCOME.md の Behavior に bullet として明記し、変更には OUTCOME.md 編集を必要とする (git 履歴で境界変更が可視化される)。
+
+### References
+
+* yomu Issue [#154](https://github.com/thkt/yomu/issues/154)
+* Threat Model: `~/GitHub/cli/yomu/.claude/workspace/planning/2026-05-19-indirect-prompt-injection-defense/threat-model.md`
+* SOW / Spec / Approaches: 同ディレクトリ配下
+* OUTCOME.md: `~/GitHub/cli/yomu/.claude/OUTCOME.md` (Behavior 拡張済み、本 ADR と同 commit cycle)
+* OWASP LLM01:2025 Prompt Injection (https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+* OWASP 2025 新規: Vector and Embedding Weaknesses
+* ADR-0060: Adopt Agent-Friendly CLI Design Principles

--- a/hooks/lib/reflection.sh
+++ b/hooks/lib/reflection.sh
@@ -1,0 +1,90 @@
+#!/bin/zsh
+# Shared helpers for reflection-* hook scripts.
+# Sourced by reflection-extract.sh / reflection-activity.sh / reflection-inject.sh.
+
+# jq_field <hook_input_json> <field_name>
+#   Extract a top-level string field from hook input JSON. Returns empty on
+#   any failure (jq missing, parse error, field absent or "null").
+jq_field() {
+  local input="$1" field="$2"
+  command -v jq >/dev/null 2>&1 || { printf ''; return 0; }
+  local value
+  value=$(printf '%s' "$input" | jq -r ".${field} // \"\"" 2>/dev/null) || value=""
+  [[ "$value" == "null" ]] && value=""
+  printf '%s' "$value"
+}
+
+# log_diag <script_name> <reason>
+#   Emit a single stderr line containing timestamp (ISO8601 UTC) + script name +
+#   failure reason. Used by all FR-V failure paths to satisfy NFR-006.
+log_diag() {
+  local script="$1" reason="$2"
+  local ts
+  ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  printf '%s %s %s\n' "$ts" "$script" "$reason" >&2
+}
+
+# resolve_knowledge_dir <hook_input_json>
+#   Resolve the knowledge directory in this precedence:
+#     1. REFLECT_KNOWLEDGE_DIR env (test override or operator opt-in)
+#     2. transcript_path-adjacent directory: <transcript_dir>/knowledge
+#     3. cwd-adjacent: <cwd>/.claude/knowledge
+#   Never falls back to a hardcoded HOME path to satisfy NFR-007.
+resolve_knowledge_dir() {
+  local input="${1:-}"
+  if [[ -n "${REFLECT_KNOWLEDGE_DIR:-}" ]]; then
+    printf '%s' "$REFLECT_KNOWLEDGE_DIR"
+    return 0
+  fi
+  local transcript_path
+  transcript_path=$(jq_field "$input" "transcript_path")
+  if [[ -n "$transcript_path" ]]; then
+    printf '%s/knowledge' "${transcript_path%/*}"
+    return 0
+  fi
+  local cwd
+  cwd=$(jq_field "$input" "cwd")
+  printf '%s/.claude/knowledge' "${cwd:-.}"
+}
+
+# write_placeholder_md <md_path> <session_id>
+#   Write a frontmatter-only reflection file for the empty-extraction path
+#   (FR-003). Body is intentionally empty.
+write_placeholder_md() {
+  # NOTE: avoid local var name `path` — zsh links `path` array to `$PATH` string,
+  # so a function-scoped `local path=...` collapses PATH inside the function and
+  # any subsequent `date` / `cat` invocation fails with "command not found".
+  # Same hazard applies to: cdpath, fpath, manpath, mailpath.
+  local md_path="$1" sid="$2"
+  local ts
+  ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  cat > "$md_path" <<EOF
+---
+session_id: $sid
+confidence: tentative
+categories: []
+word_count: 0
+created_at: $ts
+placeholder: true
+---
+EOF
+}
+
+# append_index_entry <index_path> <session_id> <md_path>
+#   Append a JSONL entry for SessionStart injection. append-only by contract.
+append_index_entry() {
+  local index="$1" sid="$2" md="$3"
+  local ts
+  ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  if command -v jq >/dev/null 2>&1; then
+    jq -nc \
+      --arg sid "$sid" \
+      --arg md "$md" \
+      --arg ts "$ts" \
+      '{session_id:$sid,reflection_file:$md,created_at:$ts}' \
+      >> "$index"
+  else
+    printf '{"session_id":"%s","reflection_file":"%s","created_at":"%s"}\n' \
+      "$sid" "$md" "$ts" >> "$index"
+  fi
+}

--- a/hooks/lifecycle/reflection-activity.sh
+++ b/hooks/lifecycle/reflection-activity.sh
@@ -1,0 +1,84 @@
+#!/bin/zsh
+# Stop hook: extract mechanical activity log from session transcript.
+# LLM-free, deterministic. Reads tool_use events from history.jsonl and writes
+# one JSONL line per Edit / Write / TodoWrite / git commit invocation.
+# Policy: fail-open. Any error path leads to exit 0; runs independently of
+# reflection-extract.sh (FR-004 / BR-004 failure isolation).
+
+set -uo pipefail
+
+# Recursion guard: when invoked from within a subagent process, exit
+# immediately so this script never re-enters from a child session.
+[[ -n "${REFLECT_HOOK_SESSION:-}" ]] && exit 0
+
+SCRIPT_NAME="reflection-activity.sh"
+SCRIPT_PATH="${0:A}"
+# ${SCRIPT_PATH:h:h} == hooks/lifecycle/.. == <plugin-root>/hooks/
+LIB="${SCRIPT_PATH:h:h}/lib/reflection.sh"
+
+if [[ ! -f "$LIB" ]]; then
+  # Inline diag because log_diag itself lives in the missing lib.
+  ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  printf '%s %s helper lib not found: %s\n' "$ts" "$SCRIPT_NAME" "$LIB" >&2
+  exit 0
+fi
+source "$LIB"
+
+HOOK_INPUT=$(cat)
+
+# FR-V001 analog: session_id missing -> diagnose + exit 0
+SESSION_ID=$(jq_field "$HOOK_INPUT" "session_id")
+if [[ -z "$SESSION_ID" ]]; then
+  log_diag "$SCRIPT_NAME" "session_id missing from hook input"
+  exit 0
+fi
+
+# transcript_path is required to read history.jsonl
+TRANSCRIPT_PATH=$(jq_field "$HOOK_INPUT" "transcript_path")
+if [[ -z "$TRANSCRIPT_PATH" ]]; then
+  log_diag "$SCRIPT_NAME" "transcript_path missing from hook input"
+  exit 0
+fi
+if [[ ! -f "$TRANSCRIPT_PATH" ]]; then
+  log_diag "$SCRIPT_NAME" "transcript_path not found at $TRANSCRIPT_PATH"
+  exit 0
+fi
+
+# FR-V002 analog: activity dir mkdir fail -> diagnose + exit 0
+KNOWLEDGE_DIR=$(resolve_knowledge_dir "$HOOK_INPUT")
+ACT_DIR="$KNOWLEDGE_DIR/activity"
+if ! mkdir -p "$ACT_DIR" 2>/dev/null; then
+  log_diag "$SCRIPT_NAME" "activity directory mkdir failed at $ACT_DIR (permission denied)"
+  exit 0
+fi
+
+JSONL="$ACT_DIR/$SESSION_ID.jsonl"
+
+if ! command -v jq >/dev/null 2>&1; then
+  log_diag "$SCRIPT_NAME" "jq command not available on PATH"
+  exit 0
+fi
+
+# Extract tool_use events from the transcript.
+# Output one line per invocation:
+#   Edit / Write     -> {tool, timestamp, path}
+#   TodoWrite        -> {tool, timestamp, subject}    (flattened per todo)
+#   Bash git commit  -> {tool: "GitCommit", timestamp, message}
+# Non-commit Bash and other tool_use events are intentionally skipped (out of
+# scope per FR-005). Errors during jq parsing are swallowed (fail-open).
+jq -c '
+  select(.type == "assistant") |
+  (.timestamp // "") as $ts |
+  (.message.content // [])[]? |
+  select(.type == "tool_use") |
+  if (.name == "Edit" or .name == "Write") then
+    {tool: .name, timestamp: $ts, path: (.input.file_path // "")}
+  elif .name == "TodoWrite" then
+    (.input.todos // [])[]? |
+    {tool: "TodoWrite", timestamp: $ts, subject: (.subject // "")}
+  elif (.name == "Bash" and ((.input.command // "") | startswith("git commit"))) then
+    {tool: "GitCommit", timestamp: $ts, message: (.input.command // "")}
+  else empty end
+' "$TRANSCRIPT_PATH" > "$JSONL" 2>/dev/null || true
+
+exit 0

--- a/hooks/lifecycle/reflection-extract.sh
+++ b/hooks/lifecycle/reflection-extract.sh
@@ -1,0 +1,114 @@
+#!/bin/zsh
+# Stop hook: extract reflection via subagent and persist per session_id.
+# Policy: fail-open. Any error path leads to exit 0 so notify-stop.sh and
+# downstream hook entries are not blocked.
+
+set -uo pipefail
+
+# Recursion guard: when invoked from within the subagent process itself,
+# exit immediately so a child Stop hook cannot reenter the extraction.
+[[ -n "${REFLECT_HOOK_SESSION:-}" ]] && exit 0
+
+SCRIPT_NAME="reflection-extract.sh"
+SCRIPT_PATH="${0:A}"
+# ${SCRIPT_PATH:h:h}   == hooks/lifecycle/..    == <plugin-root>/hooks/
+# ${SCRIPT_PATH:h:h:h} == hooks/lifecycle/../.. == <plugin-root>/ (repo root)
+LIB="${SCRIPT_PATH:h:h}/lib/reflection.sh"
+
+if [[ ! -f "$LIB" ]]; then
+  # Inline diag because log_diag itself lives in the missing lib.
+  ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  printf '%s %s helper lib not found: %s\n' "$ts" "$SCRIPT_NAME" "$LIB" >&2
+  exit 0
+fi
+source "$LIB"
+
+HOOK_INPUT=$(cat)
+
+# Parse session_id (FR-V001: missing -> diagnose + exit 0)
+SESSION_ID=$(jq_field "$HOOK_INPUT" "session_id")
+if [[ -z "$SESSION_ID" ]]; then
+  log_diag "$SCRIPT_NAME" "session_id missing from hook input"
+  exit 0
+fi
+
+# Resolve knowledge dir + create (FR-V002: mkdir fail -> diagnose + exit 0)
+KNOWLEDGE_DIR=$(resolve_knowledge_dir "$HOOK_INPUT")
+REFL_DIR="$KNOWLEDGE_DIR/reflection"
+INDEX="$KNOWLEDGE_DIR/reflection-index.jsonl"
+
+if ! mkdir -p "$REFL_DIR" 2>/dev/null; then
+  log_diag "$SCRIPT_NAME" "knowledge directory mkdir failed at $REFL_DIR (permission denied)"
+  exit 0
+fi
+
+MD_FILE="$REFL_DIR/$SESSION_ID.md"
+
+# Path passed to the subagent so a recursive child spawn (T-010) resolves to
+# this same script. Tests override via REFLECT_HOOK_EXTRACT_SH.
+HOOK_PATH_FOR_CHILD="${REFLECT_HOOK_EXTRACT_SH:-$SCRIPT_PATH}"
+PLUGIN_ROOT="${SCRIPT_PATH:h:h:h}"
+TIMEOUT_SEC="${REFLECT_SUBAGENT_TIMEOUT:-25}"
+
+# Common env block for the subagent: recursion guard + path overrides.
+typeset -a SUBAGENT_ENV
+SUBAGENT_ENV=(
+  "REFLECT_HOOK_SESSION=1"
+  "REFLECT_KNOWLEDGE_DIR=$KNOWLEDGE_DIR"
+  "REFLECT_SESSION_ID=$SESSION_ID"
+  "REFLECT_HOOK_EXTRACT_SH=$HOOK_PATH_FOR_CHILD"
+)
+
+# Common subagent invocation. Test PATH-injects this as a mock `claude`.
+typeset -a SUBAGENT_CMD
+SUBAGENT_CMD=(
+  claude --bare -p
+  --permission-mode bypassPermissions
+  --plugin-dir "$PLUGIN_ROOT"
+  "/reflection-extractor $SESSION_ID"
+)
+
+T_START=$(date +%s)
+SUBAGENT_EXIT=0
+TIMEOUT_BIN=$(command -v gtimeout || command -v timeout || true)
+
+if [[ -n "$TIMEOUT_BIN" ]]; then
+  env "${SUBAGENT_ENV[@]}" "$TIMEOUT_BIN" "${TIMEOUT_SEC}s" "${SUBAGENT_CMD[@]}" \
+    >/dev/null 2>&1 || SUBAGENT_EXIT=$?
+else
+  # Pure-zsh fallback: background subagent + sleep-kill watchdog.
+  # Note: a 0..TIMEOUT_SEC second stray `sleep` process may briefly survive
+  # after an early subagent exit. Harmless (it terminates naturally) and the
+  # gtimeout/timeout path is preferred whenever available.
+  env "${SUBAGENT_ENV[@]}" "${SUBAGENT_CMD[@]}" >/dev/null 2>&1 &
+  SUBAGENT_PID=$!
+  ( sleep "$TIMEOUT_SEC" && kill -TERM "$SUBAGENT_PID" 2>/dev/null ) &
+  WATCHDOG_PID=$!
+  wait "$SUBAGENT_PID" 2>/dev/null
+  SUBAGENT_EXIT=$?
+  kill "$WATCHDOG_PID" 2>/dev/null || true
+fi
+
+T_END=$(date +%s)
+ELAPSED=$(( T_END - T_START ))
+
+# Subagent failure diagnostics (FR-004, FR-V003, NFR-006).
+# Timeout exit codes:
+#   124 — gtimeout/timeout's own "duration exceeded" signal
+#   137 — child killed by SIGKILL (128+9)
+#   143 — child killed by SIGTERM (128+15), our zsh fallback `kill -TERM` path
+if [[ "$SUBAGENT_EXIT" -eq 124 || "$SUBAGENT_EXIT" -eq 137 || "$SUBAGENT_EXIT" -eq 143 ]]; then
+  log_diag "$SCRIPT_NAME" "subagent timeout exceeded ${TIMEOUT_SEC}s elapsed_ms=$(( ELAPSED * 1000 ))"
+elif [[ "$SUBAGENT_EXIT" -ne 0 ]]; then
+  log_diag "$SCRIPT_NAME" "subagent failure exit=$SUBAGENT_EXIT elapsed_ms=$(( ELAPSED * 1000 ))"
+fi
+
+# Fallback placeholder if subagent did not write the md (FR-003)
+if [[ ! -f "$MD_FILE" ]]; then
+  write_placeholder_md "$MD_FILE" "$SESSION_ID"
+fi
+
+# Always append index entry (FR-007 consumes this)
+append_index_entry "$INDEX" "$SESSION_ID" "$MD_FILE"
+
+exit 0

--- a/hooks/lifecycle/reflection-inject.sh
+++ b/hooks/lifecycle/reflection-inject.sh
@@ -1,0 +1,77 @@
+#!/bin/zsh
+# SessionStart hook: inject the most recent reflections into the next session.
+# Reads reflection-index.jsonl, takes the tail N entries, and concatenates the
+# corresponding reflection .md bodies to stdout. Claude Code surfaces this
+# stdout as additionalContext for the new session.
+# Policy: fail-open. Missing index / files emit warnings but never block.
+
+set -uo pipefail
+
+# Recursion guard: when invoked from a subagent process, exit immediately so
+# nested SessionStart fires do not stack injections.
+[[ -n "${REFLECT_HOOK_SESSION:-}" ]] && exit 0
+
+SCRIPT_NAME="reflection-inject.sh"
+SCRIPT_PATH="${0:A}"
+LIB="${SCRIPT_PATH:h:h}/lib/reflection.sh"
+
+if [[ ! -f "$LIB" ]]; then
+  ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  printf '%s %s helper lib not found: %s\n' "$ts" "$SCRIPT_NAME" "$LIB" >&2
+  exit 0
+fi
+source "$LIB"
+
+# SessionStart hook input is optional; some matchers fire without stdin.
+HOOK_INPUT=$(cat 2>/dev/null || true)
+
+KNOWLEDGE_DIR=$(resolve_knowledge_dir "$HOOK_INPUT")
+INDEX="$KNOWLEDGE_DIR/reflection-index.jsonl"
+
+# Index missing (first session ever) -> silent exit 0.
+[[ ! -f "$INDEX" ]] && exit 0
+
+N="${REFLECT_INJECT_CAP:-10}"
+
+# Read the last N entries. If the index is empty or unreadable, bail silently.
+ENTRIES=$(tail -n "$N" "$INDEX" 2>/dev/null) || exit 0
+[[ -z "$ENTRIES" ]] && exit 0
+
+# Collect bodies first so we only emit a header if at least one file was found.
+EMITTED=0
+BUFFER=""
+
+# extract_md_path <jsonl_line>
+#   Pull reflection_file out of a single index line. Prefer jq when available;
+#   fall back to a defensive sed for jq-less environments.
+extract_md_path() {
+  local line="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$line" | jq -r '.reflection_file // ""' 2>/dev/null
+  else
+    printf '%s' "$line" | sed -n 's/.*"reflection_file":"\([^"]*\)".*/\1/p'
+  fi
+}
+
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  md_path=$(extract_md_path "$line")
+  if [[ -z "$md_path" || "$md_path" == "null" ]]; then
+    log_diag "$SCRIPT_NAME" "index entry missing reflection_file: $line"
+    continue
+  fi
+  if [[ ! -f "$md_path" ]]; then
+    log_diag "$SCRIPT_NAME" "reflection file missing on disk: $md_path"
+    continue
+  fi
+  BUFFER+="$(cat "$md_path")"$'\n\n---\n\n'
+  EMITTED=$((EMITTED + 1))
+done <<< "$ENTRIES"
+
+if (( EMITTED == 0 )); then
+  exit 0
+fi
+
+printf '## Recent Reflections\n\n%s' "$BUFFER"
+
+exit 0

--- a/hooks/tests/fixtures/mock-claude.sh
+++ b/hooks/tests/fixtures/mock-claude.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Mock for `claude --bare -p ...` subagent invocation.
+#
+# Behavior is controlled by MOCK_CLAUDE_MODE env var:
+#   success  - write a non-empty reflection .md file directly to
+#              $REFLECT_KNOWLEDGE_DIR/reflection/$REFLECT_SESSION_ID.md and
+#              exit 0
+#   empty    - write nothing (extract.sh is expected to create a placeholder)
+#              and exit 0
+#   fail     - exit 1 without writing
+#   timeout  - sleep beyond the subagent timeout, then exit 0 (to be killed
+#              by parent watchdog). Sleep duration is controlled by
+#              MOCK_CLAUDE_SLEEP_SEC (default 4).
+#   recurse  - re-invoke $REFLECT_HOOK_EXTRACT_SH as a child subagent. Used
+#              by T-010 to verify recursion guard.
+#
+# Mock must be installed into PATH as a file literally named `claude` so that
+# extract.sh resolves it via `claude --bare ...`. See test-reflection-extract.sh
+# `setup_mock_claude` for the install convention.
+set -uo pipefail
+
+MODE="${MOCK_CLAUDE_MODE:-success}"
+SID="${REFLECT_SESSION_ID:-unknown-session}"
+KDIR="${REFLECT_KNOWLEDGE_DIR:-/tmp/reflect-knowledge}"
+REFL_DIR="$KDIR/reflection"
+
+# Surface a marker on stderr so tests can confirm the mock was actually called.
+printf 'mock-claude: mode=%s session_id=%s knowledge_dir=%s\n' \
+  "$MODE" "$SID" "$KDIR" >&2
+
+case "$MODE" in
+  success)
+    mkdir -p "$REFL_DIR" 2>/dev/null || true
+    cat > "$REFL_DIR/$SID.md" <<EOF
+---
+session_id: $SID
+confidence: confirmed
+categories: [realization, judgment, counterfactual]
+word_count: 18
+---
+
+## Realization
+
+mock subagent reflection body for $SID.
+
+## Judgment
+
+mock judgment line.
+
+## Counterfactual
+
+mock counterfactual line.
+EOF
+    exit 0
+    ;;
+  empty)
+    # Intentionally do not write any file. extract.sh must produce a
+    # placeholder with frontmatter only.
+    exit 0
+    ;;
+  fail)
+    printf 'mock-claude: simulated subagent failure\n' >&2
+    exit 1
+    ;;
+  timeout)
+    SEC="${MOCK_CLAUDE_SLEEP_SEC:-4}"
+    sleep "$SEC"
+    # If we reach here, the watchdog did not fire (unexpected for the test).
+    exit 0
+    ;;
+  recurse)
+    # Simulate the worst case: the subagent re-spawns the parent hook. The
+    # recursion guard in reflection-extract.sh must short-circuit this child
+    # so the call tree terminates.
+    CHILD_SH="${REFLECT_HOOK_EXTRACT_SH:-}"
+    if [[ -z "$CHILD_SH" ]]; then
+      printf 'mock-claude: REFLECT_HOOK_EXTRACT_SH unset; cannot recurse\n' >&2
+      exit 0
+    fi
+    # Forward stdin (the original hook input JSON) to the child so it looks
+    # like a real Stop hook invocation. REFLECT_HOOK_SESSION=1 must already
+    # be exported by the parent extract.sh; we keep it as-is.
+    printf '{"session_id":"%s"}' "$SID" | "$CHILD_SH" >/dev/null 2>&1 || true
+    exit 0
+    ;;
+  *)
+    printf 'mock-claude: unknown MOCK_CLAUDE_MODE=%s\n' "$MODE" >&2
+    exit 2
+    ;;
+esac

--- a/hooks/tests/fixtures/sample-reflection.md
+++ b/hooks/tests/fixtures/sample-reflection.md
@@ -1,0 +1,18 @@
+---
+session_id: sample
+confidence: confirmed
+categories: [realization, judgment, counterfactual]
+word_count: 12
+---
+
+## Realization
+
+sample reflection body.
+
+## Judgment
+
+sample judgment.
+
+## Counterfactual
+
+sample counterfactual.

--- a/hooks/tests/fixtures/stop-hook-input-no-session.json
+++ b/hooks/tests/fixtures/stop-hook-input-no-session.json
@@ -1,0 +1,1 @@
+{"hook_event_name":"Stop","transcript_path":"/tmp/reflect-fixture-transcript.jsonl","stop_reason":"end_turn","cwd":"/tmp"}

--- a/hooks/tests/fixtures/stop-hook-input.json
+++ b/hooks/tests/fixtures/stop-hook-input.json
@@ -1,0 +1,1 @@
+{"hook_event_name":"Stop","session_id":"test-session-001","transcript_path":"/tmp/reflect-fixture-transcript.jsonl","stop_reason":"end_turn","cwd":"/tmp"}

--- a/hooks/tests/test-reflection-activity.sh
+++ b/hooks/tests/test-reflection-activity.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# Phase 2 tests for the Stop hook reflection-activity pipeline.
+#
+# Scope (Phase 2 of Spec 2026-05-14-stop-hook-reflection):
+#   Cover FRs : FR-005, FR-006 (mechanical activity log, no LLM)
+#   Cover T-NNN: T-004, T-005
+#   Cover FR-009 (recursion guard) for activity.sh
+#   Cover FR-V001 / FR-V002 stderr fail-open paths for activity.sh
+#
+# Target (Red phase — files not expected yet):
+#   ~/.claude/hooks/lifecycle/reflection-activity.sh
+#
+# Test design notes:
+#   - activity.sh uses NO LLM. It parses history.jsonl deterministically.
+#   - Fixture: tests/fixtures/sample-history.jsonl with Edit + Write + TodoWrite
+#     + git-commit Bash + a non-commit Bash (ignored).
+#   - REFLECT_KNOWLEDGE_DIR overrides on-disk dir to tmp scratch space.
+#   - REFLECT_HOOK_SESSION=1 short-circuits the script (Phase 1 contract).
+#   - Hook input must include `transcript_path` so activity.sh can locate the
+#     jsonl. session_id is also required for the output filename.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/lifecycle/reflection-activity.sh"
+
+TMPDIR_BASE="$(mktemp -d)"
+FIXTURE_HISTORY="$SCRIPT_DIR/fixtures/sample-history.jsonl"
+
+cleanup() {
+  rm -rf "$TMPDIR_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Build hook input JSON. session_id is the output filename stem, transcript_path
+# tells activity.sh where to read tool_use events from.
+make_hook_input() {
+  local sid="$1" transcript="$2"
+  jq -nc \
+    --arg sid "$sid" \
+    --arg t "$transcript" \
+    '{hook_event_name:"Stop",session_id:$sid,transcript_path:$t,stop_reason:"end_turn"}'
+}
+
+# Run activity.sh in an isolated scratch dir. $1 = hook input JSON, $2 = out_dir.
+run_activity() {
+  local input_json="$1" out_dir="$2"
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '%s' "$input_json" | \
+    REFLECT_KNOWLEDGE_DIR="$out_dir/kdir" \
+    "$HOOK" \
+    >"$out_dir/stdout" \
+    2>"$out_dir/stderr"
+}
+
+# ---------- T-004 (FR-005, FR-006) ---------------------------------------
+
+test_t004_activity_extracts_all_tool_kinds() {
+  echo "T-004: activity.sh parses Edit / Write / TodoWrite / git commit from history.jsonl"
+  # Given: fixture transcript with Edit, Write, TodoWrite, git-commit Bash, plus
+  # a non-commit Bash (ls) that must be ignored.
+  local sid="test-004"
+  local out_dir="$TMPDIR_BASE/t004"
+  mkdir -p "$out_dir"
+  local input
+  input=$(make_hook_input "$sid" "$FIXTURE_HISTORY")
+
+  # When: activity.sh runs against the fixture transcript
+  local exit_code=0
+  run_activity "$input" "$out_dir" || exit_code=$?
+
+  assert_eq "T-004 exit code 0 (fail-open)" "0" "$exit_code"
+
+  local jsonl="$out_dir/kdir/activity/$sid.jsonl"
+  if [[ ! -f "$jsonl" ]]; then
+    echo "  FAIL: T-004 activity jsonl not generated at $jsonl"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local body; body=$(cat "$jsonl")
+  assert_contains "T-004 captures Edit"       '"tool":"Edit"'       "$body"
+  assert_contains "T-004 captures Write"      '"tool":"Write"'      "$body"
+  assert_contains "T-004 captures TodoWrite"  '"tool":"TodoWrite"'  "$body"
+  assert_contains "T-004 captures git commit" '"tool":"GitCommit"'  "$body"
+  assert_not_contains "T-004 ignores non-commit Bash (ls)" '"command":"ls -la"' "$body"
+
+  # FR-006: each line is valid JSON and has tool + timestamp keys.
+  local total ok_tool ok_ts
+  total=$(wc -l < "$jsonl" | tr -d ' ')
+  ok_tool=$(jq -c '.tool' < "$jsonl" 2>/dev/null | grep -c '"')
+  ok_ts=$(jq -c '.timestamp' < "$jsonl" 2>/dev/null | grep -c '"')
+  assert_eq "T-004 every line has tool key"      "$total" "$ok_tool"
+  assert_eq "T-004 every line has timestamp key" "$total" "$ok_ts"
+}
+
+# ---------- T-005 (FR-005 isolation) -------------------------------------
+
+test_t005_activity_independent_of_extract_failure() {
+  echo "T-005: activity.sh runs even when extract.sh fails (independent hook entries)"
+  # Given: fixture transcript and a sentinel pretending extract.sh just failed
+  # (we set REFLECT_EXTRACT_LAST_EXIT=1, but activity.sh must ignore it — each
+  # hook entry is an independent process in Claude Code's contract).
+  local sid="test-005"
+  local out_dir="$TMPDIR_BASE/t005"
+  mkdir -p "$out_dir"
+  local input
+  input=$(make_hook_input "$sid" "$FIXTURE_HISTORY")
+
+  # When: activity.sh runs with the (irrelevant) sentinel
+  local exit_code=0
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '%s' "$input" | \
+    REFLECT_KNOWLEDGE_DIR="$out_dir/kdir" \
+    REFLECT_EXTRACT_LAST_EXIT=1 \
+    "$HOOK" \
+    >"$out_dir/stdout" \
+    2>"$out_dir/stderr" || exit_code=$?
+
+  assert_eq "T-005 exit code 0" "0" "$exit_code"
+
+  local jsonl="$out_dir/kdir/activity/$sid.jsonl"
+  if [[ ! -f "$jsonl" ]]; then
+    echo "  FAIL: T-005 activity jsonl missing — depended on extract"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  local body; body=$(cat "$jsonl")
+  assert_contains "T-005 captures Edit even after extract fail" '"tool":"Edit"' "$body"
+}
+
+# ---------- FR-009: recursion guard --------------------------------------
+
+test_recursion_guard_skips_activity() {
+  echo "FR-009: REFLECT_HOOK_SESSION=1 -> activity.sh exits 0 immediately, no jsonl written"
+  local sid="test-rec"
+  local out_dir="$TMPDIR_BASE/rec"
+  mkdir -p "$out_dir"
+  local input
+  input=$(make_hook_input "$sid" "$FIXTURE_HISTORY")
+
+  local exit_code=0
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '%s' "$input" | \
+    REFLECT_KNOWLEDGE_DIR="$out_dir/kdir" \
+    REFLECT_HOOK_SESSION=1 \
+    "$HOOK" \
+    >"$out_dir/stdout" \
+    2>"$out_dir/stderr" || exit_code=$?
+
+  assert_eq "FR-009 activity exit 0 under guard" "0" "$exit_code"
+  if [[ -e "$out_dir/kdir/activity/$sid.jsonl" ]]; then
+    echo "  FAIL: FR-009 activity jsonl created despite recursion guard"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: FR-009 no activity jsonl under guard"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# ---------- FR-V001 analog: missing transcript_path ----------------------
+
+test_missing_transcript_path() {
+  echo "FR-V001: hook input missing transcript_path -> stderr diagnostic + exit 0"
+  local sid="test-mtp"
+  local out_dir="$TMPDIR_BASE/mtp"
+  mkdir -p "$out_dir"
+  local input
+  input=$(jq -nc --arg sid "$sid" \
+    '{hook_event_name:"Stop",session_id:$sid,stop_reason:"end_turn"}')
+
+  local exit_code=0
+  run_activity "$input" "$out_dir" || exit_code=$?
+
+  assert_eq "missing transcript_path exit 0 (fail-open)" "0" "$exit_code"
+  local stderr_body; stderr_body=$(cat "$out_dir/stderr")
+  assert_contains "stderr mentions transcript_path" "transcript_path" "$stderr_body"
+  if compgen -G "$out_dir/kdir/activity/*.jsonl" >/dev/null; then
+    echo "  FAIL: activity jsonl should not be created without transcript"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: no activity jsonl created on missing transcript"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# ---------- FR-V001 analog: missing session_id ---------------------------
+
+test_missing_session_id_activity() {
+  echo "FR-V001: hook input missing session_id -> stderr diagnostic + exit 0"
+  local out_dir="$TMPDIR_BASE/msi"
+  mkdir -p "$out_dir"
+  local input
+  input=$(jq -nc --arg t "$FIXTURE_HISTORY" \
+    '{hook_event_name:"Stop",transcript_path:$t,stop_reason:"end_turn"}')
+
+  local exit_code=0
+  run_activity "$input" "$out_dir" || exit_code=$?
+
+  assert_eq "missing session_id exit 0 (fail-open)" "0" "$exit_code"
+  local stderr_body; stderr_body=$(cat "$out_dir/stderr")
+  assert_contains "stderr mentions session_id" "session_id" "$stderr_body"
+}
+
+# ---------- FR-006: per-line JSONL validity ------------------------------
+
+test_jsonl_per_line_validity() {
+  echo "FR-006: every output line is valid JSON with tool + timestamp keys"
+  local sid="test-validity"
+  local out_dir="$TMPDIR_BASE/validity"
+  mkdir -p "$out_dir"
+  local input
+  input=$(make_hook_input "$sid" "$FIXTURE_HISTORY")
+
+  local exit_code=0
+  run_activity "$input" "$out_dir" || exit_code=$?
+  assert_eq "validity exit 0" "0" "$exit_code"
+
+  local jsonl="$out_dir/kdir/activity/$sid.jsonl"
+  if [[ ! -f "$jsonl" ]]; then
+    echo "  FAIL: validity test needs the jsonl file"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  # Each line must parse as JSON.
+  local bad
+  bad=$(jq -c . < "$jsonl" 2>&1 >/dev/null | grep -c . || true)
+  assert_eq "every line parses as JSON (0 errors)" "0" "$bad"
+
+  # Each parsed line must have non-null tool and timestamp.
+  local total ok
+  total=$(wc -l < "$jsonl" | tr -d ' ')
+  ok=$(jq -c 'select(.tool != null and .timestamp != null) | .tool' < "$jsonl" 2>/dev/null | grep -c '"' || true)
+  assert_eq "every line has tool + timestamp" "$total" "$ok"
+}
+
+# ---------- Pre-flight: confirm target absent (Red sanity) ---------------
+
+preflight_red_phase() {
+  echo "=== Red-phase preflight: target file should NOT exist yet ==="
+  if [[ -e "$HOOK" ]]; then
+    echo "  NOTE: target already exists: $HOOK (Green may be in progress)"
+  else
+    echo "  OK:   missing as expected: $HOOK"
+  fi
+  echo ""
+}
+
+echo "=== reflection-activity.sh Phase 2 tests ==="
+preflight_red_phase
+
+test_t004_activity_extracts_all_tool_kinds
+test_t005_activity_independent_of_extract_failure
+test_recursion_guard_skips_activity
+test_missing_transcript_path
+test_missing_session_id_activity
+test_jsonl_per_line_validity
+
+report_results

--- a/hooks/tests/test-reflection-extract.sh
+++ b/hooks/tests/test-reflection-extract.sh
@@ -1,0 +1,515 @@
+#!/usr/bin/env bash
+# Phase 1 tests for the Stop hook reflection-extract pipeline.
+#
+# Scope (Phase 1 of Spec 2026-05-14-stop-hook-reflection):
+#   Cover FRs : FR-001, FR-002, FR-003, FR-004, FR-009, FR-V001, FR-V002, FR-V003
+#   Cover T-NNN: T-001, T-002, T-003, T-009, T-010, T-015
+#   Cover NFR : NFR-006 (extract.sh stderr 3 fields on FR-V failure paths)
+#
+# Targets (Red phase — these files are not expected to exist yet):
+#   ~/.claude/hooks/lifecycle/reflection-extract.sh
+#   ~/.claude/hooks/lib/reflection.sh
+#   ~/.claude/agents/reflection-extractor.md
+#
+# Test design notes:
+#   - subagent is mocked by PATH-injecting fixtures/mock-claude.sh as a binary
+#     literally named `claude`. Mock-claude WRITES the reflection .md directly
+#     (contract A — matches wiki plugin precedent). extract.sh is responsible
+#     for the empty-output fallback path (T-002 / FR-003) and for stderr
+#     diagnostics on FR-V001 / FR-V002 / FR-V003.
+#   - REFLECT_KNOWLEDGE_DIR overrides the on-disk knowledge dir to a tmp
+#     scratch space. The Green implementation must honor this env var.
+#   - REFLECT_HOOK_SESSION=1 is the recursion guard; under it extract.sh
+#     SHALL exit 0 immediately without invoking the subagent (FR-009 / T-009).
+#   - REFLECT_SUBAGENT_TIMEOUT overrides the production 25s budget so the
+#     timeout path (FR-V003 / T-015 timeout case) can be exercised in ~2s.
+#   - All hook invocations are wrapped with `|| exit_code=$?` so the test
+#     harness survives missing implementations during the Red phase.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/lifecycle/reflection-extract.sh"
+LIB="$REPO_ROOT/hooks/lib/reflection.sh"
+AGENT_PROMPT="$REPO_ROOT/agents/reflection-extractor.md"
+
+TMPDIR_BASE="$(mktemp -d)"
+MOCK_BIN_DIR="$TMPDIR_BASE/mock-bin"
+KNOWLEDGE_DIR_BASE="$TMPDIR_BASE/knowledge"
+mkdir -p "$MOCK_BIN_DIR" "$KNOWLEDGE_DIR_BASE"
+
+cleanup() { rm -rf "$TMPDIR_BASE"; }
+trap cleanup EXIT
+
+# Install mock-claude into PATH under the literal name `claude` so that
+# `claude --bare ...` inside extract.sh resolves to the stub. The Green
+# implementation MUST invoke claude via the PATH-resolved name (not an
+# absolute path), otherwise this injection is bypassed and the test
+# becomes a no-op.
+setup_mock_claude() {
+  cp "$SCRIPT_DIR/fixtures/mock-claude.sh" "$MOCK_BIN_DIR/claude"
+  chmod +x "$MOCK_BIN_DIR/claude"
+}
+
+# Build a per-test knowledge dir so cross-test state never leaks. Returns
+# the dir path on stdout.
+fresh_knowledge_dir() {
+  local sub
+  sub=$(mktemp -d "$KNOWLEDGE_DIR_BASE/k.XXXXXX")
+  printf '%s' "$sub"
+}
+
+# Run extract.sh with a fully scoped environment. Reads stdin JSON from
+# arg $1, writes stdout/stderr to files in $2. Returns the script's exit
+# code (0 if missing — `|| exit_code=$?` is used at the call site).
+#
+# Contract for Green-phase implementor (T-010 / FR-009 recursion guard):
+#   extract.sh MUST export REFLECT_HOOK_SESSION=1 (and propagate
+#   REFLECT_KNOWLEDGE_DIR, REFLECT_HOOK_EXTRACT_SH) into the subagent
+#   invocation, mirroring wiki plugin's `WIKI_HOOK_SESSION=1 claude --bare ...`
+#   pattern. Without that propagation, a recursive child invocation cannot
+#   short-circuit and T-010 will hang up to its 5s watchdog.
+run_extract() {
+  local input_json="$1" out_dir="$2"
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '%s' "$input_json" | \
+    PATH="$MOCK_BIN_DIR:$PATH" \
+    REFLECT_KNOWLEDGE_DIR="$out_dir/kdir" \
+    REFLECT_HOOK_EXTRACT_SH="$HOOK" \
+    "$HOOK" \
+    >"$out_dir/stdout" \
+    2>"$out_dir/stderr"
+}
+
+# ---------- T-001 (FR-001, FR-002) ---------------------------------------
+
+test_t001_extract_writes_md_with_frontmatter() {
+  echo "T-001: extract.sh writes per-session_id md with required frontmatter keys"
+  # Given: subagent stub in success mode, session_id=test-001
+  setup_mock_claude
+  local sid="test-001"
+  local out_dir="$TMPDIR_BASE/t001"
+  mkdir -p "$out_dir"
+  local input
+  input=$(jq -nc --arg sid "$sid" '{hook_event_name:"Stop",session_id:$sid,stop_reason:"end_turn"}')
+
+  # When: extract.sh runs locally with mock-claude on PATH
+  local exit_code=0
+  MOCK_CLAUDE_MODE=success run_extract "$input" "$out_dir" || exit_code=$?
+
+  # Then: per-session md exists with frontmatter containing all 4 keys
+  local md="$out_dir/kdir/reflection/$sid.md"
+  if [[ -f "$md" ]]; then
+    local body; body=$(cat "$md")
+    assert_eq "T-001 exit code 0 (fail-open)" "0" "$exit_code"
+    assert_contains "T-001 frontmatter session_id" "session_id: $sid" "$body"
+    assert_contains "T-001 frontmatter confidence key present" "confidence:" "$body"
+    assert_contains "T-001 frontmatter categories key present" "categories:" "$body"
+    assert_contains "T-001 frontmatter word_count key present" "word_count:" "$body"
+  else
+    echo "  FAIL: T-001 reflection md not generated at $md"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------- T-002 (FR-003) -----------------------------------------------
+
+test_t002_empty_extraction_writes_placeholder() {
+  echo "T-002: subagent returns no content -> extract.sh writes frontmatter-only placeholder + index entry"
+  # Given: subagent stub in empty mode (writes nothing), session_id=test-002
+  setup_mock_claude
+  local sid="test-002"
+  local out_dir="$TMPDIR_BASE/t002"
+  mkdir -p "$out_dir"
+  local input
+  input=$(jq -nc --arg sid "$sid" '{hook_event_name:"Stop",session_id:$sid,stop_reason:"end_turn"}')
+
+  # When: extract.sh runs with empty mock subagent
+  local exit_code=0
+  MOCK_CLAUDE_MODE=empty run_extract "$input" "$out_dir" || exit_code=$?
+
+  # Then: extract.sh creates a placeholder md (frontmatter only) AND appends
+  # one entry to reflection-index.jsonl with matching session_id.
+  local md="$out_dir/kdir/reflection/$sid.md"
+  local index="$out_dir/kdir/reflection-index.jsonl"
+  assert_eq "T-002 exit code 0" "0" "$exit_code"
+  if [[ -f "$md" ]]; then
+    local body; body=$(cat "$md")
+    assert_contains "T-002 placeholder has session_id frontmatter" "session_id: $sid" "$body"
+    assert_contains "T-002 placeholder has confidence frontmatter" "confidence:" "$body"
+  else
+    echo "  FAIL: T-002 placeholder md not generated at $md"
+    FAIL=$((FAIL + 1))
+  fi
+  if [[ -f "$index" ]]; then
+    local idx_body; idx_body=$(cat "$index")
+    assert_contains "T-002 index has session_id entry" "$sid" "$idx_body"
+  else
+    echo "  FAIL: T-002 reflection-index.jsonl not created at $index"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------- T-003 (FR-004) -----------------------------------------------
+
+test_t003_extract_fail_notify_independent() {
+  echo "T-003: extract.sh exit != 0 must not propagate; downstream hooks run independently"
+  # Given: subagent stub fails (exit 1), session_id=test-003
+  setup_mock_claude
+  local sid="test-003"
+  local out_dir="$TMPDIR_BASE/t003"
+  mkdir -p "$out_dir"
+  local input
+  input=$(jq -nc --arg sid "$sid" '{hook_event_name:"Stop",session_id:$sid,stop_reason:"end_turn"}')
+
+  # When: extract.sh runs against the failing subagent stub
+  local exit_code=0
+  MOCK_CLAUDE_MODE=fail run_extract "$input" "$out_dir" || exit_code=$?
+
+  # Then: extract.sh itself MUST return exit 0 (fail-open per FR-004 / BR-004).
+  # Independent hook entries (notify-stop.sh) are scheduled by Claude Code as
+  # separate processes — extract.sh's contract is to exit 0 so settings.json
+  # never wires the failure into a chain.
+  assert_eq "T-003 extract.sh exits 0 even when subagent fails" "0" "$exit_code"
+
+  # And: a diagnostic line is emitted to stderr so the failure is observable.
+  # Match script name AND a failure keyword on the same line so the shell's own
+  # "No such file or directory" error during Red phase cannot spuriously match.
+  if grep -E 'reflection-extract\.sh' "$out_dir/stderr" 2>/dev/null | grep -iE 'fail|error|exit|subagent' >/dev/null 2>&1; then
+    echo "  PASS: T-003 stderr mentions script + failure keyword"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: T-003 stderr lacks 'reflection-extract.sh' + fail/error/exit/subagent on one line"
+    echo "    stderr: $(head -3 "$out_dir/stderr")"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------- T-009 (FR-009) -----------------------------------------------
+
+test_t009_recursion_guard_exits_immediately() {
+  echo "T-009: REFLECT_HOOK_SESSION=1 -> extract.sh exits 0 immediately without invoking subagent"
+  # Given: recursion guard env is set, subagent stub would otherwise write a file
+  setup_mock_claude
+  local sid="test-009"
+  local out_dir="$TMPDIR_BASE/t009"
+  mkdir -p "$out_dir"
+  local input
+  input=$(jq -nc --arg sid "$sid" '{hook_event_name:"Stop",session_id:$sid,stop_reason:"end_turn"}')
+
+  # When: extract.sh runs with REFLECT_HOOK_SESSION=1
+  local exit_code=0
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '%s' "$input" | \
+    PATH="$MOCK_BIN_DIR:$PATH" \
+    REFLECT_KNOWLEDGE_DIR="$out_dir/kdir" \
+    REFLECT_HOOK_SESSION=1 \
+    MOCK_CLAUDE_MODE=success \
+    "$HOOK" \
+    >"$out_dir/stdout" \
+    2>"$out_dir/stderr" || exit_code=$?
+
+  # Then: exit 0 AND no reflection file written AND mock-claude never ran
+  # (mock-claude writes a marker line to stderr on every invocation).
+  assert_eq "T-009 exit code 0" "0" "$exit_code"
+  if [[ -e "$out_dir/kdir/reflection/$sid.md" ]]; then
+    echo "  FAIL: T-009 reflection md was generated despite recursion guard"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: T-009 no reflection md written under recursion guard"
+    PASS=$((PASS + 1))
+  fi
+  local stderr_body; stderr_body=$(cat "$out_dir/stderr")
+  assert_not_contains "T-009 mock-claude not invoked" "mock-claude: mode=" "$stderr_body"
+}
+
+# ---------- T-010 (FR-009 integration) -----------------------------------
+
+test_t010_recursive_spawn_no_deadlock() {
+  echo "T-010: parent extract.sh -> mock subagent -> child extract.sh terminates within 5s (no deadlock)"
+  # Given: mock-claude in `recurse` mode re-invokes extract.sh as a child while
+  # REFLECT_HOOK_SESSION=1 is inherited from the parent's subagent spawn step.
+  setup_mock_claude
+  local sid="test-010"
+  local out_dir="$TMPDIR_BASE/t010"
+  mkdir -p "$out_dir"
+  local input
+  input=$(jq -nc --arg sid "$sid" '{hook_event_name:"Stop",session_id:$sid,stop_reason:"end_turn"}')
+
+  # When: parent runs under a hard 5s outer watchdog (gtimeout) so a deadlock
+  # surfaces as a watchdog kill rather than a hung test suite.
+  local exit_code=0
+  local timeout_bin; timeout_bin=$(command -v gtimeout || command -v timeout || true)
+  if [[ -z "$timeout_bin" ]]; then
+    echo "  SKIP: gtimeout/timeout not available; cannot bound T-010"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '%s' "$input" | \
+    "$timeout_bin" 5s env \
+      PATH="$MOCK_BIN_DIR:$PATH" \
+      REFLECT_KNOWLEDGE_DIR="$out_dir/kdir" \
+      REFLECT_HOOK_EXTRACT_SH="$HOOK" \
+      MOCK_CLAUDE_MODE=recurse \
+      "$HOOK" \
+      >"$out_dir/stdout" \
+      2>"$out_dir/stderr" || exit_code=$?
+
+  # Then: parent exits 0 (gtimeout returns 124 on timeout — that signals the
+  # recursion guard failed and the test must FAIL loudly).
+  if [[ "$exit_code" == "124" ]]; then
+    echo "  FAIL: T-010 watchdog (5s) fired — recursion guard did not break the cycle"
+    FAIL=$((FAIL + 1))
+  else
+    assert_eq "T-010 parent exit code 0" "0" "$exit_code"
+  fi
+}
+
+# ---------- FR-V001 (T-015 component, fail-open on missing session_id) ----
+
+test_fr_v001_missing_session_id() {
+  echo "FR-V001: hook input missing session_id -> stderr diagnostic + exit 0"
+  # Given: hook input JSON without a session_id key
+  setup_mock_claude
+  local out_dir="$TMPDIR_BASE/v001"
+  mkdir -p "$out_dir"
+  local input
+  input=$(jq -nc '{hook_event_name:"Stop",stop_reason:"end_turn"}')
+
+  # When: extract.sh runs with the malformed input
+  local exit_code=0
+  MOCK_CLAUDE_MODE=success run_extract "$input" "$out_dir" || exit_code=$?
+
+  # Then: exit 0 (fail-open) AND stderr contains a diagnostic mentioning the
+  # missing session_id. No reflection file is created.
+  assert_eq "FR-V001 exit 0 (fail-open)" "0" "$exit_code"
+  local stderr_body; stderr_body=$(cat "$out_dir/stderr")
+  assert_contains "FR-V001 stderr mentions session_id" "session_id" "$stderr_body"
+  if compgen -G "$out_dir/kdir/reflection/*.md" >/dev/null; then
+    echo "  FAIL: FR-V001 reflection md should not be created for missing session_id"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: FR-V001 no reflection md created"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# ---------- FR-V002 (T-015 component, fail-open on mkdir failure) ---------
+
+test_fr_v002_mkdir_fail() {
+  echo "FR-V002: knowledge dir not writable -> stderr diagnostic + exit 0"
+  # Given: REFLECT_KNOWLEDGE_DIR points at a path inside a read-only parent so
+  # mkdir -p fails. Create a parent dir, chmod it to 0500, then ask extract.sh
+  # to create a child under it.
+  setup_mock_claude
+  local sid="test-v002"
+  local out_dir="$TMPDIR_BASE/v002"
+  mkdir -p "$out_dir/readonly-parent"
+  chmod 0500 "$out_dir/readonly-parent"
+  local input
+  input=$(jq -nc --arg sid "$sid" '{hook_event_name:"Stop",session_id:$sid,stop_reason:"end_turn"}')
+
+  # When: extract.sh runs with knowledge dir under the read-only parent
+  local exit_code=0
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '%s' "$input" | \
+    PATH="$MOCK_BIN_DIR:$PATH" \
+    REFLECT_KNOWLEDGE_DIR="$out_dir/readonly-parent/kdir" \
+    MOCK_CLAUDE_MODE=success \
+    "$HOOK" \
+    >"$out_dir/stdout" \
+    2>"$out_dir/stderr" || exit_code=$?
+
+  # Restore perms so cleanup() can recurse-delete.
+  chmod 0700 "$out_dir/readonly-parent" 2>/dev/null || true
+
+  # Then: exit 0 (fail-open) AND stderr mentions the directory failure.
+  assert_eq "FR-V002 exit 0 (fail-open)" "0" "$exit_code"
+  local stderr_body; stderr_body=$(cat "$out_dir/stderr")
+  # Accept any of these substrings — Green impl picks one concrete phrasing.
+  # `directory` is omitted on purpose so the shell's "No such file or directory"
+  # noise during Red phase cannot spuriously match.
+  if echo "$stderr_body" | grep -qE 'knowledge|mkdir|permission|writable|denied'; then
+    echo "  PASS: FR-V002 stderr surfaces dir creation failure"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: FR-V002 stderr lacks dir-failure diagnostic"
+    echo "    stderr: $(head -3 "$out_dir/stderr")"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------- FR-V003 (T-015 component, timeout path) -----------------------
+
+test_fr_v003_subagent_timeout() {
+  echo "FR-V003: subagent exceeds REFLECT_SUBAGENT_TIMEOUT -> kill + warning + exit 0"
+  # Given: mock subagent in `timeout` mode sleeps for 4s; extract.sh's per-run
+  # timeout is overridden to 2s via REFLECT_SUBAGENT_TIMEOUT. Outer watchdog
+  # (gtimeout 8s) bounds the whole test so a missing impl cannot hang.
+  setup_mock_claude
+  local sid="test-v003"
+  local out_dir="$TMPDIR_BASE/v003"
+  mkdir -p "$out_dir"
+  local input
+  input=$(jq -nc --arg sid "$sid" '{hook_event_name:"Stop",session_id:$sid,stop_reason:"end_turn"}')
+  local timeout_bin; timeout_bin=$(command -v gtimeout || command -v timeout || true)
+  if [[ -z "$timeout_bin" ]]; then
+    echo "  SKIP: gtimeout/timeout not available; cannot bound FR-V003"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  # When: extract.sh runs with timeout knob = 2s, mock sleeps 4s
+  local exit_code=0
+  local t_start; t_start=$(date +%s)
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '%s' "$input" | \
+    "$timeout_bin" 8s env \
+      PATH="$MOCK_BIN_DIR:$PATH" \
+      REFLECT_KNOWLEDGE_DIR="$out_dir/kdir" \
+      REFLECT_SUBAGENT_TIMEOUT=2 \
+      MOCK_CLAUDE_MODE=timeout \
+      MOCK_CLAUDE_SLEEP_SEC=4 \
+      "$HOOK" \
+      >"$out_dir/stdout" \
+      2>"$out_dir/stderr" || exit_code=$?
+  local t_end; t_end=$(date +%s)
+  local elapsed=$(( t_end - t_start ))
+
+  # Then: exit 0 (fail-open), elapsed << 8s (the watchdog upper bound), and
+  # stderr contains a timeout-flavored warning.
+  if [[ "$exit_code" == "124" ]]; then
+    echo "  FAIL: FR-V003 outer watchdog (8s) fired — extract.sh did not enforce its own timeout"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  assert_eq "FR-V003 exit 0 (fail-open)" "0" "$exit_code"
+  # Lower bound (>=1s) rejects instant-bail runs where the timeout was never
+  # actually enforced; upper bound (<7s) catches a missing kill.
+  if (( elapsed >= 1 && elapsed < 7 )); then
+    echo "  PASS: FR-V003 elapsed ${elapsed}s within enforced timeout window"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: FR-V003 elapsed ${elapsed}s outside expected [1, 7)s window — timeout not enforced"
+    FAIL=$((FAIL + 1))
+  fi
+  local stderr_body; stderr_body=$(cat "$out_dir/stderr")
+  if echo "$stderr_body" | grep -qiE 'timeout|timed out|elapsed'; then
+    echo "  PASS: FR-V003 stderr surfaces timeout warning"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: FR-V003 stderr lacks timeout warning"
+    echo "    stderr: $(head -3 "$out_dir/stderr")"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------- T-015 (NFR-006 stderr 3-field shape on all FR-V paths) --------
+
+# Helper: assert stderr has at least one line containing all 3 fields
+# (timestamp-like token + script name + reason keyword).
+assert_stderr_3_fields() {
+  local label="$1" reason_re="$2" stderr_file="$3"
+  # Timestamp pattern: ISO-like (YYYY-...) OR HH:MM:SS. Loose for Red phase.
+  local ts_re='([0-9]{4}-[0-9]{2}-[0-9]{2}|[0-9]{2}:[0-9]{2}:[0-9]{2})'
+  local script_re='reflection-extract\.sh'
+  if grep -E "$ts_re" "$stderr_file" 2>/dev/null | grep -E "$script_re" 2>/dev/null | grep -iE "$reason_re" >/dev/null 2>&1; then
+    echo "  PASS: T-015 [$label] stderr contains timestamp + script + reason on one line"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: T-015 [$label] stderr missing 3-field diagnostic (ts + 'reflection-extract.sh' + /$reason_re/)"
+    echo "    stderr: $(head -3 "$stderr_file")"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+test_t015_stderr_3_fields() {
+  echo "T-015 (NFR-006): FR-V001/V002/V003 failure paths emit timestamp + script + reason on stderr"
+  setup_mock_claude
+
+  # --- V001: missing session_id ---
+  local d1="$TMPDIR_BASE/t015-v001"; mkdir -p "$d1"
+  local input1; input1=$(jq -nc '{hook_event_name:"Stop",stop_reason:"end_turn"}')
+  local _ec=0
+  MOCK_CLAUDE_MODE=success run_extract "$input1" "$d1" || _ec=$?
+  assert_stderr_3_fields "FR-V001" "session_id|missing|input" "$d1/stderr"
+
+  # --- V002: mkdir fail ---
+  local d2="$TMPDIR_BASE/t015-v002"; mkdir -p "$d2/ro"
+  chmod 0500 "$d2/ro"
+  local input2; input2=$(jq -nc '{hook_event_name:"Stop",session_id:"t015-v002",stop_reason:"end_turn"}')
+  _ec=0
+  : > "$d2/stdout"
+  : > "$d2/stderr"
+  printf '%s' "$input2" | \
+    PATH="$MOCK_BIN_DIR:$PATH" \
+    REFLECT_KNOWLEDGE_DIR="$d2/ro/kdir" \
+    MOCK_CLAUDE_MODE=success \
+    "$HOOK" \
+    >"$d2/stdout" \
+    2>"$d2/stderr" || _ec=$?
+  chmod 0700 "$d2/ro" 2>/dev/null || true
+  assert_stderr_3_fields "FR-V002" "knowledge|mkdir|permission|directory" "$d2/stderr"
+
+  # --- V003: subagent timeout ---
+  local d3="$TMPDIR_BASE/t015-v003"; mkdir -p "$d3"
+  local input3; input3=$(jq -nc '{hook_event_name:"Stop",session_id:"t015-v003",stop_reason:"end_turn"}')
+  local timeout_bin; timeout_bin=$(command -v gtimeout || command -v timeout || true)
+  if [[ -z "$timeout_bin" ]]; then
+    echo "  SKIP: T-015 [FR-V003] gtimeout/timeout not available"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  _ec=0
+  : > "$d3/stdout"
+  : > "$d3/stderr"
+  printf '%s' "$input3" | \
+    "$timeout_bin" 8s env \
+      PATH="$MOCK_BIN_DIR:$PATH" \
+      REFLECT_KNOWLEDGE_DIR="$d3/kdir" \
+      REFLECT_SUBAGENT_TIMEOUT=2 \
+      MOCK_CLAUDE_MODE=timeout \
+      MOCK_CLAUDE_SLEEP_SEC=4 \
+      "$HOOK" \
+      >"$d3/stdout" \
+      2>"$d3/stderr" || _ec=$?
+  assert_stderr_3_fields "FR-V003" "timeout|timed out|elapsed" "$d3/stderr"
+}
+
+# ---------- Pre-flight: confirm target files are absent (Red sanity check) -
+
+preflight_red_phase() {
+  echo "=== Red-phase preflight: target files should NOT exist yet ==="
+  for f in "$HOOK" "$LIB" "$AGENT_PROMPT"; do
+    if [[ -e "$f" ]]; then
+      echo "  NOTE: target already exists: $f (Green may be in progress)"
+    else
+      echo "  OK:   missing as expected: $f"
+    fi
+  done
+  echo ""
+}
+
+echo "=== reflection-extract.sh Phase 1 tests ==="
+preflight_red_phase
+
+test_t001_extract_writes_md_with_frontmatter
+test_t002_empty_extraction_writes_placeholder
+test_t003_extract_fail_notify_independent
+test_t009_recursion_guard_exits_immediately
+test_t010_recursive_spawn_no_deadlock
+test_fr_v001_missing_session_id
+test_fr_v002_mkdir_fail
+test_fr_v003_subagent_timeout
+test_t015_stderr_3_fields
+
+report_results

--- a/hooks/tests/test-reflection-inject.sh
+++ b/hooks/tests/test-reflection-inject.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Phase 3 tests for SessionStart reflection-inject pipeline.
+#
+# Scope (Phase 3 of Spec 2026-05-14-stop-hook-reflection):
+#   Cover FRs : FR-007, FR-008, FR-012
+#   Cover T-NNN: T-006, T-007, T-008, T-013
+#   Cover FR-009 (recursion guard) for inject.sh
+#   Cover NFR-002 (SessionStart latency < 1000ms)
+#
+# Target (Red phase — file not expected yet):
+#   ~/.claude/hooks/lifecycle/reflection-inject.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/lifecycle/reflection-inject.sh"
+
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE" 2>/dev/null || true' EXIT
+
+# seed_reflections <kdir> <count>
+# Create count synthetic reflection .md files and a matching index.
+seed_reflections() {
+  local kdir="$1" count="$2"
+  local refl_dir="$kdir/reflection"
+  local index="$kdir/reflection-index.jsonl"
+  mkdir -p "$refl_dir"
+  : > "$index"
+  local i
+  for ((i = 1; i <= count; i++)); do
+    local sid
+    sid=$(printf 'ses-%03d' "$i")
+    local md="$refl_dir/$sid.md"
+    cat > "$md" <<EOF
+---
+session_id: $sid
+confidence: confirmed
+categories: [realization]
+word_count: 5
+---
+
+## Realization
+Reflection body for $sid.
+EOF
+    printf '{"session_id":"%s","reflection_file":"%s","created_at":"2026-05-14T09:00:00Z"}\n' \
+      "$sid" "$md" >> "$index"
+  done
+}
+
+run_inject() {
+  local out_dir="$1"
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '{"hook_event_name":"SessionStart","session_id":"new-session","source":"startup"}' | \
+    REFLECT_KNOWLEDGE_DIR="$out_dir/kdir" \
+    "$HOOK" \
+    >"$out_dir/stdout" \
+    2>"$out_dir/stderr"
+}
+
+# ---------- T-006 (FR-007) ----------------------------------------------
+
+test_t006_cap_at_10() {
+  echo "T-006: index of 15 -> stdout includes last 10 only"
+  local out_dir="$TMPDIR_BASE/t006"
+  mkdir -p "$out_dir"
+  seed_reflections "$out_dir/kdir" 15
+
+  local exit_code=0
+  run_inject "$out_dir" || exit_code=$?
+  assert_eq "T-006 exit 0" "0" "$exit_code"
+
+  local body; body=$(cat "$out_dir/stdout")
+  assert_not_contains "T-006 ses-001 excluded" "Reflection body for ses-001" "$body"
+  assert_not_contains "T-006 ses-005 excluded" "Reflection body for ses-005" "$body"
+  assert_contains     "T-006 ses-006 included" "Reflection body for ses-006" "$body"
+  assert_contains     "T-006 ses-015 included" "Reflection body for ses-015" "$body"
+}
+
+# ---------- T-007 (FR-008) ----------------------------------------------
+
+test_t007_fewer_than_cap() {
+  echo "T-007: index of 3 -> stdout emits all 3"
+  local out_dir="$TMPDIR_BASE/t007"
+  mkdir -p "$out_dir"
+  seed_reflections "$out_dir/kdir" 3
+
+  local exit_code=0
+  run_inject "$out_dir" || exit_code=$?
+  assert_eq "T-007 exit 0" "0" "$exit_code"
+
+  local body; body=$(cat "$out_dir/stdout")
+  assert_contains "T-007 ses-001 included" "Reflection body for ses-001" "$body"
+  assert_contains "T-007 ses-002 included" "Reflection body for ses-002" "$body"
+  assert_contains "T-007 ses-003 included" "Reflection body for ses-003" "$body"
+}
+
+# ---------- T-008 (FR-012) ----------------------------------------------
+
+test_t008_missing_reflection_skipped() {
+  echo "T-008: 5-entry index with 2nd file deleted -> stderr warning + 4 emitted + exit 0"
+  local out_dir="$TMPDIR_BASE/t008"
+  mkdir -p "$out_dir"
+  seed_reflections "$out_dir/kdir" 5
+  rm "$out_dir/kdir/reflection/ses-002.md"
+
+  local exit_code=0
+  run_inject "$out_dir" || exit_code=$?
+  assert_eq "T-008 exit 0" "0" "$exit_code"
+
+  local body; body=$(cat "$out_dir/stdout")
+  assert_contains     "T-008 ses-001 still included" "Reflection body for ses-001" "$body"
+  assert_not_contains "T-008 ses-002 skipped"        "Reflection body for ses-002" "$body"
+  assert_contains     "T-008 ses-003 still included" "Reflection body for ses-003" "$body"
+
+  local stderr_body; stderr_body=$(cat "$out_dir/stderr")
+  assert_contains "T-008 stderr warns about missing ses-002" "ses-002" "$stderr_body"
+}
+
+# ---------- T-013 (NFR-002 latency budget) ------------------------------
+
+test_t013_latency_under_1s() {
+  echo "T-013 (NFR-002): 10 reflections, 5 sequential invocations, each < 1000ms"
+  local out_dir="$TMPDIR_BASE/t013"
+  mkdir -p "$out_dir"
+  seed_reflections "$out_dir/kdir" 10
+  local exit_code=0
+  local i
+  for ((i = 1; i <= 5; i++)); do
+    local t_start; t_start=$(python3 -c 'import time; print(int(time.time()*1000))')
+    run_inject "$out_dir" || exit_code=$?
+    local t_end; t_end=$(python3 -c 'import time; print(int(time.time()*1000))')
+    local elapsed_ms=$(( t_end - t_start ))
+    if (( elapsed_ms < 1000 )); then
+      echo "  PASS: T-013 iter $i elapsed ${elapsed_ms}ms"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: T-013 iter $i elapsed ${elapsed_ms}ms exceeds 1000ms"
+      FAIL=$((FAIL + 1))
+    fi
+  done
+  assert_eq "T-013 all 5 exit 0" "0" "$exit_code"
+}
+
+# ---------- Index absent: silent --------------------------------------
+
+test_no_index_silent() {
+  echo "FR-007 boundary: index missing -> empty stdout, exit 0"
+  local out_dir="$TMPDIR_BASE/none"
+  mkdir -p "$out_dir/kdir"
+  local exit_code=0
+  run_inject "$out_dir" || exit_code=$?
+  assert_eq "no-index exit 0" "0" "$exit_code"
+  local body; body=$(cat "$out_dir/stdout")
+  assert_eq "no-index empty stdout" "" "$body"
+}
+
+# ---------- FR-009: recursion guard ----------------------------------
+
+test_recursion_guard_inject() {
+  echo "FR-009: REFLECT_HOOK_SESSION=1 -> inject.sh exits 0, empty stdout"
+  local out_dir="$TMPDIR_BASE/rec"
+  mkdir -p "$out_dir"
+  seed_reflections "$out_dir/kdir" 3
+
+  local exit_code=0
+  : > "$out_dir/stdout"
+  : > "$out_dir/stderr"
+  printf '{"hook_event_name":"SessionStart","session_id":"x","source":"startup"}' | \
+    REFLECT_KNOWLEDGE_DIR="$out_dir/kdir" \
+    REFLECT_HOOK_SESSION=1 \
+    "$HOOK" \
+    >"$out_dir/stdout" 2>"$out_dir/stderr" || exit_code=$?
+  assert_eq "FR-009 inject exit 0 under guard" "0" "$exit_code"
+  local body; body=$(cat "$out_dir/stdout")
+  assert_eq "FR-009 stdout empty under guard" "" "$body"
+}
+
+preflight_red_phase() {
+  echo "=== Red-phase preflight: target file should NOT exist yet ==="
+  if [[ -e "$HOOK" ]]; then
+    echo "  NOTE: target already exists: $HOOK (Green may be in progress)"
+  else
+    echo "  OK:   missing as expected: $HOOK"
+  fi
+  echo ""
+}
+
+echo "=== reflection-inject.sh Phase 3 tests ==="
+preflight_red_phase
+
+test_t006_cap_at_10
+test_t007_fewer_than_cap
+test_t008_missing_reflection_skipped
+test_t013_latency_under_1s
+test_no_index_silent
+test_recursion_guard_inject
+
+report_results

--- a/hooks/tests/test-reflection-wire.sh
+++ b/hooks/tests/test-reflection-wire.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Phase 5 wire-up + AC verification for Stop hook Knowledge Reflection.
+#
+# Scope (Phase 5 of Spec 2026-05-14-stop-hook-reflection):
+#   - settings.json wires the 3 new hook scripts.
+#   - AC-5 cache safety (auto-loaded path immutability):
+#       T-011 (mtime invariant), T-012a (memory grep), T-012b (paths grep)
+#   - NFR-001 (Stop hook total latency budget): T-014
+#   - NFR-007 (hardcode portability): T-016
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SETTINGS="$REPO_ROOT/settings.json"
+
+EXTRACT="$REPO_ROOT/hooks/lifecycle/reflection-extract.sh"
+ACTIVITY="$REPO_ROOT/hooks/lifecycle/reflection-activity.sh"
+INJECT="$REPO_ROOT/hooks/lifecycle/reflection-inject.sh"
+
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE" 2>/dev/null || true' EXIT
+
+# ---------- wire-config: settings.json references the 3 hooks ------------
+
+test_wire_stop_extract() {
+  echo "wire: settings.json Stop[] references reflection-extract.sh"
+  if jq -e '.hooks.Stop[]?.hooks[]? | select(.command | test("reflection-extract\\.sh"))' \
+       "$SETTINGS" >/dev/null 2>&1; then
+    echo "  PASS: Stop entry for reflection-extract.sh present"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: settings.json Stop missing reflection-extract.sh"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+test_wire_stop_activity() {
+  echo "wire: settings.json Stop[] references reflection-activity.sh"
+  if jq -e '.hooks.Stop[]?.hooks[]? | select(.command | test("reflection-activity\\.sh"))' \
+       "$SETTINGS" >/dev/null 2>&1; then
+    echo "  PASS: Stop entry for reflection-activity.sh present"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: settings.json Stop missing reflection-activity.sh"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+test_wire_sessionstart_inject() {
+  echo "wire: settings.json SessionStart[] references reflection-inject.sh"
+  if jq -e '.hooks.SessionStart[]?.hooks[]? | select(.command | test("reflection-inject\\.sh"))' \
+       "$SETTINGS" >/dev/null 2>&1; then
+    echo "  PASS: SessionStart entry for reflection-inject.sh present"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: settings.json SessionStart missing reflection-inject.sh"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+test_wire_stop_order_notify_first() {
+  echo "wire: notify-stop.sh fires before reflection-extract.sh (independent ordering)"
+  # Pull the flat list of command strings under Stop[].hooks[].command, in order.
+  local order
+  order=$(jq -r '.hooks.Stop[]?.hooks[]?.command' "$SETTINGS" 2>/dev/null)
+  local notify_line; notify_line=$(echo "$order" | grep -n "notify-stop\.sh" | head -1 | cut -d: -f1)
+  local extract_line; extract_line=$(echo "$order" | grep -n "reflection-extract\.sh" | head -1 | cut -d: -f1)
+  if [[ -n "$notify_line" && -n "$extract_line" && "$notify_line" -lt "$extract_line" ]]; then
+    echo "  PASS: notify-stop.sh appears before reflection-extract.sh"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: notify-stop.sh must precede reflection-extract.sh (notify=$notify_line extract=$extract_line)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------- T-011 (FR-010 cache safety: mtime invariant) -----------------
+
+test_t011_auto_loaded_mtime_invariant() {
+  echo "T-011 (FR-010, NFR-004): hook run does not modify CLAUDE.md / rules / MEMORY.md"
+  local kdir="$TMPDIR_BASE/t011/kdir"
+  mkdir -p "$kdir"
+
+  local cmd_md="$REPO_ROOT/CLAUDE.md"
+  local rules_dir="$REPO_ROOT/rules"
+  local memory="$REPO_ROOT/projects/-Users-thkt--claude/memory/MEMORY.md"
+
+  # Baseline mtimes
+  local before_cmd=""; [[ -f "$cmd_md" ]] && before_cmd=$(stat -f %m "$cmd_md")
+  local before_mem=""; [[ -f "$memory" ]] && before_mem=$(stat -f %m "$memory")
+  local before_rules=""; [[ -d "$rules_dir" ]] && before_rules=$(find "$rules_dir" -name "*.md" -exec stat -f %m {} \; 2>/dev/null | md5)
+
+  # Drive: extract.sh (with mock subagent), activity.sh (against the sample
+  # fixture), inject.sh (against the seeded index). All scoped to $kdir so
+  # nothing they write touches the real harness.
+  local mock_bin="$TMPDIR_BASE/t011/mockbin"; mkdir -p "$mock_bin"
+  cp "$SCRIPT_DIR/fixtures/mock-claude.sh" "$mock_bin/claude"
+  chmod +x "$mock_bin/claude"
+
+  local sid="t011"
+  local input
+  input=$(jq -nc --arg sid "$sid" --arg t "$SCRIPT_DIR/fixtures/sample-history.jsonl" \
+    '{hook_event_name:"Stop",session_id:$sid,transcript_path:$t,stop_reason:"end_turn"}')
+  printf '%s' "$input" | PATH="$mock_bin:$PATH" REFLECT_KNOWLEDGE_DIR="$kdir" MOCK_CLAUDE_MODE=success "$EXTRACT" >/dev/null 2>&1 || true
+  printf '%s' "$input" | REFLECT_KNOWLEDGE_DIR="$kdir" "$ACTIVITY" >/dev/null 2>&1 || true
+  printf '{"hook_event_name":"SessionStart","session_id":"new","source":"startup"}' \
+    | REFLECT_KNOWLEDGE_DIR="$kdir" "$INJECT" >/dev/null 2>&1 || true
+
+  # Post-run mtimes
+  local after_cmd=""; [[ -f "$cmd_md" ]] && after_cmd=$(stat -f %m "$cmd_md")
+  local after_mem=""; [[ -f "$memory" ]] && after_mem=$(stat -f %m "$memory")
+  local after_rules=""; [[ -d "$rules_dir" ]] && after_rules=$(find "$rules_dir" -name "*.md" -exec stat -f %m {} \; 2>/dev/null | md5)
+
+  assert_eq "T-011 CLAUDE.md mtime unchanged" "$before_cmd" "$after_cmd"
+  assert_eq "T-011 MEMORY.md mtime unchanged" "$before_mem" "$after_mem"
+  assert_eq "T-011 rules/*.md mtime aggregate unchanged" "$before_rules" "$after_rules"
+}
+
+# ---------- T-012a (FR-011 memory grep) ----------------------------------
+
+test_t012a_no_knowledge_link_in_memory() {
+  echo "T-012a (FR-011): memory/ has no 'knowledge/' references"
+  local mem="$REPO_ROOT/projects/-Users-thkt--claude/memory"
+  if [[ ! -d "$mem" ]]; then
+    echo "  SKIP: memory dir not present"
+    return
+  fi
+  local count
+  count=$(grep -rE 'knowledge/' "$mem" 2>/dev/null | wc -l | tr -d ' ')
+  assert_eq "T-012a 0 hits under memory/" "0" "$count"
+}
+
+# ---------- T-012b (FR-011 paths frontmatter grep) -----------------------
+
+test_t012b_no_paths_attaches_knowledge() {
+  echo "T-012b (FR-011, AC-5#3): no 'paths:' frontmatter attaches knowledge/"
+  local count
+  count=$(grep -rE '^paths:.*knowledge/' \
+            "$REPO_ROOT/rules" "$REPO_ROOT/agents" "$REPO_ROOT/skills" \
+            "$REPO_ROOT/CLAUDE.md" 2>/dev/null | wc -l | tr -d ' ')
+  assert_eq "T-012b 0 hits across rules/agents/skills/CLAUDE.md" "0" "$count"
+}
+
+# ---------- T-014 (NFR-001 Stop hook total latency) ----------------------
+
+test_t014_stop_hook_total_latency() {
+  echo "T-014 (NFR-001): notify + extract + activity total < 30,000ms"
+  local kdir="$TMPDIR_BASE/t014/kdir"
+  mkdir -p "$kdir"
+  local mock_bin="$TMPDIR_BASE/t014/mockbin"; mkdir -p "$mock_bin"
+  cp "$SCRIPT_DIR/fixtures/mock-claude.sh" "$mock_bin/claude"
+  chmod +x "$mock_bin/claude"
+
+  local sid="t014"
+  local input
+  input=$(jq -nc --arg sid "$sid" --arg t "$SCRIPT_DIR/fixtures/sample-history.jsonl" \
+    '{hook_event_name:"Stop",session_id:$sid,transcript_path:$t,stop_reason:"end_turn"}')
+
+  local t_start; t_start=$(python3 -c 'import time; print(int(time.time()*1000))')
+  # notify-stop.sh has side-effects (sound) — skip in test, measure only the
+  # reflection hooks. T-014 enforces the budget the reflection pipeline adds.
+  printf '%s' "$input" | PATH="$mock_bin:$PATH" REFLECT_KNOWLEDGE_DIR="$kdir" MOCK_CLAUDE_MODE=success "$EXTRACT" >/dev/null 2>&1 || true
+  printf '%s' "$input" | REFLECT_KNOWLEDGE_DIR="$kdir" "$ACTIVITY" >/dev/null 2>&1 || true
+  local t_end; t_end=$(python3 -c 'import time; print(int(time.time()*1000))')
+  local elapsed_ms=$(( t_end - t_start ))
+
+  if (( elapsed_ms < 30000 )); then
+    echo "  PASS: T-014 elapsed ${elapsed_ms}ms within 30,000ms budget"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: T-014 elapsed ${elapsed_ms}ms exceeds 30,000ms"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------- T-016 (NFR-007 portability hardcode grep) --------------------
+
+test_t016_no_home_claude_hardcode() {
+  echo "T-016 (NFR-007): hooks/lifecycle/reflection-*.sh has 0 ~/.claude or \$HOME/.claude hardcode"
+  local home_hits tilde_hits
+  home_hits=$(grep -nE '\$HOME/\.claude' \
+                "$REPO_ROOT/hooks/lifecycle/reflection-extract.sh" \
+                "$REPO_ROOT/hooks/lifecycle/reflection-activity.sh" \
+                "$REPO_ROOT/hooks/lifecycle/reflection-inject.sh" \
+                2>/dev/null | wc -l | tr -d ' ')
+  tilde_hits=$(grep -nE '~/\.claude' \
+                 "$REPO_ROOT/hooks/lifecycle/reflection-extract.sh" \
+                 "$REPO_ROOT/hooks/lifecycle/reflection-activity.sh" \
+                 "$REPO_ROOT/hooks/lifecycle/reflection-inject.sh" \
+                 2>/dev/null | wc -l | tr -d ' ')
+  assert_eq "T-016 \$HOME/.claude hits = 0"   "0" "$home_hits"
+  assert_eq "T-016 ~/.claude hits = 0"        "0" "$tilde_hits"
+}
+
+echo "=== reflection wire + AC verification (Phase 5) ==="
+test_wire_stop_extract
+test_wire_stop_activity
+test_wire_sessionstart_inject
+test_wire_stop_order_notify_first
+test_t011_auto_loaded_mtime_invariant
+test_t012a_no_knowledge_link_in_memory
+test_t012b_no_paths_attaches_knowledge
+test_t014_stop_hook_total_latency
+test_t016_no_home_claude_hardcode
+
+report_results

--- a/skills/audit-undocumented/SKILL.md
+++ b/skills/audit-undocumented/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: audit-undocumented
+description: Discover undocumented design decisions and challenge each candidate via critic-design before promotion. Rank by impact and reversibility, produce ADR promotion candidates. Treat each candidate as a position arguing for ADR status, not a fact to be filed.
+when_to_use: 判断未記録の発掘, undocumented decisions, ADR候補発掘, 設計判断棚卸し, decision archaeology, design rationale audit
+allowed-tools: Read Write Edit LS Bash(git:*) Bash(gh:*) Bash(ugrep:*) Bash(bfs:*) Bash(yomu:*) Bash(sqlite3:*) Bash(wc:*) Task AskUserQuestion
+model: opus
+argument-hint: "[--threshold=N] [--paths=path,path]"
+---
+
+# /audit-undocumented - Undocumented Decisions Audit
+
+Discover design decisions that exist in the code but have no ADR. Each candidate is challenged by critic-design (Step 6.2) before promotion. The final list is what survived the adversarial pass, not what the initial scan found. Produce a ranked list of ADR promotion candidates so the next refactor has a complete decision baseline.
+
+## When to Use
+
+- Repo has accumulated implicit decisions that are not in ADRs
+- Before refactoring, you want to know which decisions to preserve vs question
+- New maintainers need a map of "why is the code shaped this way"
+
+This skill is complementary to `/audit-adr-drift`. Run drift scan first if ADRs exist; the gaps it cannot answer become the input here.
+
+For cross-repo `scope:` cluster detection on ADRs already tagged with the scope frontmatter (YAML or `- Scope:` bullet), invoke `scripts/audit-adr-scopes.py` directly. That sibling script aggregates ADRs from `~/.claude` and `~/GitHub/{cli,apps,plugins}/*/docs/decisions/` and surfaces same-scope title clusters (horizontal-expansion candidates).
+
+## Input
+
+`$ARGUMENTS` holds the full argument string. Parse before use:
+
+- Split on whitespace into tokens
+- `--threshold=N`: integer, default `400` if unset or non-numeric (must be `> 0`)
+- `--paths=p1,p2,...`: comma-separated paths to documents. If unset, auto-detect via Step 2 table
+- `--no-challenge`: skip the critic-design challenge step (default: challenge runs)
+- Reject unknown flags with an explicit error rather than silently ignore
+- All flags optional; with no input, auto-detect everything and run challenge
+
+## Execution
+
+| Step | Action                                                                                     |
+| ---- | ------------------------------------------------------------------------------------------ |
+| 1    | Detect large files exceeding threshold (default >400 lines)                                |
+| 2    | Detect prose documents likely to contain decisions (README, CONTRIBUTING, etc.)            |
+| 3    | Run language-appropriate reviewer on each large file; cross-reference with existing ADRs   |
+| 4    | Extract decision-shaped sentences from prose documents; cross-reference with existing ADRs |
+| 5    | Tag each candidate with impact (H/M/L) and reversibility (high/medium/low)                 |
+| 6    | Rank initial candidates; spawn critic-design to challenge them (skip if `--no-challenge`)  |
+| 7    | Write report to `docs/audit/<YYYY-MM-DD>-undocumented-decisions.md`                        |
+| 8    | List post-challenge ADR promotion candidates as follow-up issues                           |
+
+### Step 1: Large File Detection
+
+```bash
+# Find source files exceeding the threshold
+# NOTE: Do not use awk '$1 > t' here. SKILL loader expands `$1` to the second
+# whitespace-token of $ARGUMENTS (0-indexed split). Use find+while instead.
+bfs <repo-root> -type f \( -name '*.rs' -o -name '*.ts' -o -name '*.tsx' -o -name '*.py' -o -name '*.go' -o -name '*.swift' \) \
+  -not -path '*/target/*' -not -path '*/node_modules/*' -not -path '*/.git/*' \
+  -print0 \
+  | while IFS= read -r -d '' file; do
+      lines=$(wc -l < "$file")
+      [ "$lines" -gt "$THRESHOLD" ] && printf '%s %s\n' "$lines" "$file"
+    done | sort -rn
+```
+
+Default threshold is 400 lines (one-screen ceiling, see rules/development/THRESHOLDS.md).
+
+### Step 2: Document Detection
+
+Scan top-level and `docs/` for files matching:
+
+| Filename pattern                                                     | Likely content                       |
+| -------------------------------------------------------------------- | ------------------------------------ |
+| `README.md`                                                          | Design intent, naming, prohibitions  |
+| `CONTRIBUTING.md`                                                    | Code style decisions, workflow rules |
+| `SECURITY.md`                                                        | Threat boundaries, security policies |
+| `THREAT_MODEL.md`                                                    | Trust boundaries, mitigations        |
+| `ARCHITECTURE.md`                                                    | Module decomposition, layer policy   |
+| `DESIGN.md` / `*.design.md`                                          | Component rationale                  |
+| `CLAUDE.md` / `AGENTS.md`                                            | AI-agent operating decisions         |
+| `Makefile` / `justfile`                                              | Build flow decisions                 |
+| Linter config (`Cargo.toml` `[lints.*]`, `.eslintrc`, `oxlint.json`) | Rule selection rationale             |
+
+### Step 3: Large File Decision Mining
+
+For files exceeding 800 lines (2x threshold), run a triage sub-step first: spawn the reviewer with a "scan first 200 lines and estimate finding density (findings per 100 lines)" instruction, then AskUserQuestion with three options:
+
+- Continue full scan
+- Truncate to first 600 lines (covers module preamble and main types)
+- Skip this file (record as `skipped_for_size`)
+
+For files at or below 800 lines, proceed directly to full scan.
+
+For each large file (full or truncated scope), spawn the matching reviewer via Task (same routing as `/audit-adr-drift` Step 5). The reviewer answers:
+
+- Why is this file shaped at this granularity?
+- What invariant or contract does it carry that a reader cannot derive from the code?
+- Is there a comment or module-doc that already records the rationale?
+- Does the comment describe the current state but omit the rule for future contributors? (this is the `incomplete-contract` pattern)
+
+Findings format: `file:line` + decision summary + evidence (code comment, naming, module-doc) + `documented?` (Yes/Partial/No) + `incomplete-contract?` (Yes/No).
+
+The `incomplete-contract` flag captures findings where the code has a comment describing what is true, but not what must remain true. Example: an SSRF-safe HTTP client field is annotated "redirect disabled for SSRF" but no rule says "future commands handling user URLs MUST use this client." This pattern is common with security invariants and design rationale that depend on the reader inferring "and this should stay this way." Findings with `incomplete-contract=Yes` are strong ADR candidates regardless of `documented?` value, because the missing rule is what an ADR uniquely provides.
+
+After collecting findings, cross-reference each one against the ADR directory (if any). Drop findings already covered by an ADR (record count as "ADR-covered (excluded)" in the summary).
+
+### Step 4: Prose Decision Extraction
+
+For each detected document, find sentences containing decision verbs and check for ADR coverage:
+
+- Decision verbs (English): "decide", "choose", "adopt", "reject", "deprecate", "must not", "never", "always"
+- Decision verbs (Japanese): "決定", "採用", "禁止", "方針", "選定", "排除", "従う", "規約"
+
+Each match is a candidate. Then for each candidate, search the ADR directory (if any) for cross-reference. Drop candidates already covered by an ADR.
+
+#### External ADR Dependency Detection
+
+In addition to prose docs, scan source code for `per ADR-NNNN` / `see ADR-NNNN` / `ADR-NNNN` reference patterns:
+
+```bash
+ugrep -r -n -E "(per |see |governed by )?ADR-[0-9]{4}" --include="*.rs" --include="*.ts" --include="*.tsx" --include="*.py" --include="*.go" --include="*.md" --include="*.toml" .
+```
+
+For each captured ADR id, check whether the matching `NNNN-*.md` exists in the local ADR directory:
+
+- Local match → existing ADR coverage, skip
+- No local match → record as **External ADR Dependency** candidate
+
+External ADR dependencies are flagged for promotion (write a scout-local ADR that supersedes or imports the external decision). This is impact=H by default because cross-repo ADR drift is silent and hard to detect after the fact.
+
+### Step 5: Impact + Reversibility Tagging
+
+| Impact | Criteria                                                              |
+| ------ | --------------------------------------------------------------------- |
+| H      | Crosses module boundary, affects public API, or governs 2+ subsystems |
+| M      | Affects single module's internal contract                             |
+| L      | Local style or naming choice                                          |
+
+| Reversibility | Criteria                                                         |
+| ------------- | ---------------------------------------------------------------- |
+| high          | Decision can be reversed by editing one location                 |
+| medium        | Reversal requires coordinated changes across 2-5 files           |
+| low           | Reversal requires migration, deprecation cycle, or schema change |
+
+### Step 6: Ranking and Challenge
+
+#### 6.1 Initial Ranking
+
+ADR promotion candidates = (impact=H) AND (reversibility=low OR medium).
+
+Findings with `incomplete-contract=Yes` are also promoted regardless of `documented?` value, because the missing rule for future contributors is precisely what an ADR records (and a comment, by itself, cannot).
+
+Other findings are recorded but not promoted (informational).
+
+#### 6.2 Devil's Advocate Challenge
+
+Skip this sub-step if `--no-challenge` is set.
+
+Spawn `critic-design` via Task with the initial promotion candidate list. The agent challenges each candidate with:
+
+- Does a future contributor actually benefit from the rule? Who is the reader?
+- Can a code comment + test suffice instead of an ADR?
+- Does ADR risk lock-in (over-documenting decisions that should evolve)?
+- For statement-of-fact configs (deny.toml, Cargo.toml lints): is the config file itself already the source of truth, making an ADR redundant?
+- For monolithic-boundary candidates: would the ADR justify the status quo and reduce pressure to split?
+- Is there already an enforcement mechanism (type system, lint, test) that makes the rule mechanical, leaving the ADR with nothing to add?
+- **Bug vs Invariant**: is this candidate describing a fix-the-bug case (current code is wrong and should change) or an invariant-to-document case (current code is intentional and should be preserved)? Bugs must be surfaced as bug-fix follow-ups, not ADRs — documenting wrong behavior as intentional locks in the bug.
+
+ADR worth heuristic (empirically derived from scout試運転 2026-05-13): existing enforcement mechanisms (lint config, type system, automated tests) are stronger than ADR text for mechanical decisions. Reserve ADR for two categories where mechanisms cannot help:
+
+1. Invariants not enforceable by tools (e.g., "field X must not be used with Y" when both are same type)
+2. Public API compatibility commitments (e.g., exit code convention, JSON output schema)
+
+Statement-of-fact configs (deny.toml, Cargo.toml `[lints.*]`) are themselves the source of truth — duplicating into an ADR creates drift risk. A 1-2 line policy comment in the config block usually suffices.
+
+For each candidate, critic-design returns one of:
+
+| Verdict     | Meaning                                                                                                                                                               |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keep`      | ADR worth, file as standalone or merge with related candidates                                                                                                        |
+| `downgrade` | Not standalone ADR; absorb into a related ADR section or strengthen comments                                                                                          |
+| `drop`      | Not ADR-worthy; config/comment/test already covers it, cost > value, or **the candidate is a bug** (surface as bug-fix follow-up, do not document the wrong behavior) |
+
+Record the challenge verdict alongside the initial ranking. The final candidate list = initial candidates marked `keep` + those marked `downgrade` (with target ADR), minus those marked `drop`.
+
+When agent is unavailable or times out, fall back to initial ranking with a `challenge_skipped: timeout` note in the summary.
+
+### Step 7: Report Output
+
+Compute the date with `date -u +%Y-%m-%d` (UTC, ISO format) for cross-timezone consistency. Ensure the output directory exists:
+
+```bash
+mkdir -p docs/audit
+DATE=$(date -u +%Y-%m-%d)
+REPORT="docs/audit/${DATE}-undocumented-decisions.md"
+```
+
+Write the report with:
+
+```markdown
+# Undocumented Decisions Audit: <YYYY-MM-DD>
+
+## Summary
+
+| Metric                   | Value |
+| ------------------------ | ----- |
+| Large files scanned      | N     |
+| Documents scanned        | N     |
+| Decision candidates      | N     |
+| ADR-covered (excluded)   | N     |
+| Net new candidates       | N     |
+| ADR promotion candidates | N     |
+
+## Large File Decisions
+
+### src/foo.rs (NNN lines)
+
+| # | Line | Decision | Documented? | Incomplete-contract? | Impact | Reversibility |
+| - | ---- | -------- | ----------- | -------------------- | ------ | ------------- |
+| 1 | 42   | ...      | Partial     | Yes                  | H      | low           |
+
+## Prose Document Decisions
+
+### README.md
+
+| # | Line | Decision Verb | Decision | ADR Coverage |
+| - | ---- | ------------- | -------- | ------------ |
+| 1 | 12   | must not      | ...      | None         |
+
+## ADR Promotion Candidates (post-challenge)
+
+| # | Candidate                       | Initial | Challenge | Final          |
+| - | ------------------------------- | ------- | --------- | -------------- |
+| 1 | `<source>:<line>` — `<summary>` | promote | keep      | ADR            |
+| 2 | `<source>:<line>` — `<summary>` | promote | downgrade | inline-comment |
+| 3 | `<source>:<line>` — `<summary>` | promote | drop      | skip           |
+
+Summary line per file: `keep N / downgrade N / drop N`.
+
+If `--no-challenge` was set, omit Challenge and Final columns and use the initial ranking directly.
+```
+
+### Step 8: Follow-up Hand-off
+
+Print only the post-challenge `keep` candidates and offer to invoke `/adr` for each, or aggregate them into a single tracking issue via `/issue`. `downgrade` candidates are listed as comment-strengthening tasks (not ADRs). `drop` candidates are recorded in the report for traceability but not surfaced as follow-up.
+
+## Output
+
+- Report path: `docs/audit/<YYYY-MM-DD>-undocumented-decisions.md`
+- Console summary: candidate count, promotion candidate count
+- Optional: ADR drafting via `/adr` or tracking issue via `/issue`
+
+## Out of Scope
+
+- Drafting the ADRs themselves (use `/adr` after this skill produces the candidate list)
+- Implementing code changes
+- Updating README/CONTRIBUTING/etc. bodies (only extraction here)
+- Drift scan against existing ADRs (use `/audit-adr-drift`)
+- Cross-repo scope cluster detection (use `scripts/audit-adr-scopes.py` directly; this skill is single-repo by design)
+
+## Acceptance Criteria
+
+- [ ] Report file exists at `docs/audit/<YYYY-MM-DD>-undocumented-decisions.md`
+- [ ] Every large file exceeding threshold has a section
+- [ ] Every scanned document has an extraction section (or "no decisions found")
+- [ ] Every candidate has impact + reversibility tags
+- [ ] ADR promotion candidates are listed at the end with a one-line rationale

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit
-description: Orchestrate specialized review agents for code quality assessment. Do NOT use for quick PR screening (use /preview instead).
+description: Orchestrate reviewer agents under adversarial challenge (critic-audit + critic-evidence). Findings are positions to be argued, not facts to be aggregated. Do NOT use for quick PR screening (use /preview instead).
 when_to_use: レビューして, コードレビュー, 品質チェック, code review, quality check, review
 allowed-tools: Bash(git diff:*) Bash(git status:*) Bash(git log:*) Bash(git show:*) Bash(date:*) Bash(mkdir:*) Read Write LS Task AskUserQuestion Bash(ugrep:*) Bash(bfs:*)
 model: opus
@@ -9,7 +9,7 @@ argument-hint: "[target files or scope]"
 
 # /audit - Code Audit Orchestrator
 
-Orchestrate specialized review agents with evidence-based filtering. The finding schema requires `file:line` on every finding. Entries without evidence are structurally invalid.
+Orchestrate reviewer agents, then run findings through critic-audit (challenge) and critic-evidence (verify) before integration. The pipeline is reviewer → challenge → verify → integrate, not reviewer → aggregate. Each finding is a position to be argued, not a fact. The finding schema requires `file:line` on every finding. Entries without evidence are structurally invalid.
 
 ## Rationalization Counters
 
@@ -45,7 +45,7 @@ After File Routing assigns reviewers by file pattern, Leader filters the result 
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | security    | reviewer-security, reviewer-silence                                                                                                                                                                                                                                |
 | performance | reviewer-performance, reviewer-efficiency, reviewer-progressive                                                                                                                                                                                                    |
-| quality     | reviewer-readability, reviewer-design, reviewer-react-pattern, reviewer-strictness, reviewer-encapsulation, reviewer-causation, reviewer-resilience, reviewer-duplication, reviewer-reuse, reviewer-testability, reviewer-operations, reviewer-document, reviewer-prompt, reviewer-silence |
+| quality     | reviewer-readability, reviewer-design, reviewer-react-pattern, reviewer-strictness, reviewer-rust, reviewer-encapsulation, reviewer-causation, reviewer-resilience, reviewer-duplication, reviewer-reuse, reviewer-testability, reviewer-operations, reviewer-document, reviewer-prompt, reviewer-silence |
 | a11y        | reviewer-accessibility, reviewer-progressive                                                                                                                                                                                                                       |
 | all         | No filter. All reviewers per File Routing run                                                                                                                                                                                                                      |
 
@@ -126,7 +126,8 @@ Leader classifies each target file by path and assigns to relevant reviewers onl
 | `*.sh`               | reviewer-security, reviewer-silence, reviewer-duplication, reviewer-reuse, reviewer-efficiency, reviewer-operations, reviewer-resilience                                                                                                                                 |
 | `*.ts, *.js`         | reviewer-security, reviewer-silence, reviewer-strictness, reviewer-duplication, reviewer-reuse, reviewer-efficiency, reviewer-design, reviewer-react-pattern, reviewer-testability, reviewer-performance, reviewer-operations, reviewer-resilience                       |
 | `*.tsx, *.jsx`       | reviewer-security, reviewer-silence, reviewer-strictness, reviewer-duplication, reviewer-reuse, reviewer-efficiency, reviewer-design, reviewer-react-pattern, reviewer-testability, reviewer-performance, reviewer-operations, reviewer-resilience, reviewer-accessibility, reviewer-progressive |
-| `*.rs, *.py`         | reviewer-security, reviewer-silence, reviewer-strictness, reviewer-duplication, reviewer-reuse, reviewer-efficiency, reviewer-design, reviewer-testability, reviewer-performance, reviewer-operations, reviewer-resilience                                               |
+| `*.rs`               | reviewer-security, reviewer-silence, reviewer-rust, reviewer-duplication, reviewer-reuse, reviewer-efficiency, reviewer-design, reviewer-testability, reviewer-performance, reviewer-operations, reviewer-resilience                                                     |
+| `*.py`               | reviewer-security, reviewer-silence, reviewer-strictness, reviewer-duplication, reviewer-reuse, reviewer-efficiency, reviewer-design, reviewer-testability, reviewer-performance, reviewer-operations, reviewer-resilience                                               |
 | `*.md`               | reviewer-prompt, reviewer-document                                                                                                                                                                                                                                       |
 | `*.yaml, *.json`     | reviewer-encapsulation, reviewer-document                                                                                                                                                                                                                                |
 | `*.css, *.html`      | reviewer-accessibility, reviewer-progressive, reviewer-performance, reviewer-duplication                                                                                                                                                                                 |

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -22,7 +22,7 @@ DB path: `<project_root>/.yomu/index.db` (`git rev-parse --show-toplevel`). If n
 
 ## Schema
 
-Run queries via `sqlite3 -readonly <db_path> "<query>"`.
+Run queries via `sqlite3 "file:<db_path>?immutable=1" "<query>"`.
 
 ```sql
 chunks (

--- a/skills/polish/SKILL.md
+++ b/skills/polish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polish
-description: Light review + cleanup with optional Codex + CodeRabbit + Gemini cross-check, slop removal, and test audit. Do NOT use for deep multi-reviewer audits (use /audit).
+description: Light adversarial probe + cleanup. Codex + CodeRabbit + Gemini findings are challenged by critic-audit, not aggregated as facts. Do NOT use for deep multi-reviewer audits (use /audit).
 when_to_use: 整理して, きれいにして, コード整理, slop除去, ポリッシュ, テスト整理, テスト監査, クロスチェック, crosscheck, Codex レビュー, CodeRabbit, Gemini レビュー
 allowed-tools: Bash(codex:*) Bash(coderabbit:*) Bash(gemini:*) Bash(git diff:*) Bash(git log:*) Bash(git stash:*) Bash(git status:*) Bash(cargo test:*) Bash(npm test:*) Bash(npm run test:*) Bash(bun test:*) Bash(pnpm test:*) Bash(yarn test:*) Bash(make test:*) Bash(which:*) Read Edit LS Skill Task AskUserQuestion Bash(ugrep:*) Bash(bfs:*)
 model: opus
@@ -9,7 +9,9 @@ argument-hint: "[target scope]"
 
 # /polish - Light Review + Cleanup
 
-Parallel review (simplify + Codex + CodeRabbit + Gemini) → cleanup (enhancer-code). All fixes applied directly in foreground.
+Parallel review (simplify + Codex + CodeRabbit + Gemini) → critic-audit adversarial challenge → cleanup (enhancer-code). All fixes applied directly in foreground.
+
+Phase 1 reviewers run in parallel without seeing each other's findings. Aggregating their outputs is a sum, not a discussion. Phase 1.5 spawns `critic-audit` once over the aggregated set so a single skeptical reader judges each finding against the actual code, downgrades or disputes the ones that miss context, and lets only validated items reach Phase 2.
 
 ## Input
 
@@ -18,7 +20,7 @@ Parallel review (simplify + Codex + CodeRabbit + Gemini) → cleanup (enhancer-c
 
 ## Execution
 
-### Phase 1: Parallel review
+### Phase 1: Parallel review + adversarial challenge
 
 Run simplify, Codex, CodeRabbit, and Gemini in parallel. Each tool skips independently if unavailable. If all skip, proceed to Phase 2. Gemini provides cross-family review to counter Self-Enhancement bias when Claude generated the code.
 
@@ -39,7 +41,7 @@ Mode selection by change state. If both uncommitted and committed changes exist,
 Gemini command. Capture the diff via the source above into `$DIFF`, then pass it inline so Gemini does not need shell access.
 
 ```sh
-gemini --skip-trust --approval-mode plan -m gemini-2.5-pro -p "$(cat <<EOF
+gemini --skip-trust --approval-mode plan -m gemini-2.5-flash -p "$(cat <<EOF
 Review this diff. The code may be Claude-generated, so be skeptical to counter Self-Enhancement bias.
 Focus: Logic correctness, Architecture, Maintainability.
 Skip: Security (covered by CodeRabbit), Code reuse and AI slop (covered by simplify and enhancer).
@@ -51,7 +53,7 @@ EOF
 )"
 ```
 
-Notes. `--skip-trust` bypasses the trusted-folder check for headless mode. `--approval-mode plan` enforces read-only so Gemini cannot edit files. `gemini-2.5-pro` is current; switch to Gemini 3 once it leaves preview and capacity stabilizes on oauth-personal.
+Notes. `--skip-trust` bypasses the trusted-folder check for headless mode. `--approval-mode plan` enforces read-only so Gemini cannot edit files. `gemini-2.5-flash` is current. OAuth-personal Pro quota is 100 RPD (Dec 2025 nerf) and routinely exhausted by interactive use, so Pro is unreliable for polish. Flash has 250 RPD on the same auth. Revisit when Gemini 3 Flash ships or when paid API quota becomes available.
 
 Steps for orchestrating Phase 1.
 
@@ -61,9 +63,10 @@ Steps for orchestrating Phase 1.
 | 2    | Spawn simplify via `Skill("simplify", args: "$ARGUMENTS")` and run Codex/CodeRabbit/Gemini CLIs concurrently in the same response                                                           |
 | 3    | Wait for all four tasks to return findings                                                                                                                                                  |
 | 4    | Dedupe findings across tools by file:line                                                                                                                                                   |
-| 5    | Triage: keep simplify all, keep Codex P1/P2, keep CodeRabbit critical only, keep Gemini Critical+Major. Drop Phase 2 territory. Drop fixes whose edits touch files outside `git diff` scope |
-| 6    | Fix surviving findings (high first, then medium)                                                                                                                                            |
-| 7    | Detect test command and validate. `git stash` fix on test failure                                                                                                                           |
+| 5    | Adversarial challenge. Map each aggregated finding to the critic-audit input schema (see `~/.claude/agents/critics/critic-audit.md`, Input section). Spawn `Task(subagent_type: "critic-audit")` once with the full list. Wait for per-finding verdict: confirmed / disputed / downgraded / needs_context |
+| 6    | Triage. Apply critic-audit verdicts first: drop `disputed`, apply `downgraded` severity, surface `needs_context` to user with a one-line summary. On the survivors, keep simplify all, Codex P1/P2, CodeRabbit critical only, Gemini Critical+Major. Drop Phase 2 territory. Drop fixes whose edits touch files outside `git diff` scope |
+| 7    | Fix surviving findings (high first, then medium)                                                                                                                                            |
+| 8    | Detect test command and validate. `git stash` fix on test failure                                                                                                                           |
 
 CodeRabbit drops (Phase 2 territory, not applied here): naming, formatting, readability, AI slop. Users should set `profile: chill` in `.coderabbit.yaml` to reduce free-tier rate-limit pressure.
 
@@ -81,6 +84,8 @@ Phase 1 (review):
   codex: <fixed N / skipped N with reasons / not available>
   coderabbit: <fixed N / skipped N with reasons / not available>
   gemini: <fixed N / skipped N with reasons / not available>
+Phase 1.5 (critic-audit challenge):
+  total: N / confirmed: N / disputed: N / downgraded: N / needs_context: N
 Phase 2 (cleanup):
   Code: <changes with file:line>
   Tests: <changes with file:line>
@@ -101,5 +106,7 @@ Phase 2 (cleanup):
 | gemini not installed         | Skip Gemini only, keep others          |
 | gemini capacity exhausted    | Skip Gemini only, log model name       |
 | gemini call fails            | Log warning, proceed                   |
+| critic-audit returns empty   | Log warning, keep aggregated findings as-is, proceed to Triage |
+| critic-audit fails           | Log warning, keep aggregated findings as-is, proceed to Triage |
 | All Phase 1 tools skipped    | Proceed directly to Phase 2            |
 | Fix causes test fail         | `git stash` the fix, skip finding      |

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: reflect
+description: Surface the current session's tentative reflection (realization / judgment / counterfactual) and optionally promote it to the durable knowledge store. Escape hatch for when Stop hook reflection extraction failed.
+allowed-tools: Read Write Bash
+---
+
+# /reflect — manual reflection promotion
+
+Escape hatch for ADR-0068. Stop hook subagent extraction (`reflection-extract.sh`) normally writes per-session reflections automatically. When that pipeline fails (subagent timeout, API error, build issue), `/reflect` lets you produce the same artifact manually before the session ends.
+
+This is NOT the primary path. The Stop hook is. Use this skill when:
+
+- The latest `knowledge/reflection/<session_id>.md` is a `placeholder: true` file (auto-extraction returned empty) and you have meaningful reflection to capture.
+- You want to override or edit the auto-extracted content before the next session reads it.
+- You suspect the Stop hook is broken on this machine and want to verify the knowledge store stays current.
+
+## Procedure
+
+### Step 0: Resolve paths
+
+Run once at the top of the skill.
+
+```bash
+KDIR="${REFLECT_KNOWLEDGE_DIR:-${CLAUDE_PROJECT_DIR}/.claude/knowledge}"
+SID="${CLAUDE_SESSION_ID:?session id required}"
+MD="$KDIR/reflection/$SID.md"
+INDEX="$KDIR/reflection-index.jsonl"
+```
+
+If `$KDIR` does not exist, advise the user to run a session under the Stop hook at least once (the directory is created on first auto-extraction) or set `REFLECT_KNOWLEDGE_DIR` explicitly.
+
+### Step 1: Read the current state
+
+Print to the user, in this order:
+
+1. Does `$MD` exist? If yes, show it (frontmatter + body).
+2. Is it a placeholder (`placeholder: true`)? Flag it.
+3. Latest 3 entries from `$INDEX` (so the user sees the local history).
+
+### Step 2: Compose
+
+Generate a fresh reflection across the 3 categories. Use the same shape as `agents/reflection-extractor.md` and reuse its guidance (realization / judgment / counterfactual). Keep the body under 300 words total. Output frontmatter:
+
+```
+---
+session_id: <SID>
+confidence: confirmed   # always "confirmed" for /reflect — user-attested
+categories: [...]
+word_count: <int>
+created_at: <ISO8601 UTC>
+promoted_via: reflect-skill
+---
+```
+
+The `promoted_via: reflect-skill` field marks manual promotions so audits can distinguish them from auto-extracted reflections.
+
+### Step 3: Confirm
+
+Show the user the composed reflection in a fenced block. Ask: "Promote this to `$MD`? (yes / edit / cancel)"
+
+- `yes` → Step 4
+- `edit` → ask what to change, regenerate, return to Step 3
+- `cancel` → exit without writing
+
+### Step 4: Write and index
+
+```bash
+# Atomic write: stage to a temp file, then move.
+TMP="$(mktemp "$KDIR/reflection/.$SID.XXXXXX")"
+cat > "$TMP" <<EOF
+<composed reflection>
+EOF
+mv "$TMP" "$MD"
+
+# Index: append if this session has no prior entry, otherwise skip
+# (append-only contract; duplicates are tolerated but noisy).
+if ! grep -Fq "\"session_id\":\"$SID\"" "$INDEX" 2>/dev/null; then
+  printf '{"session_id":"%s","reflection_file":"%s","created_at":"%s","promoted_via":"reflect-skill"}\n' \
+    "$SID" "$MD" "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$INDEX"
+fi
+
+echo "Promoted to $MD"
+```
+
+## Constraints
+
+- Never modify `CLAUDE.md`, `MEMORY.md`, `rules/`, `agents/`, `skills/`, or any file referenced by `paths:` frontmatter. Same auto-loaded-path immutability rule as the Stop hook (ADR-0068 BR-006). Violations invalidate the prompt cache for every following session.
+- Never read transcripts outside the current session.
+- Never call `claude --bare` recursively. This skill runs in the main session, not in a subagent.
+
+## When NOT to use this
+
+- The Stop hook is working and the latest reflection is `confidence: confirmed` (not placeholder). Re-running `/reflect` would overwrite a higher-quality extraction.
+- You want to edit a reflection from an old session. That requires manual edit of `$KDIR/reflection/<old-sid>.md`, not this skill.
+- You want to delete entries. The index is append-only by contract; deletion is a separate operation outside this skill.
+
+## Related
+
+- ADR-0068: Stop hook Knowledge Reflection design (this skill is the escape hatch named there).
+- `agents/reflection-extractor.md`: shares the 3-category output shape.
+- `hooks/lifecycle/reflection-extract.sh`: the primary auto-extraction path this skill complements.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Perform project research and technical investigation without implementation. Do NOT use for design planning or SOW/Spec generation (use /think instead).
+description: Probe project and technical questions. Findings are positions to be challenged with explicit sources, not conclusions. Phase 5 advisor pass argues against the synthesis before it lands. Do NOT use for design planning or SOW/Spec generation (use /think instead).
 when_to_use: 調査して, 調べて, リサーチ, investigate, 分析して, issueやろう, issue見て, 横並びチェック, 類似パターン検出, refactor 横展開
 allowed-tools: Bash(tree:*) Bash(git log:*) Bash(git diff:*) Bash(wc:*) Bash(yomu:*) Read LS Task AskUserQuestion Bash(ugrep:*) Bash(bfs:*)
 model: opus
@@ -10,7 +10,7 @@ argument-hint: "[research subject or question]"
 
 # /research
 
-Investigate codebase with source-based findings, without implementation.
+Investigate codebase with source-based findings, without implementation. Findings are positions to be challenged. Phase 5 advisor pass argues against the synthesis before it lands.
 
 ## Input
 
@@ -19,27 +19,33 @@ Investigate codebase with source-based findings, without implementation.
 
 ## Execution
 
-| Phase | Action                               | Detail                                                                                      |
-| ----- | ------------------------------------ | ------------------------------------------------------------------------------------------- |
-| 0     | Prior research scan                  | bfs same-subject files in `.claude/workspace/research/`. Inherit Findings/Constraints       |
-| 1     | Intent + Domain clarification        | Ask via AskUserQuestion (skip if obvious from `$ARGUMENTS`)                                 |
-| 2     | Domain-scoped parallel investigation | yomu search + Task(Explore) + targeted Read/ugrep, scoped by Domain                         |
-| 3     | Strong Inference (Bug only)          | ≥3 hypotheses, discriminating tests, eliminate                                              |
-| 4     | Synthesis                            | Merge prior baseline, source pass for findings. Disconfirmation only if Phase 3 was skipped |
+| Phase | Action                               | Detail                                                                                                                                                                       |
+| ----- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0     | Outcome Anchor                       | Read `.claude/OUTCOME.md`; if absent, stub generation (see rules/core/OUTCOME.md). Confirm investigation scope aligns with outcome state                                     |
+| 1     | Prior research scan                  | bfs same-subject files in `.claude/workspace/research/`. Inherit Findings/Constraints                                                                                        |
+| 2     | Intent + Domain clarification        | Ask via AskUserQuestion (skip if obvious from `$ARGUMENTS`)                                                                                                                  |
+| 3     | Domain-scoped parallel investigation | yomu search + Task(Explore) + targeted Read/ugrep, scoped by Domain. Capture command + raw output to scratch. Cross-method verify when claim drives PR scope or crosses repo |
+| 4     | Strong Inference (Bug only)          | ≥3 hypotheses, discriminating tests, eliminate                                                                                                                               |
+| 5     | Advisor pre-synthesis check          | Invoke `advisor()` with no parameters. Skip per conditions in Phase 5 section                                                                                                |
+| 6     | Synthesis                            | Merge prior baseline, source pass for findings. Disconfirmation only if Phase 4 was skipped                                                                                  |
 
-### Phase 0: Prior Research Scan
+### Phase 0: Outcome Anchor
 
-Derive subject slug from `$ARGUMENTS` (lowercase, hyphenated). Run `bfs .claude/workspace/research -name '*<slug>*.md'`. For each match:
+Read `.claude/OUTCOME.md`. If absent, generate stub via rules/core/OUTCOME.md flow. Confirm the investigation scope aligns with the outcome state. If the investigation steps into Non-goals, explicitly confirm with user before proceeding.
+
+### Phase 1: Prior Research Scan
+
+Derive subject slug from `$ARGUMENTS` (lowercase, hyphenated). Run `bfs .claude/workspace/research -name '*<slug>*.md'`. For each match, the table below shows the carry-forward mapping.
 
 | Extract                 | Carry forward as                          |
 | ----------------------- | ----------------------------------------- |
-| Key Findings table      | Phase 4 baseline (re-verify or supersede) |
-| Constraints table       | Phase 2 input (do not re-discover)        |
-| Disconfirmation results | Phase 4 reference                         |
+| Key Findings table      | Phase 6 baseline (re-verify or supersede) |
+| Constraints table       | Phase 3 input (do not re-discover)        |
+| Disconfirmation results | Phase 6 reference                         |
 
 If no match, skip and note "No prior research found for `<slug>`".
 
-### Phase 1: Intent + Domain Clarification
+### Phase 2: Intent + Domain Clarification
 
 Skip if `$ARGUMENTS` clearly indicates both. Otherwise ask via AskUserQuestion.
 
@@ -48,11 +54,11 @@ Skip if `$ARGUMENTS` clearly indicates both. Otherwise ask via AskUserQuestion.
 | Research intent | Feature planning / Bug investigation / Understanding |
 | Domain          | Data model / API / Infrastructure / General          |
 
-Domain drives Phase 2 scoping. Domain=General applies no scoping.
+Domain drives Phase 3 scoping. Domain=General applies no scoping.
 
-### Phase 2: Domain-Scoped Parallel Investigation
+### Phase 3: Domain-Scoped Parallel Investigation
 
-Run in parallel:
+Run in parallel.
 
 | Tool                                               | Purpose                             | Domain Scoping                                                     |
 | -------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------ |
@@ -60,7 +66,7 @@ Run in parallel:
 | `Task(subagent_type: Explore)`                     | File / symbol / reference discovery | Pass Domain glob roots in the prompt                               |
 | Read / ugrep / bfs                                 | Targeted reads on identified files  | Use Domain glob roots as starting point                            |
 
-Domain glob roots:
+Use the following Domain glob roots.
 
 | Domain         | Suggested roots                                                 |
 | -------------- | --------------------------------------------------------------- |
@@ -73,7 +79,15 @@ For Feature planning intent, additionally invoke `Task(subagent_type: explorer-f
 
 State sources directly for all findings as they accumulate: file:line for facts, "inferred from X" for inferences, "unknown, requires X" for unverified claims.
 
-### Phase 3: Strong Inference (Bug investigation only)
+### Audit trail capture
+
+As Phase 3 searches run, append each command verbatim and its raw output to a scratch buffer in this conversation. Phase 6 Disconfirmation quotes from this scratch directly. Reconstruct nothing. The actual command and actual output is the audit trail.
+
+### Cross-method verification
+
+When a finding states "no caller" / "X is the only Y" / "X is the exhaustive list of Y" / "not used in [repo set]" and that claim drives downstream PR scope or crosses repo boundary, verify with at least 2 of: yomu search, ugrep / bfs, Task(Explore). If results disagree, flag the discrepancy and identify the tool error before recording. Single-tool zero result is suspect, not authoritative.
+
+### Phase 4: Strong Inference (Bug investigation only)
 
 Apply Debug Investigation Protocol from `rules/core/OPERATION.md`.
 
@@ -87,14 +101,26 @@ Apply Debug Investigation Protocol from `rules/core/OPERATION.md`.
 
 Skip when intent is Feature planning or Understanding.
 
-### Phase 4: Synthesis
+### Phase 5: Advisor Pre-Synthesis Check
 
-| Step                 | Action                                                                                                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Merge prior baseline | If Phase 0 found prior research, integrate inherited Findings/Constraints into Key Findings, marking re-verified or superseded                                                  |
-| Source pass          | Each finding states its basis: file:line / command output for facts, "inferred from X (source)" for inferences, "unknown, requires X" for gaps                                  |
-| Disconfirmation      | If Phase 3 was skipped, search for one piece of evidence contradicting the leading hypothesis. Record found / not found. If Phase 3 ran, write "Covered by Phase 3 elimination" |
-| Coverage check       | All Phase 1 questions answered, or noted as "unknown, requires X" with investigation method                                                                                     |
+Invoke `advisor()` with no parameters. Advisor sees full conversation history including Phase 2 answers, Phase 3 findings, and the audit trail scratch.
+
+Skip when all conditions hold.
+
+- Phase 1 hit prior research and current run inherits only
+- Intent = Understanding AND Domain = General
+- No claim crosses repo boundary or drives PR scope
+
+If advisor flags missed area or weak inference, return to Phase 3 for targeted scoping. Record skip reason in output if applicable.
+
+### Phase 6: Synthesis
+
+| Step                 | Action                                                                                                                                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Merge prior baseline | If Phase 1 found prior research, integrate inherited Findings/Constraints into Key Findings, marking re-verified or superseded                                                                                                 |
+| Source pass          | Each finding states its basis: file:line / command output for facts, "inferred from X (source)" for inferences, "unknown, requires X" for gaps                                                                                 |
+| Disconfirmation      | If Phase 4 was skipped, quote the command and raw output from the Phase 3 scratch verbatim (no reconstruction). Treat 0 hits as "tool may be misused" before "absence". If Phase 4 ran, write "Covered by Phase 4 elimination" |
+| Coverage check       | All Phase 2 questions answered, or noted as "unknown, requires X" with investigation method                                                                                                                                    |
 
 ## Error Handling
 
@@ -102,7 +128,7 @@ Skip when intent is Feature planning or Understanding.
 | ----------------------------- | --------------------------------------------------- |
 | Explore returns empty         | Re-run with broader keywords, note in findings      |
 | yomu search returns empty     | Suggest user run `yomu rebuild`, fall back to ugrep |
-| Intent unclear after Phase 1  | Stop, name the ambiguity, ask user                  |
+| Intent unclear after Phase 2  | Stop, name the ambiguity, ask user                  |
 | Domain glob roots all missing | Fall back to Domain=General scoping                 |
 
 ## Output
@@ -115,10 +141,14 @@ Template: ${CLAUDE_SKILL_DIR}/templates/research.md
 
 ## Verification
 
-| Check                                                              | Required |
-| ------------------------------------------------------------------ | -------- |
-| `Prior research` field filled (slug or `none found`)?              | Yes      |
-| All findings have explicit sources or "unknown, requires X" notes? | Yes      |
-| Disconfirmation recorded (if Phase 3 skipped)?                     | Yes      |
-| Output saved to `workspace/research/`?                             | Yes      |
-| Next Steps section in template included?                           | Yes      |
+| Check                                                                                  | Required     |
+| -------------------------------------------------------------------------------------- | ------------ |
+| OUTCOME.md present (Phase 0)?                                                          | Yes          |
+| `Prior research` field filled (slug or `none found`)?                                  | Yes          |
+| All findings have explicit sources or "unknown, requires X" notes?                     | Yes          |
+| Phase 3 audit trail scratch captured (command + raw output verbatim)?                  | Yes          |
+| Cross-method verification performed for "no caller" / "exhaustive enumeration" claims? | Yes (or N/A) |
+| Phase 5 advisor invoked or skip reason recorded?                                       | Yes          |
+| Disconfirmation recorded (if Phase 4 skipped)?                                         | Yes          |
+| Output saved to `workspace/research/`?                                                 | Yes          |
+| Next Steps section in template included?                                               | Yes          |

--- a/skills/think/SKILL.md
+++ b/skills/think/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: think
-description: Design exploration with SOW and Spec generation. Do NOT use for codebase investigation without planning intent (use /research instead).
+description: Design exploration with built-in adversarial challenge (Step 4: critic-design). Generates SOW and Spec from approaches that survive the challenge. Do NOT use for codebase investigation without planning intent (use /research instead).
 when_to_use: 計画して, 設計して, アプローチ検討, 方針決め, planning, design exploration
 allowed-tools: Read Write LS Task TaskCreate TaskList AskUserQuestion Bash(ugrep:*) Bash(bfs:*)
 model: opus
@@ -9,7 +9,7 @@ argument-hint: "[task description]"
 
 # /think
 
-Deep design exploration. Compare approaches, validate assumptions, generate SOW and Spec.
+Deep design exploration with adversarial challenge. Compare ≥2 approaches, run critic-design against them (Step 4), and let only the surviving approaches reach Spec. Approaches are positions to be argued, not options to be picked.
 
 ## Input
 
@@ -17,15 +17,17 @@ Task description from `$ARGUMENTS`, research context, or AskUserQuestion if empt
 
 ## Execution
 
-| Step | Action             | Detail                                                              |
-| ---- | ------------------ | ------------------------------------------------------------------- |
-| 0    | Why Discovery      | ${CLAUDE_SKILL_DIR}/references/step-0-why-discovery.md              |
-| 1    | Q&A Clarification  | Scope, Priority (MoSCoW), Constraints, Risks (if needed)            |
-| 2-5  | Design Exploration | ${CLAUDE_SKILL_DIR}/references/step-2-5-design-exploration.md       |
-| 6    | User Review        | Present design with trade-off rationale; wait for approval          |
-| 6.5  | ADR Proposal       | Ask if ADR needed for technical decisions. Skip for simple features |
-| 7-8  | SOW and Spec       | ${CLAUDE_SKILL_DIR}/references/step-7-8-document-generation.md      |
-| 9-10 | Review + Decompose | ${CLAUDE_SKILL_DIR}/references/step-9-10-review-decomposition.md    |
+| Step  | Action             | Detail                                                                            |
+| ----- | ------------------ | --------------------------------------------------------------------------------- |
+| 0     | Outcome Anchor     | Read `.claude/OUTCOME.md`; if absent, stub generation (see rules/core/OUTCOME.md) |
+| 1     | Why Discovery      | ${CLAUDE_SKILL_DIR}/references/step-1-why-discovery.md (assumes OUTCOME.md)       |
+| 2     | Q&A Clarification  | Scope, Priority (MoSCoW), Constraints, Risks (if needed)                          |
+| 3-6   | Design Exploration | ${CLAUDE_SKILL_DIR}/references/step-3-6-design-exploration.md                     |
+| 7     | User Review        | Present design with trade-off rationale; wait for approval                        |
+| 7.5   | ADR Proposal       | Ask if ADR needed for technical decisions. Skip for simple features               |
+| 8-9   | SOW and Spec       | ${CLAUDE_SKILL_DIR}/references/step-8-9-document-generation.md                    |
+| 10-11 | Review + Decompose | ${CLAUDE_SKILL_DIR}/references/step-10-11-review-decomposition.md                 |
+| 12    | View Generation    | Pass planning slug to `use-workflow-plan-preview`. Share returned URL with user   |
 
 ## Output
 
@@ -37,12 +39,14 @@ Always use this exact path. Write tool creates parent directories if absent.
 
 ## Verification
 
-- [ ] Why Statement established (Step 0)
-- [ ] Codebase explored (Step 2)
-- [ ] ≥2 approaches compared (Step 3)
-- [ ] DA challenge applied (Step 4)
-- [ ] Design composed (Step 5)
-- [ ] User reviewed (Step 6)
-- [ ] sow.md and spec.md generated (Steps 7-8)
-- [ ] Spec review passed (Step 9)
-- [ ] Tasks decomposed: milestones, first move, scope cut candidates (Step 10)
+- [ ] OUTCOME.md present (Step 0)
+- [ ] Why Statement established (Step 1)
+- [ ] Codebase explored (Step 3)
+- [ ] ≥2 approaches compared (Step 4)
+- [ ] DA challenge applied (Step 5)
+- [ ] Design composed (Step 6)
+- [ ] User reviewed (Step 7)
+- [ ] sow.md and spec.md generated (Steps 8-9)
+- [ ] Spec review passed (Step 10)
+- [ ] Tasks decomposed: milestones, first move, scope cut candidates (Step 11)
+- [ ] View generated and `http://localhost:4321/spec/<short-slug>` URL shared (Step 12)


### PR DESCRIPTION
## What & Why

explore skill が示す sqlite3 クエリ例を immutable=1 URI に修正する。`sqlite3 -readonly` は WAL モードの yomu index.db で error 14 (SQLITE_CANTOPEN) になり、Prerequisite の DB path 案内直後の全クエリ (caller lookup / import chain / FTS) が失敗する。

## Changes

- `skills/explore/SKILL.md:25` の Schema セクション、クエリ実行例を `sqlite3 -readonly <db_path> "<query>"` から `sqlite3 "file:<db_path>?immutable=1" "<query>"` に変更。immutable=1 は -wal/-shm への書き込み権限なしで読み取り専用オープンするため、WAL DB でも開ける

## Scope

- Not included: 他 skill/agent への横展開。`ugrep 'sqlite3 -readonly'` で確認済みで、同パターンは explore のみ

## Design Decisions

- issue #48 提案の immutable=1 URI を採用。`-readonly` は WAL の -wal/-shm 書き込みを要求して失敗するが、immutable=1 はそれを回避する。read-only の構造調査用途なので、DB 変更中の不整合読み込みリスクは許容範囲

## How to Test

1. WAL モードの DB に対し `sqlite3 "file:<project_root>/.yomu/index.db?immutable=1" ".tables"` を実行
2. テーブル一覧が取得でき、error 14 (SQLITE_CANTOPEN) が出ないことを確認（修正前の `-readonly` では失敗）

## Related

- Closes #48
