### PR TITLE
feat(issue,build): plan を issue 本文へ移し build を実行ループへ縮小

### DIFF
--- a/.ja/skills/issue/SKILL.md
+++ b/.ja/skills/issue/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: issue
-description: 構造化されたタイトルと本文で GitHub Issue を生成する。premise check と challenge で下書きの主張を投稿前に検証する。
-when_to_use: Issue作って, Issue書いて, Issue作成, GitHub Issue
-allowed-tools: Bash(gh:*) Bash(cat:*) Bash(ugrep:*) Read Task Skill AskUserQuestion
+description: 構造化されたタイトルと本文で GitHub Issue を生成する。人間と練る工程の受け皿で、premise check と challenge workflow の GO を exit gate として、build workflow に渡せる水準まで issue を練り上げる。
+when_to_use: Issue作って, Issue書いて, Issue作成, GitHub Issue, issueを練る, buildに渡す準備
+allowed-tools: Bash(gh:*) Bash(cat:*) Bash(ugrep:*) Bash(test:*) Read Task Skill Workflow AskUserQuestion
 model: opus
 argument-hint: "[issue description]"
 ---
 
 # /issue - GitHub Issue 生成
 
-構造化されたタイトルと本文で GitHub Issue を生成し、premise check と challenge で下書きの主張を投稿前に検証する。
+構造化されたタイトルと本文で GitHub Issue を生成し、premise check と challenge で下書きの主張を投稿前に検証する。「人間と練る」工程はここで完結させる。challenge workflow の GO 後は research / think workflow を通して `## Plan` 節を書き下ろし、build workflow が plan をそのまま抽出できる issue に仕上げる。
 
 ## 入力
 
@@ -22,16 +22,34 @@ argument-hint: "[issue description]"
 ## 実行
 
 1. `.claude/OUTCOME.md` を読む。不在なら `/outcome` で stub を生成
-2. 説明から種別を検出 (§ 種別判定)
-3. テンプレートを選ぶ (§ テンプレート選択)
-4. テンプレートに従いタイトルと本文を生成し、確定/仮をマーク (§ 確信度マーキング)
-5. epic 規模で分割すべきか判定 (§ 分割判定)
-6. 下書きした主張を前提チェックでフィルタ (§ 前提チェック)
-7. `${CLAUDE_SKILL_DIR}/references/prose-review.md` と、本文言語に対応する空句ファイル (日本語なら `${CLAUDE_SKILL_DIR}/references/phrases.ja.md`、英語なら `${CLAUDE_SKILL_DIR}/references/phrases.en.md`) の基準で本文をインライン精査
-8. `/challenge` で前提を検証 (GO / NO-GO)、feature / bug のみ (§ Adversarial Challenge)
-9. Issue プレビュー + 仮項目 → AskUserQuestion: "Create this issue?"
-10. 本文を一時ファイルに書き出し、ラベルを付けて `gh issue create --body-file` で起票し、出力から Issue URL を取得 (§ ラベル。sandbox 互換で長い本文のエスケープを回避)
-11. step 5 で分割を承認していれば、起票した issue を /slice に渡す (§ 分割判定)
+2. 説明から Why (誰が必要とし、どんな痛みがあり、何が成功か) が読み取れない場合、AskUserQuestion で壁打ちして詰める (§ Why 壁打ち)。feature / bug のみ
+3. 説明から種別を検出し (§ 種別判定)、skip 分岐に該当するか判定する (§ Skip 分岐)
+4. テンプレートを選ぶ (§ テンプレート選択)
+5. テンプレートに従いタイトルと本文を生成し、確定/仮をマーク (§ 確信度マーキング)
+6. epic 規模で分割すべきか判定 (§ 分割判定)
+7. 下書きした主張を前提チェックでフィルタ (§ 前提チェック)
+8. `${CLAUDE_SKILL_DIR}/references/prose-review.md` と、本文言語に対応する空句ファイル (日本語なら `${CLAUDE_SKILL_DIR}/references/phrases.ja.md`、英語なら `${CLAUDE_SKILL_DIR}/references/phrases.en.md`) の基準で本文をインライン精査。step 12 で Plan 節を追記した後は、Plan 節にも同じ基準を適用する
+9. challenge workflow で前提を検証 (GO / NO-GO)、feature / bug のみ。NO-GO なら壁打ちで本文を修正して再実行する (§ Adversarial Challenge)
+10. research workflow で実装前調査を実行する (§ Research)。skip 分岐該当時は step 10〜12 を飛ばす
+11. think workflow で構造化 plan を生成する (§ Think)
+12. 構造化 plan を `## Plan` 節として本文に書き下ろし、round-trip fidelity check と前提実在検証を通す (§ Plan 書き下ろし)
+13. Issue プレビュー + 仮項目 → AskUserQuestion: "Create this issue?"
+14. 本文を一時ファイルに書き出し、ラベルを付けて `gh issue create --body-file` で起票し、出力から Issue URL を取得 (§ ラベル。sandbox 互換で長い本文のエスケープを回避)
+15. step 6 で分割を承認していれば、起票した issue を /slice に渡す (§ 分割判定)
+
+## Why 壁打ち
+
+issue の Why を本文起草の前に確立する。docs / chore では省略する。次の 3 点が説明から読み取れるなら質問せず先へ進む。
+
+| 質問                               | 本文での置き場      |
+| ---------------------------------- | ------------------- |
+| 誰がこれを必要としている？         | What & Why          |
+| どんな痛みが存在する？その根拠は？ | What & Why          |
+| 計測可能な結果、成功とは何？       | Acceptance Criteria |
+
+- 1 メッセージにつき 1 質問し、仮説 (期待する答え) を推奨回答として添える。ユーザーは仮説を訂正するだけで済む
+- コードベースで解決できる疑問は、問う前に Read / ugrep で探索する
+- 次に問う質問の答えを予測できるようになったら理解は十分。質問をやめて起草に進む
 
 ## 種別判定
 
@@ -43,6 +61,16 @@ argument-hint: "[issue description]"
 | feature | 新しい能力や拡張要望                     |
 | docs    | ドキュメント追加や訂正                   |
 | chore   | メンテナンス、設定、依存更新             |
+
+## Skip 分岐
+
+docs / chore と軽微 bug は research / think / plan 書き下ろし (step 10〜12) を飛ばす。軽微 bug の該当例は typo 修正。非該当例は原因未特定の間欠 (intermittent) bug で、この場合は skip せず step 10〜12 を通常どおり通す。skip した issue は本文フッターに「軽微につき /fix で処理してもよい」と注記し、/fix への導線を示す。bug を軽微と判定するのは次の 3 基準を全て満たすときに限る。
+
+| 基準     | 内容                         |
+| -------- | ---------------------------- |
+| 変更範囲 | 1 ファイルに収まる           |
+| 再現     | 再現手順が確定している       |
+| 調査     | コードベースの横断調査が不要 |
 
 ## テンプレート選択
 
@@ -66,7 +94,7 @@ argument-hint: "[issue description]"
 
 ## 分割判定
 
-独立して実装可能な criteria が 2 つ以上あれば、AskUserQuestion で分割を問う。選択肢は「1 issue のまま」か「epic + 子 issue に分割」。1 つの成果物を検証するだけの細かいチェックは数えず、1 issue 内に留める。N 件の起票は取り消しにくいため自動分割はしない。承認時はこの issue を epic として起票し、前提チェック以降のフローはそのまま epic に通す。番号取得後、step 10 で `Skill("slice", "#<epic 番号>")` を実行する。
+独立して実装可能な criteria が 2 つ以上あれば、AskUserQuestion で分割を問う。選択肢は「1 issue のまま」か「epic + 子 issue に分割」。1 つの成果物を検証するだけの細かいチェックは数えず、1 issue 内に留める。N 件の起票は取り消しにくいため自動分割はしない。承認時はこの issue を epic として起票し、前提チェック以降のフローはそのまま epic に通す。番号取得後、step 15 で `Skill("slice", "#<epic 番号>")` を実行する。
 
 ## 前提チェック
 
@@ -83,12 +111,31 @@ argument-hint: "[issue description]"
 
 ## Adversarial Challenge
 
-feature または bug のときだけ `Skill("challenge", <下書きしたタイトル + 本文>)` を実行する (空なら省略)。返る verdict と findings は Issue 本文には決して入れず、プレビューの challenge ブロックに集約する。これは確定時のレビュー材料であり、反映するか却下するかの最終判断はユーザーに残す。
+feature または bug のときだけ `Workflow({name: "challenge", args: {task: <下書きしたタイトル + 本文>}})` を実行する (空なら省略)。build workflow が使うのと同じ検証 (premise → 2 攻撃 → verdict + script gate) をここで先に通すことで、GO の issue は build にそのまま渡せる状態になる。返る verdict と findings は Issue 本文には決して入れず、プレビューの challenge ブロックに集約する。
 
 | Verdict | 扱い                                                                                                  |
 | ------- | ----------------------------------------------------------------------------------------------------- |
 | GO      | プレビューへ進む。条件が併記されていれば一時的な批評として提示し、本文に折り込むものだけ 1 回反映する |
-| NO-GO   | 反証根拠をプレビューに提示し、起票継続 / 修正 / 取り下げをユーザーに委ねる                            |
+| NO-GO   | 壁打ちループへ (下記)                                                                                 |
+
+NO-GO の壁打ちループ。why と gate (script gate が降格した場合は rule と detail に残余の一覧が入る) を材料に、残余 1 件ごとに AskUserQuestion で仮説付きの決定を問い、回答を本文に反映して challenge workflow を再実行する。GO になるまで繰り返す (再実行は最大 3 回)。3 回で GO に達しない場合、または ユーザーが「このまま起票」を選んだ場合は、NO-GO の根拠をプレビューに提示し、起票継続 / 取り下げをユーザーに委ねる。gate を素通しする回避策 (残余を本文から消すだけの修正) はしない。残余は決定に変えるか、仮マークで本文に残す。
+
+## Research
+
+feature / bug で skip 分岐非該当のとき、`Workflow({name: "research", args: {question: <issue 本文から導いた調査質問>, repo: <対象リポジトリ>}})` を実行し、結果の要点を本文の根拠と think の入力に反映する。stopped: unresearchable が返ったら、missing の各項目を AskUserQuestion で仮説付きに壁打ちして解消し、回答を反映して再実行する。この壁打ちは最大 2 回。上限に達しても解消しない項目は仮マークで本文に残し、扱いをユーザーに委ねる。
+
+## Think
+
+research の結果を添えて `Workflow({name: "think", args: {task: <タイトル + 本文>, research: <research の要約>}})` を実行し、構造化 plan を得る。ready=false が返ったら、blockers の各項目を AskUserQuestion で仮説付きに問うて決着させ、再実行する。ready=false の決着は最大 2 回。上限に達しても ready にならない項目は仮マークで本文に残し、進め方をユーザーに委ねる。
+
+## Plan 書き下ろし
+
+think が返した構造化 plan を、`${CLAUDE_SKILL_DIR}/references/plan-section.md` の書式で本文の `## Plan` 節として自然言語に書き下ろす。機械用の隠し block は置かない。
+
+1. 書き下ろし。units / tests / 前提 / test_command を plan-section.md の骨格へ写す
+2. round-trip fidelity check。書いた Plan 節から plan-section.md の抽出 contract に従い構造を再抽出し、think plan と突合する。突合フィールドは unit id 集合 / depends_on / test id 集合 / test name / test_command。不一致があれば Plan 節を書き直す。書き直しは最大 2 回で、解消しなければ差分をユーザーに提示して判断を仰ぐ
+3. 前提実在検証。`### 前提` の各行を、path は `test -f <path>`、anchor は `ugrep -F '<pattern>' <path>` で検証し、失敗した行は修正するか落とす
+4. `## Backlog candidates` 節を追記する。plan がスコープ外へ切り出した候補を列挙し、無ければ「なし」と書く
 
 ## ラベル
 

--- a/.ja/skills/issue/references/plan-section.md
+++ b/.ja/skills/issue/references/plan-section.md
@@ -1,0 +1,92 @@
+# Plan 節フォーマット
+
+issue 本文の `## Plan` 節の書式と、build workflow (think 経由) がそこから構造化 plan を抽出する contract を定義する。issue SKILL.md と build.js の共有 source であり、書式の変更はこのファイルを更新してから両者に反映する。Plan 節は人間が読める markdown のみで構成し、機械用の隠し block は置かない。
+
+## Plan 節の構成
+
+| 要素               | 位置                    | 内容                                                                     |
+| ------------------ | ----------------------- | ------------------------------------------------------------------------ |
+| 導入 prose         | `## Plan` 直下          | outcome の 1 行 (done 状態、実装非依存、観測可能) + test_command の 1 行 |
+| 前提               | `### 前提`              | unit 群が依存する既存コードの箇条書き                                    |
+| unit 小節          | `### U-NNN` (連番)      | goal 言い切り + files + contract prose + 受け入れテスト + 依存           |
+| Backlog candidates | `## Backlog candidates` | 本 issue のスコープ外に切り出す候補の箇条書き。無ければ「なし」          |
+
+骨格の例。
+
+```markdown
+## Plan
+
+Outcome: <done 状態の 1 行>
+test_command: <テスト実行コマンド 1 行。例 cargo test / node --test tests/>
+
+### 前提
+
+- `src/storage/mod.rs` の `open_db`
+- `src/config.rs`
+
+### U-001 <unit タイトル>
+
+<goal の言い切り 1 行。この unit が届ける振る舞い>
+
+- files: `src/foo.rs`, `tests/foo.test.rs`
+- contract: <公開インターフェースの prose。signature / CLI flag / schema の素描>
+- depends_on: なし
+
+受け入れテスト。
+
+- T-001 <検証する仕様の言明。テスト名になる>
+  - given: <前提状態>
+  - when: <操作>
+  - then: <期待結果>
+
+## Backlog candidates
+
+- <スコープ外に切り出す候補>
+```
+
+### id 記法
+
+| id    | 対象               | 規則                                      |
+| ----- | ------------------ | ----------------------------------------- |
+| U-NNN | unit (`### U-NNN`) | 001 からの連番。plan 内で一意             |
+| T-NNN | 受け入れテスト     | plan 全体で一意 (unit ごとに振り直さない) |
+
+### 前提 (preconditions) の authoring 規則
+
+`### 前提` には次の 5 規則を適用する。
+
+1. 既存の依存先のみを載せる。unit が作る新規作成ファイルは前提に載せない
+2. anchor は stable anchor (exported / 公開シンボル名) に限る。private な実装詳細やコメント文字列を anchor にしない
+3. 安定したシンボルが無ければ path のみの行にする
+4. 各行は path 単独、または path + stable anchor の 2 形式のどちらか
+5. issue 投稿前に実在を検証する。path は `test -f <path>`、anchor は `ugrep -F '<pattern>' <path>` で確認し、失敗した行は修正するか落とす
+
+## 抽出 contract
+
+build workflow は Plan 節を読み、think workflow の PLAN_SCHEMA と同型の構造化 plan を組み立てる。Plan 節の各要素は次のフィールドに対応する。
+
+| Plan 節の要素                    | フィールド                          | 型              |
+| -------------------------------- | ----------------------------------- | --------------- |
+| planning dir (workflow が決める) | dir                                 | string          |
+| 導入 prose の outcome 行         | outcome                             | string          |
+| issue 本文の決定事項             | decisions                           | string[]        |
+| issue 本文の仮マーク・仮定       | assumptions                         | string[]        |
+| issue 本文の non-goal            | non_goals                           | string[]        |
+| issue 本文の制約                 | constraints                         | string[]        |
+| `### U-NNN` 小節の列             | units                               | object[]        |
+| U-NNN の id                      | units[].id                          | string          |
+| goal 言い切り行                  | units[].goal                        | string          |
+| files 箇条書き                   | units[].files                       | string[]        |
+| contract prose                   | units[].contract                    | string          |
+| 受け入れテストの列               | units[].tests                       | object[]        |
+| T-NNN の id                      | units[].tests[].id                  | string          |
+| テストの言明                     | units[].tests[].name                | string          |
+| given / when / then の各行       | units[].tests[].given / when / then | string          |
+| depends_on 行 (「なし」は空配列) | units[].depends_on                  | string[]        |
+| 導入 prose の test_command 行    | test_command                        | string          |
+| `### 前提` の各行                | preconditions                       | object[]        |
+| 前提行の path                    | preconditions[].path                | string          |
+| 前提行の stable anchor           | preconditions[].pattern             | string (省略可) |
+| `## Backlog candidates` の各行   | backlog_candidates                  | string[]        |
+
+preconditions と backlog_candidates は PLAN_SCHEMA (think.js) の必須フィールドではなく、Plan 節から build workflow が拾う追加情報。抽出は markdown の見出しと箇条書きの構造のみに依存し、特別なマーカーやコメント記法を要求しない。

--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -1,90 +1,218 @@
 export const meta = {
   name: "build",
   description:
-    "Autonomous end-to-end build. challenge / branch / research / think / code / audit / polish / ship run headless as deterministic script stages, so every machinery fan-out fires instead of being inlined. Review at the draft PR.",
+    "autonomous な end-to-end build。/issue で練られた Plan 節付き issue を入力に、Load (verbatim fetch -> 決定論 id 収集 -> extract -> validate + id cross-check) / Revalidate / Branch / Code / Audit / Polish / Backlog / Ship が決定論的 script stage として headless に走る。レビューは draft PR で行う。",
   whenToUse:
-    "Fire-and-forget implementation. You walk away and come back to a draft PR, where you review the logged assumptions and the audit result. Reach for this when the task is specified enough to advance residual choices on best-guess; when it needs live steering mid-flight, drive the phases interactively instead.",
+    'fire-and-forget の実装。人間と練る工程は /issue で完結させ、その issue 番号 ("123" / "#123") / URL / {issue, repo} を args で渡す。離席して戻ると draft PR があり、記録された assumption と audit 結果と backlog issue をレビューする。飛行中の操舵が要るなら対話で phase を回す。',
   phases: [
-    { title: "Challenge" },
+    { title: "Load" },
+    { title: "Revalidate" },
     { title: "Branch" },
-    { title: "Research" },
-    { title: "Think" },
     { title: "Code" },
     { title: "Audit" },
     { title: "Polish" },
+    { title: "Backlog" },
     { title: "Ship" },
   ],
 };
 
-// Autonomous build owns each phase's fan-out at the script level, because a
-// spawned agent cannot spawn its own sub-agents (nested spawn is blocked). The
-// interactive /build skill relies on that nesting (challenge -> critic-design,
-// audit -> reviewer swarm); here the script flattens it to one level, except
-// audit, which delegates to workflow("audit") so it keeps /audit's full routing
-// table (nesting a workflow is one level deep, which is allowed). Fidelity cuts
-// are deliberate and logged, not silent: code runs a single implementer rather
-// than /code's RGRC machinery, and interactive gates are replaced by best-guess
-// assumptions surfaced at the draft PR.
+// 上流の /issue が premise 検証と人間との refine を終えている前提で、build は plan の
+// 再発明をしない。issue 本文の ## Plan 節が唯一の計画ソースで、抽出は LLM に任せるが
+// 検証は script が持つ: Plan 見出し検査と U/T id 収集は決定論 regex、構造検証は
+// validate()、抽出の silent drop は id 集合の exact 比較で reject する。issue 起票から
+// build 起動までの間に前提コードが動いた可能性は Revalidate (preconditions の
+// exists/matches 検査) が fail-close で捕まえる。fan-out を内側に持つ stage は入れ子
+// workflow に委譲する (code / audit / polish。入れ子は 1 段まで許可)。
 
-const task = typeof args === "string" ? args : (args && args.task) || "";
-if (!task) {
-  return { stopped: "no-task", why: "Pass the implementation task as args (string or {task})." };
+phase("Load");
+
+const input = typeof args === "object" && args ? args : {};
+const issueRef = String(typeof args === "string" ? args : input.issue || "").trim();
+// "123" / "#123" / issue URL の末尾から issue 番号を決定論で取り出す。
+const issueNumber = (issueRef.match(/(\d+)\D*$/) || [])[1] || "";
+if (!issueRef || !issueNumber) {
+  return {
+    stopped: "no-issue",
+    why: 'issue を args で渡す ("123" / "#123" / URL / {issue, repo})。',
+  };
 }
 
-// Optional repo target. When set, the build runs against a repository other than
-// the session cwd. Every filesystem / git / build step must be anchored there;
-// relying on "subagents inherit the session cwd" is model-discretion and would
-// misfire when the build is launched from elsewhere. anchor() prepends an
-// absolute cd so the starting cwd is irrelevant rather than assumed. guard is a
-// deterministic backstop for the hard-to-reverse steps (branch, commit, push,
-// PR): confirm the repo root before mutating, since the run completes headless
-// with no chance to intervene mid-flight.
-const repo = typeof args === "object" && args && typeof args.repo === "string" ? args.repo : "";
+// repo 指定時は session cwd と無関係にその repository へ固定する。「subagent は session cwd を
+// 引き継ぐ」に頼るのは model 裁量で、別の場所から起動されると事故る。anchor() が絶対 cd を
+// 前置して開始 cwd を無関係にする。guard は取り返しの利きにくい step (branch / commit / push /
+// PR) の決定論的な backstop で、headless 完走中に介入の機会が無いぶん、git を変更する前に
+// repo root を確認させる。
+const repo = typeof input.repo === "string" ? input.repo : "";
 const anchor = (p) =>
   repo
-    ? `Run every git, file, and build command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`, which persists for that command's own follow-ups).\n\n${p}`
+    ? `git / ファイル / ビルドのコマンドはすべて ${repo} の repository から実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`
     : p;
 const guard = repo
-  ? ` Before this step's first commit, push, or branch mutation, run \`cd ${repo} && git rev-parse --show-toplevel\` and confirm it prints ${repo}; if it prints anything else, abort without mutating git and report the mismatch.`
+  ? ` この step で最初の commit / push / branch 変更を行う前に \`cd ${repo} && git rev-parse --show-toplevel\` を実行し、出力が ${repo} であることを確認する。異なる場合は git を変更せず中断し、不一致を報告する。`
   : "";
 
-const VERDICT_SCHEMA = {
+const FETCH_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["verdict", "why", "decisions", "assumptions"],
+  required: ["found", "body"],
   properties: {
-    verdict: { type: "string", enum: ["GO", "NO-GO"] },
-    why: { type: "string" },
-    decisions: { type: "array", items: { type: "string" } },
-    tradeoffs: { type: "array", items: { type: "string" } },
-    assumptions: {
-      type: "array",
-      items: { type: "string" },
-      description: "residual preferences advanced on best-guess; user veto targets at the PR",
-    },
+    found: { type: "boolean" },
+    body: { type: "string", description: "issue 本文の verbatim。要約・整形をしない" },
   },
 };
 
-const CRITIQUE_SCHEMA = {
+// think.js の PLAN_SCHEMA 相当 + preconditions + backlog_candidates。抽出は issue に
+// 書かれた plan の構造化であって再計画ではない。
+const EXTRACT_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["verdict", "weaknesses"],
-  properties: {
-    verdict: { type: "string" },
-    weaknesses: { type: "array", items: { type: "string" } },
-  },
-};
-
-const PLANNING_SCHEMA = {
-  type: "object",
-  additionalProperties: false,
-  required: ["dir", "summary"],
+  required: [
+    "dir",
+    "outcome",
+    "decisions",
+    "assumptions",
+    "units",
+    "test_command",
+    "preconditions",
+    "backlog_candidates",
+  ],
   properties: {
     dir: {
       type: "string",
-      description: "planning dir, e.g. .claude/workspace/planning/YYYY-MM-DD-slug",
+      description: "planning dir。例 .claude/workspace/planning/YYYY-MM-DD-slug",
     },
-    summary: { type: "string" },
+    outcome: { type: "string", description: "done 状態の 1 行記述 (実装非依存、観測可能)" },
+    decisions: { type: "array", items: { type: "string" } },
+    assumptions: {
+      type: "array",
+      items: { type: "string" },
+      description: "issue に記録された best-guess の残余。PR でのユーザー拒否対象",
+    },
+    non_goals: { type: "array", items: { type: "string" } },
+    constraints: { type: "array", items: { type: "string" } },
+    units: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "goal", "files", "contract", "tests", "depends_on"],
+        properties: {
+          id: { type: "string", description: "U-001 形式。issue 本文の id をそのまま使う" },
+          goal: { type: "string", description: "この unit が届ける振る舞いの 1 行記述" },
+          files: {
+            type: "array",
+            items: { type: "string" },
+            description: "作成・変更するファイルパス",
+          },
+          contract: {
+            type: "string",
+            description: "公開インターフェース。signature / CLI flag / schema の素描",
+          },
+          tests: {
+            type: "array",
+            items: {
+              type: "object",
+              additionalProperties: false,
+              required: ["id", "name", "given", "when", "then"],
+              properties: {
+                id: { type: "string", description: "T-001 形式 (plan 全体で一意)" },
+                name: { type: "string", description: "検証する仕様の言明。テスト名になる" },
+                given: { type: "string" },
+                when: { type: "string" },
+                // JSON Schema の property 定義であり thenable ではない (BDD の given/when/then)
+                // oxlint-disable-next-line unicorn/no-thenable
+                then: { type: "string" },
+              },
+            },
+          },
+          depends_on: {
+            type: "array",
+            items: { type: "string" },
+            description: "先行 unit の id。無ければ空配列",
+          },
+        },
+      },
+    },
+    test_command: { type: "string", description: "テスト実行コマンド。例 cargo test / bun test" },
+    preconditions: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["path"],
+        properties: {
+          path: { type: "string", description: "plan が前提とする既存ファイル" },
+          pattern: { type: "string", description: "そのファイルに存在するはずの symbol / 文字列" },
+        },
+      },
+      description: "issue の plan が前提とする既存コード。無ければ空配列",
+    },
+    backlog_candidates: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["summary"],
+        properties: {
+          summary: { type: "string" },
+        },
+      },
+      description: "issue に書かれた scope 外候補。無ければ空配列",
+    },
+  },
+};
+
+const REVALIDATE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["results"],
+  properties: {
+    results: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["path", "pattern", "exists", "matches"],
+        properties: {
+          path: { type: "string" },
+          pattern: { type: "string" },
+          exists: { type: "boolean" },
+          matches: { type: "boolean" },
+        },
+      },
+    },
+  },
+};
+
+const BACKLOG_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["posted", "deferred"],
+  properties: {
+    posted: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "url"],
+        properties: {
+          title: { type: "string" },
+          url: { type: "string" },
+        },
+      },
+    },
+    deferred: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "reason"],
+        properties: {
+          title: { type: "string" },
+          reason: { type: "string" },
+        },
+      },
+    },
   },
 };
 
@@ -99,150 +227,300 @@ const SHIP_SCHEMA = {
   },
 };
 
-// ---- Challenge: premise -> two critic-design attacks -> GO/NO-GO ----
-phase("Challenge");
-const premise = await agent(
-  anchor(`You are the premise-analysis stage of an autonomous build. Task: "${task}".\n`) +
-    `Read .claude/OUTCOME.md if present for the outcome axis. List the open questions in the task, sort each into fact (evidence settles it) or preference (needs a choice). Verify the facts against the codebase. Report a one-line approach summary, the architectural decisions that crystallised, the trade-offs, and the residual preferences you would otherwise ask the user (these become logged assumptions).\n` +
-    `Return that package as your final text.`,
-  { label: "premise", phase: "Challenge" },
-);
-const critiques = await parallel([
-  () =>
-    agent(
-      anchor(
-        `critic-design, internal attack. Attack this build premise on its own terms (hidden weaknesses, failure modes). Premise:\n${premise}`,
-      ),
-      { agentType: "critic-design", phase: "Challenge", schema: CRITIQUE_SCHEMA },
-    ),
-  () =>
-    agent(
-      anchor(
-        `critic-design, outcome attack. Read .claude/OUTCOME.md and attack whether this premise reaches the outcome (outcome fit, non-goal breach, constraint breach). Premise:\n${premise}`,
-      ),
-      { agentType: "critic-design", phase: "Challenge", schema: CRITIQUE_SCHEMA },
-    ),
-]);
-const verdict = await agent(
-  `Reconcile the premise and the two critic-design attacks into a single GO/NO-GO verdict for an autonomous build.\n` +
-    `Premise:\n${premise}\n\nInternal attack:\n${JSON.stringify(critiques[0])}\n\nOutcome attack:\n${JSON.stringify(critiques[1])}\n\n` +
-    `Rule NO-GO only when fact evidence overturns the core (targets a state that already holds, or a verified fact contradicts it). Otherwise GO, proceeding on the surviving part. List residual preferences as assumptions.`,
-  { label: "verdict", phase: "Challenge", schema: VERDICT_SCHEMA },
-);
-if (verdict.verdict === "NO-GO") {
-  return { stopped: "NO-GO", why: verdict.why, decisions: verdict.decisions };
-}
-log(`GO. ${verdict.assumptions.length} residual(s) advanced on best-guess (veto at the PR).`);
+// think.js の validate() 移植 + content 非空検査。構造 (id 重複 / 宙吊り / 循環 / テスト
+// 欠落) と内容 (contract / name / given / when / then の空) を決定論で reject する。
+const validate = (plan) => {
+  const errors = [];
+  const units = plan.units || [];
+  if (!units.length) errors.push("units が空。実装 unit を 1 件以上定義する");
+  const ids = new Set(units.map((u) => u.id));
+  if (ids.size !== units.length) errors.push("unit id が重複している");
+  const testIds = new Set();
+  for (const u of units) {
+    if (!u.tests.length) errors.push(`${u.id} に test scenario が無い`);
+    if (!u.files.length) errors.push(`${u.id} に対象ファイルが無い`);
+    if (!String(u.goal || "").trim()) errors.push(`${u.id} の goal が空`);
+    if (!String(u.contract || "").trim()) errors.push(`${u.id} の contract が空`);
+    for (const t of u.tests) {
+      if (testIds.has(t.id)) errors.push(`test id ${t.id} が重複している`);
+      testIds.add(t.id);
+      for (const field of ["name", "given", "when", "then"]) {
+        if (!String(t[field] || "").trim()) errors.push(`${t.id} の ${field} が空`);
+      }
+    }
+    for (const d of u.depends_on) {
+      if (!ids.has(d)) errors.push(`${u.id} の depends_on ${d} が存在しない unit を指す`);
+    }
+  }
+  // 循環検出 (DFS)
+  const state = new Map();
+  const visit = (id, path) => {
+    if (state.get(id) === "done") return;
+    if (state.get(id) === "visiting") {
+      errors.push(`depends_on が循環している: ${[...path, id].join(" -> ")}`);
+      return;
+    }
+    state.set(id, "visiting");
+    const u = units.find((x) => x.id === id);
+    for (const d of (u && u.depends_on) || []) visit(d, [...path, id]);
+    state.set(id, "done");
+  };
+  for (const u of units) visit(u.id, []);
+  return errors;
+};
 
-// ---- Branch ----
+// ---- Load: verbatim fetch -> Plan 見出し検査 -> 決定論 id 収集 -> extract -> validate + cross-check ----
+const fetched = await agent(
+  anchor(
+    `GitHub issue ${issueRef} の本文を取得する。gh CLI (例: gh issue view ${issueRef} --json body) を使い、body は要約・整形・省略を一切せず verbatim で返す。issue が見つからない・取得に失敗した場合は found: false を返す。`,
+  ),
+  { label: "fetch", phase: "Load", agentType: "general-purpose", schema: FETCH_SCHEMA },
+);
+if (!fetched || !fetched.found || !String(fetched.body || "").trim()) {
+  return {
+    stopped: "no-issue-body",
+    why: `issue ${issueRef} の本文を取得できなかった。issue 番号と repo を確認する。`,
+  };
+}
+const body = fetched.body;
+
+// Plan 見出し検査と id 収集は extract agent より前に script が決定論で行う。
+const planHeading = body.match(/^##\s+Plan\b.*$/m);
+if (!planHeading) {
+  return {
+    stopped: "no-plan",
+    why: "issue 本文に ## Plan 節が無い。/issue で plan を練ってから build を起動する。",
+  };
+}
+const afterHeading = body.slice(planHeading.index + planHeading[0].length);
+const nextSection = afterHeading.search(/^##[^#]/m);
+const planSection = nextSection === -1 ? afterHeading : afterHeading.slice(0, nextSection);
+const idSet = (re) => new Set([...planSection.matchAll(re)].map((m) => m[0]));
+const bodyUnitIds = idSet(/\bU-\d{3}\b/g);
+const bodyTestIds = idSet(/\bT-\d{3}\b/g);
+
+const plan = await agent(
+  anchor(
+    `次の GitHub issue 本文の ## Plan 節から構造化 plan を抽出する。再計画・要約・補完はせず、書かれている内容をそのまま構造化する。` +
+      `unit id (U-NNN) と test id (T-NNN) は本文のものを漏れなく保持する (欠落は後段の決定論 cross-check で reject される)。` +
+      `preconditions は plan が前提とする既存コードの {path, pattern} 一覧、backlog_candidates は issue に書かれた scope 外候補。本文に無ければ空配列。\n\n---\n${body}`,
+  ),
+  { label: "extract", phase: "Load", agentType: "general-purpose", schema: EXTRACT_SCHEMA },
+);
+if (!plan) {
+  return { stopped: "extraction-failed", why: "extract agent が plan を返さなかった。" };
+}
+
+const blockers = validate(plan);
+if (blockers.length) {
+  return { stopped: "invalid-plan", blockers, why: "抽出された plan が構造検証を通らない。" };
+}
+
+// 抽出での silent drop / 捏造を id 集合の exact 比較で reject する。
+const planUnitIds = new Set(plan.units.map((u) => u.id));
+const planTestIds = new Set(plan.units.flatMap((u) => u.tests.map((t) => t.id)));
+const setDiff = (a, b) => [...a].filter((x) => !b.has(x));
+const mismatch = {
+  units_missing: setDiff(bodyUnitIds, planUnitIds),
+  units_extra: setDiff(planUnitIds, bodyUnitIds),
+  tests_missing: setDiff(bodyTestIds, planTestIds),
+  tests_extra: setDiff(planTestIds, bodyTestIds),
+};
+if (Object.values(mismatch).some((l) => l.length)) {
+  return {
+    stopped: "extraction-mismatch",
+    detail: mismatch,
+    why: "issue 本文の U/T id 集合と抽出結果が一致しない。",
+  };
+}
+log(
+  `plan 抽出: unit ${plan.units.length} 件、test scenario ${planTestIds.size} 件、id cross-check pass。`,
+);
+
+// ---- Revalidate: preconditions を現在の codebase に対して再検証 (evidence + script gate) ----
+// issue 起票から build 起動までの間に前提コードが動いた可能性を fail-close で捕まえる。
+// miss の判定は agent の自己申告でなく script の filter が行う。
+phase("Revalidate");
+const preconditions = plan.preconditions || [];
+if (preconditions.length) {
+  const reval = await agent(
+    anchor(
+      `plan の preconditions を現在の codebase に対して再検証する。各 {path, pattern} について、path の存在 (exists) と pattern の grep 一致 (matches。pattern 無しなら exists と同値) を実際にコマンドで確認し、全 ${preconditions.length} 件を results で返す。判定を甘くしない。\n${JSON.stringify(preconditions)}`,
+    ),
+    {
+      label: "revalidate",
+      phase: "Revalidate",
+      agentType: "general-purpose",
+      schema: REVALIDATE_SCHEMA,
+    },
+  );
+  if (!reval || !Array.isArray(reval.results) || reval.results.length !== preconditions.length) {
+    return {
+      stopped: "revalidate-failed",
+      detail: reval,
+      why: "revalidate agent が全 preconditions の results を返さなかった。",
+    };
+  }
+  const drift = reval.results.filter((r) => !r.exists || !r.matches);
+  if (drift.length) {
+    return {
+      stopped: "plan-drift",
+      drift,
+      why: "issue の plan が前提とするコードが現在の codebase に無い。issue を更新してから再起動する。",
+    };
+  }
+  log(`revalidate: preconditions ${preconditions.length} 件 全 pass。`);
+}
+
+// ---- Branch: 作業 branch を checkout ----
 phase("Branch");
 const branch = await agent(
   anchor(
-    `Check out a new git working branch for: "${task}". Choose a conventional branch name (type then short slug) from the task and run git checkout -b with that name. If already off the default branch, keep the current branch. Report the branch name as your final text.${guard}`,
+    `issue #${issueNumber} "${plan.outcome}" のための新しい git 作業 branch を checkout する。conventional な branch 名 (type + 短い slug) を選び、その名前で git checkout -b を実行する。既に default branch 以外に居るなら現在の branch を維持する。branch 名を最終テキストで報告する。${guard}`,
   ),
   { label: "checkout", phase: "Branch", agentType: "general-purpose" },
 );
 
-// ---- Research (light; skips cleanly when there are no unknowns) ----
-phase("Research");
-const research = await parallel([
-  () =>
-    agent(
-      anchor(
-        `Explore the codebase for prior art, patterns, and constraints relevant to: "${task}". Report file:line anchors. medium breadth.`,
-      ),
-      { agentType: "Explore", phase: "Research", label: "explore:patterns" },
-    ),
-  () =>
-    agent(
-      anchor(
-        `Explore the codebase for integration points, existing helpers to reuse, and edge cases relevant to: "${task}". Report file:line anchors. medium breadth.`,
-      ),
-      { agentType: "Explore", phase: "Research", label: "explore:integration" },
-    ),
-]);
-const researchDigest = research.filter(Boolean).join("\n\n");
-
-// ---- Think: SOW/Spec -> critic-design ----
-phase("Think");
-const planning = await agent(
-  anchor(`Generate a SOW and Spec for an autonomous build of: "${task}".\n`) +
-    `Inputs. Challenge decisions: ${JSON.stringify(verdict.decisions)}. Trade-offs: ${JSON.stringify(verdict.tradeoffs || [])}. Assumptions (log these in the SOW Why): ${JSON.stringify(verdict.assumptions)}.\n` +
-    `Research:\n${researchDigest}\n\n` +
-    `Run \`date -u +%Y-%m-%d\` for the slug. Write .claude/workspace/planning/<date>-<slug>/sow.md (AC-N ids) and spec.md (FR-001 / T-001 / NFR-001 ids). Return the dir and a one-line summary.`,
-  { label: "plan", phase: "Think", agentType: "general-purpose", schema: PLANNING_SCHEMA },
-);
-await agent(
-  anchor(
-    `critic-design. Attack the SOW and Spec at ${planning.dir} for hidden weaknesses, unstated assumptions, and outcome drift. Report a verdict table and actionable items.`,
-  ),
-  { agentType: "critic-design", phase: "Think", label: "critic:spec" },
-);
-// ---- Code: single implementer (fidelity cut vs /code RGRC machinery) ----
+// ---- Code: workflow("code") に委譲 (unit ごとの Red -> Green + 独立 verify) ----
+// preconditions / backlog_candidates は build 側で消費済みなので、code へは
+// PLAN_SCHEMA 相当だけを渡す。
 phase("Code");
-log("Code phase runs a single implementer agent, not /code's full RGRC machinery.");
-await agent(
-  anchor(
-    `Implement the SOW and Spec at ${planning.dir}. Test-first (TDD): write failing tests from the T-NNN scenarios, implement to green, refactor. Run the project's lint / type-check / test gates and keep going until every AC is met and tests pass. Do not commit.`,
-  ),
-  { label: "implement", phase: "Code", agentType: "general-purpose" },
-);
+const stripPreconditions = (p) =>
+  Object.fromEntries(
+    Object.entries(p).filter(([k]) => k !== "preconditions" && k !== "backlog_candidates"),
+  );
+const code =
+  (await workflow("code", { plan: stripPreconditions(plan), repo, model: "sonnet" })) || null;
+if (!code || code.stopped) {
+  return { stopped: "code-failed", detail: code, planning: plan.dir };
+}
+if (!code.tests_pass || !code.gates_pass)
+  log(
+    `code の独立 verify が fail (tests=${code.tests_pass} gates=${code.gates_pass})。audit へ前進し PR に表面化する。`,
+  );
 
-// ---- Audit: delegate to the deterministic audit workflow (full routing) ----
-// workflow("audit") owns the fan-out: it ports /audit's glob routing table to
-// JS and fires every routed reviewer -> critic-audit -> critic-evidence ->
-// team-integration. Nesting a workflow is one level deep, which is allowed, so
-// build keeps /audit fidelity here instead of the old 6-reviewer cut. No scope
-// is passed, so audit routes the uncommitted diff (code has not committed yet),
-// which is the whole implementation.
+// ---- Audit ∥ Polish review -> fix -> re-audit loop (audit 実行は最大 3 回) ----
+// audit は workflow("audit") が fan-out を所有する (/audit の glob routing 表 + reviewer ->
+// challenge -> verify -> integrate)。scope を渡さないので uncommitted diff、つまり実装全体を
+// route する。code phase がテストを green にしているので preflight は省く。polish の review
+// mode は読み取りのみで、同じ diff に外部 Codex レンズを audit と並走できる。
 phase("Audit");
-const audit = (await workflow("audit", { repo })) || { findings: [] };
+const [audit0, review] = await parallel([
+  () => workflow("audit", { repo, skipPreflight: true }),
+  () => workflow("polish", { repo, mode: "review" }),
+]);
+let audit = audit0 || { findings: [] };
 log(
-  `Audit fired ${(audit.assignments || []).length} reviewer group(s), ${(audit.skipped || []).length} skipped.`,
+  `audit が ${(audit.assignments || []).length} reviewer group を発火、polish レンズは ${review && review.codex_available ? "有効" : "無効"}。`,
 );
-const blocking = (audit.findings || []).filter(
-  (f) => f.severity === "critical" || f.severity === "high",
-);
-if (blocking.length) {
-  log(`Fixing ${blocking.length} critical/high finding(s).`);
+const criticalHigh = (a) =>
+  (a.findings || []).filter((f) => f.severity === "critical" || f.severity === "high");
+const polishSurvivors = ((review && review.survivors) || []).map((f) => ({
+  severity: f.severity === "P1" ? "high" : "medium",
+  summary: `${f.title}: ${f.detail}`,
+  file: f.file || "",
+}));
+// fix -> re-audit を 0 critical/high まで回す。旧版は fix 1 回で re-audit なし、つまり fix の
+// 検証が無かった。最終 round の fix だけは re-audit 予算が尽きるため未検証のまま PR に
+// 表面化する。
+let toFix = [...criticalHigh(audit), ...polishSurvivors];
+let reaudited = true;
+for (let round = 1; round <= 3 && toFix.length; round++) {
+  log(`fix round ${round}: ${toFix.length} 件を修正。`);
   await agent(
     anchor(
-      `Fix these critical/high audit findings, then confirm tests still pass:\n${JSON.stringify(blocking)}`,
+      `これらの review findings を修正し、テストが通ることを確認する:\n${JSON.stringify(toFix)}`,
     ),
-    { agentType: "general-purpose", phase: "Audit", label: "fix" },
+    { agentType: "general-purpose", phase: "Audit", label: `fix:${round}` },
+  );
+  if (round === 3) {
+    reaudited = false;
+    log("fix round 上限。最終 round の fix は re-audit されず、PR に表面化する。");
+    break;
+  }
+  audit = (await workflow("audit", { repo, skipPreflight: true })) || { findings: [] };
+  toFix = criticalHigh(audit);
+}
+const residualBlocking = reaudited ? criticalHigh(audit) : [];
+
+// ---- Polish: cleanup のみ (simplify -> enhancer-code -> テスト検証) ----
+// review レンズは Audit phase で消化済みなので、ここは mutator だけを回す。
+phase("Polish");
+const cleanup = await workflow("polish", { repo, mode: "cleanup" });
+
+// ---- Backlog: scope 外の発見を issue 化する (ハイブリッド) ----
+// 候補源は issue 本文に書かれた scope 外候補 (source: issue) と build 中の発見。既存 issue と
+// 照合して新規と確信できるものだけ自動 post する。確信の持てない候補は PR body に回して
+// 人間が triage する。重複 issue の量産は自動化への信頼を下げるので、迷ったら deferred に倒す。
+phase("Backlog");
+const backlogCandidates = [
+  ...(plan.backlog_candidates || []).map((c) => ({ ...c, source: "issue" })),
+  ...(code.anomalies || []).map((a) => ({
+    source: "code",
+    summary: `${a.unit} で Red 未確認 (${a.kind}): ${a.notes}`,
+  })),
+  ...(audit.findings || [])
+    .filter((f) => f.severity === "medium" || f.severity === "low")
+    .map((f) => ({ source: "audit", summary: f.summary, file: f.file, severity: f.severity })),
+  ...((review && review.needs_context) || []).map((f) => ({
+    source: "polish",
+    summary: `${f.title}: ${f.why || f.detail}`,
+  })),
+];
+let backlog = { posted: [], deferred: [] };
+if (backlogCandidates.length) {
+  backlog = (await agent(
+    anchor(
+      `build 中に発見された scope 外の問題を GitHub issue 化する backlog stage。build 元 issue: #${issueNumber}。候補:\n${JSON.stringify(backlogCandidates)}\n` +
+        `各候補について次を行う。(1) issue に値するか判定する (actionable で、この build の scope 外で、些末でない。重複や言い換えは 1 件に統合する)。` +
+        `(2) gh CLI の issue 検索 (state open、候補のキーワード) で既存 issue との重複を照合する。\n` +
+        `新規と確信できるものだけ issue を立てる (上限 5 件)。label build-discovered を付け、repo に無ければ gh の label サブコマンドで先に用意する (色 BFD4F2、説明は「autonomous build が発見した scope 外の問題」。用意に失敗したら label なしで立てる)。issue 本文に出所 (source) と発見元の build 元 issue #${issueNumber} を記す。\n` +
+        `重複の疑いがある・判断に迷う候補は post せず deferred に回し、理由を書く。gh が使えない場合は全候補を deferred にする。`,
+    ),
+    { label: "backlog", phase: "Backlog", agentType: "general-purpose", schema: BACKLOG_SCHEMA },
+  )) || {
+    posted: [],
+    deferred: backlogCandidates.map((c) => ({
+      title: `[${c.source}] ${c.summary}`,
+      reason: "backlog agent が結果を返さなかった",
+    })),
+  };
+  log(
+    `backlog: issue ${backlog.posted.length} 件を post、${backlog.deferred.length} 件を PR body へ。`,
   );
 }
 
-// ---- Polish: external Codex + enhancer-code cleanup ----
-phase("Polish");
-await agent(
-  anchor(
-    `Run external Codex review on the uncommitted diff if the \`codex\` CLI is installed (a non-Claude lens against self-enhancement bias), apply its safe fixes, then run enhancer-code style cleanup (simplify, clarify). If codex is not installed, do cleanup only. If any fix breaks tests, revert that fix. Do not commit.`,
-  ),
-  { label: "polish", phase: "Polish", agentType: "general-purpose" },
-);
-
-// ---- Ship: commit + draft PR (outward-facing, so draft = reversible) ----
+// ---- Ship: commit + draft PR (外向きの操作なので draft = 可逆) ----
 phase("Ship");
-const shipPrompt = anchor(
-  `Commit all changes (planning artifacts + implementation) in one Conventional Commits commit. ` +
-    `Then push the branch and open a draft pull request using the gh CLI in draft mode. ` +
-    `The PR body must list the logged assumptions so the user can veto: ${JSON.stringify(verdict.assumptions)}. ` +
-    `Report committed status and the PR url.${guard}`,
+const ship = await agent(
+  anchor(
+    `全変更 (planning 成果物 + 実装) を 1 つの Conventional Commits commit にする。` +
+      `branch を push し、gh CLI で draft の pull request を開く。\n` +
+      `PR body には次を全て載せる。(1) 元 issue を閉じる参照 "Closes #${issueNumber}"。` +
+      `(2) plan に記録された assumption (ユーザーの拒否対象): ${JSON.stringify(plan.assumptions)}。` +
+      `(3) backlog で post した issue: ${JSON.stringify(backlog.posted)}。` +
+      `(4) 人間の triage 待ち backlog 候補: ${JSON.stringify(backlog.deferred)}。` +
+      `(5) 未解決の critical/high findings: ${JSON.stringify(residualBlocking)}${reaudited ? "" : " (最終 fix round は re-audit されていない旨を明記する)"}。` +
+      `(6) code の Red 未確認 anomaly: ${JSON.stringify(code.anomalies || [])}。` +
+      `(7) code の独立 verify 結果 (tests=${code.tests_pass} gates=${code.gates_pass})${code.tests_pass && code.gates_pass ? "" : `。fail の詳細: ${JSON.stringify(code.verify_output)}`}。\n` +
+      `committed 状態と PR url を報告する。${guard}`,
+  ),
+  { label: "ship", phase: "Ship", agentType: "general-purpose", schema: SHIP_SCHEMA },
 );
-const ship = await agent(shipPrompt, {
-  label: "ship",
-  phase: "Ship",
-  agentType: "general-purpose",
-  schema: SHIP_SCHEMA,
-});
 
 return {
-  verdict: verdict.verdict,
+  issue: issueNumber,
   branch,
-  planning: planning.dir,
+  planning: plan.dir,
+  units_completed: code.completed.length,
+  code_anomalies: (code.anomalies || []).length,
+  code_verified: code.tests_pass && code.gates_pass,
   audit_findings: (audit.findings || []).length,
-  assumptions: verdict.assumptions,
+  residual_blocking: residualBlocking.length,
+  polish_cleanup: cleanup && cleanup.cleanup ? cleanup.cleanup.tests_pass : null,
+  backlog_posted: backlog.posted,
+  backlog_deferred: backlog.deferred.length,
+  assumptions: plan.assumptions,
   pr_url: ship.pr_url,
   committed: ship.committed,
 };

--- a/.ja/workflows/code.js
+++ b/.ja/workflows/code.js
@@ -1,0 +1,217 @@
+export const meta = {
+  name: "code",
+  description:
+    'think workflow の構造化 plan を受け取り、unit ごとに Red -> Green を script 強制で回す TDD workflow。Red 未確認 (テストが最初から通る) は anomaly として記録され、最後に独立 agent が全 suite + lint + type-check を検証する。テスト後書きと Red 省略が構造的に起きない。単体でも、build から workflow("code") 経由の入れ子でも呼べる。',
+  whenToUse:
+    "headless に TDD 実装を回したいとき。args は {plan, repo, model}。plan は think workflow の返り値の plan (units / test_command を持つ)。model (任意) は Red / Green 実装 agent にのみ伝播する。",
+  phases: [{ title: "Implement" }, { title: "Verify" }],
+};
+
+// main loop 裁量の RGRC は「テストをまとめて後書き」「Red 確認を飛ばす」という省略が
+// 起きうる。この workflow は unit 単位の Red -> Green を script の loop が所有し、
+// Red の確認結果を schema で受け取って記録する。Green の自己申告は信用せず、最後に実装に
+// 関与していない独立 agent が全 suite を再実行する (reward hack 対策)。
+
+// args は object で届くことも、caller が stringify すると JSON 文字列で届くこともある。
+// 一度だけ正規化する。nested の workflow("code", {plan}) は object で届くのでその分岐を残す。
+const input = (() => {
+  if (typeof args === "object" && args) return args;
+  if (typeof args !== "string") return {};
+  const s = args.trim();
+  if (s.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(s);
+      if (parsed && typeof parsed === "object") return parsed;
+    } catch {
+      // malformed JSON: plan なしとして fail-close
+    }
+  }
+  return {};
+})();
+const plan = input.plan;
+if (!plan || !Array.isArray(plan.units) || !plan.units.length) {
+  return { stopped: "no-plan", why: "args.plan に think workflow の plan (units 必須) を渡す。" };
+}
+const repo = typeof input.repo === "string" ? input.repo : "";
+const anchor = (p) =>
+  repo
+    ? `git / ファイル / ビルドのコマンドはすべて ${repo} の repository から実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`
+    : p;
+
+const RED_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["red_confirmed", "test_files", "notes"],
+  properties: {
+    red_confirmed: {
+      type: "boolean",
+      description: "書いたテストを実行し、期待どおり fail することを確認できたら true",
+    },
+    test_files: { type: "array", items: { type: "string" } },
+    notes: {
+      type: "string",
+      description: "red_confirmed が false の場合はその理由 (既に振る舞いが存在する等)",
+    },
+  },
+};
+
+const GREEN_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["green", "notes"],
+  properties: {
+    green: { type: "boolean", description: "unit のテストが全て pass したら true" },
+    notes: { type: "string" },
+  },
+};
+
+const VERIFY_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["tests_pass", "gates_pass", "output_tail"],
+  properties: {
+    tests_pass: { type: "boolean" },
+    gates_pass: { type: "boolean", description: "lint / type-check が pass したら true" },
+    output_tail: { type: "string", description: "失敗時は失敗箇所の出力末尾" },
+  },
+};
+
+// 依存順に整列する (think の validate 済みだが、単体呼び出しの malformed plan に fail-close)。
+const units = [];
+const placed = new Set();
+let progressed = true;
+while (progressed && units.length < plan.units.length) {
+  progressed = false;
+  for (const u of plan.units) {
+    if (placed.has(u.id)) continue;
+    if ((u.depends_on || []).every((d) => placed.has(d))) {
+      units.push(u);
+      placed.add(u.id);
+      progressed = true;
+    }
+  }
+}
+if (units.length < plan.units.length) {
+  const stuck = plan.units.filter((u) => !placed.has(u.id)).map((u) => u.id);
+  return { stopped: "invalid-plan", why: `depends_on を解決できない unit: ${stuck.join(", ")}` };
+}
+
+const testCmd = plan.test_command || "";
+const completed = [];
+const anomalies = [];
+
+// ---- Implement: unit ごとに Red -> Green (working tree を共有するため直列) ----
+phase("Implement");
+for (const unit of units) {
+  const ctx =
+    `Unit ${unit.id}: ${unit.goal}\n対象ファイル: ${JSON.stringify(unit.files)}\n` +
+    `Contract: ${unit.contract}\nTest scenarios: ${JSON.stringify(unit.tests)}\n` +
+    `テスト実行: ${testCmd}\n` +
+    (completed.length ? `実装済み unit: ${completed.join(", ")}\n` : "");
+
+  // Red: テストを書き、fail を実行で確認する。実装は書かない。
+  let red = await agent(
+    anchor(
+      `TDD の Red step。${ctx}` +
+        `各 test scenario (T-NNN) を failing test として書く。テスト名は scenario の name をそのまま使う。` +
+        `実装コードは一切書かない。テストを実行し、期待どおり fail することを確認して報告する。` +
+        `テストが fail しない場合は実装せず、その理由を notes に書く。`,
+    ),
+    {
+      label: `red:${unit.id}`,
+      phase: `Unit ${unit.id}`,
+      agentType: "general-purpose",
+      schema: RED_SCHEMA,
+      ...(input.model ? { model: input.model } : {}),
+    },
+  );
+  if (red && !red.red_confirmed) {
+    // Red が確認できない = 振る舞いが既に存在するか、テストが空回りしている。1 回だけ精査させる。
+    red = await agent(
+      anchor(
+        `TDD の Red step 再試行。${ctx}` +
+          `前回テストが fail しなかった: ${red.notes}\n` +
+          `テストが対象の振る舞いを本当に検証しているか精査する (assertion が空でないか、対象コードを呼んでいるか)。` +
+          `振る舞いが未実装なら fail するはずである。精査後もテストが pass するなら、振る舞いは実装済みと judged し red_confirmed=false のまま理由を notes に書く。`,
+      ),
+      {
+        label: `red2:${unit.id}`,
+        phase: `Unit ${unit.id}`,
+        agentType: "general-purpose",
+        schema: RED_SCHEMA,
+        ...(input.model ? { model: input.model } : {}),
+      },
+    );
+  }
+  if (!red) return { stopped: "red-failed", unit: unit.id, completed, anomalies };
+  if (!red.red_confirmed) {
+    anomalies.push({ unit: unit.id, kind: "no-red", notes: red.notes });
+    log(`${unit.id}: Red 未確認 (${red.notes})。実装 step を skip して次の unit へ。`);
+    completed.push(unit.id);
+    continue;
+  }
+
+  // Green: テストが pass するまで実装し、その後 refactor する。テストは変更しない。
+  let green = await agent(
+    anchor(
+      `TDD の Green step。${ctx}` +
+        `テストファイル ${JSON.stringify(red.test_files)} の failing test を pass させる最小の実装を書く。` +
+        `テストの assertion を弱める・skip する・削除する変更は禁止 (テスト構造の修正が必要なら notes に書いて green=false で返す)。` +
+        `pass 後、テストを green に保ったまま refactor する。unit のテストを再実行して報告する。`,
+    ),
+    {
+      label: `green:${unit.id}`,
+      phase: `Unit ${unit.id}`,
+      agentType: "general-purpose",
+      schema: GREEN_SCHEMA,
+      ...(input.model ? { model: input.model } : {}),
+    },
+  );
+  if (green && !green.green) {
+    green = await agent(
+      anchor(
+        `TDD の Green step 再試行。${ctx}` +
+          `前回 pass しなかった: ${green.notes}\n原因を特定して実装を修正し、unit のテストを pass させる。テストの弱体化は禁止。`,
+      ),
+      {
+        label: `green2:${unit.id}`,
+        phase: `Unit ${unit.id}`,
+        agentType: "general-purpose",
+        schema: GREEN_SCHEMA,
+        ...(input.model ? { model: input.model } : {}),
+      },
+    );
+  }
+  if (!green || !green.green) {
+    return {
+      stopped: "unit-failed",
+      unit: unit.id,
+      why: (green && green.notes) || "green agent が結果を返さなかった",
+      completed,
+      anomalies,
+    };
+  }
+  completed.push(unit.id);
+  log(`${unit.id}: Red -> Green 完了 (${completed.length}/${units.length})。`);
+}
+
+// ---- Verify: 実装に関与していない独立 agent が全 suite + gate を再実行する ----
+phase("Verify");
+const verify = (await agent(
+  anchor(
+    `検証 stage。実装には関与していない。全テスト suite (${testCmd}) とプロジェクトの lint / type-check gate を実行し、結果をそのまま報告する。修正はしない。`,
+  ),
+  { label: "verify", phase: "Verify", agentType: "general-purpose", schema: VERIFY_SCHEMA },
+)) || { tests_pass: false, gates_pass: false, output_tail: "verify agent が結果を返さなかった" };
+
+log(
+  `code: ${completed.length}/${units.length} unit 完了、anomaly ${anomalies.length} 件、verify tests=${verify.tests_pass} gates=${verify.gates_pass}。`,
+);
+
+return {
+  completed,
+  anomalies,
+  tests_pass: verify.tests_pass,
+  gates_pass: verify.gates_pass,
+  verify_output: verify.output_tail,
+};

--- a/.ja/workflows/tests/build.behavior.test.mjs
+++ b/.ja/workflows/tests/build.behavior.test.mjs
@@ -1,0 +1,379 @@
+// U-004: build.js が Load (fetch -> 決定論 id 収集 -> extract -> validate + id cross-check) /
+// Revalidate / Branch / Code (sonnet) / Audit / Polish / Backlog (source: issue) / Ship の
+// 実行ループになることの行動検証。fail-close 分岐・phase 順・stopped 値 snapshot を自動検証する。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "./run-workflow.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const buildJs = join(here, "..", "build.js");
+
+// ---- fixtures ----
+
+// Plan 節付き issue body。unitIds / testIds は決定論 id 収集の対象になるリテラル。
+const bodyFor = (unitIds, testIds) =>
+  [
+    "Issue の背景説明。",
+    "",
+    "## Plan",
+    "",
+    ...unitIds.map((u) => `### ${u}: unit の見出し`),
+    ...testIds.map((t) => `- ${t}: test scenario`),
+    "",
+    "test_command: echo test",
+    "",
+  ].join("\n");
+
+// think.js validate() 相当 + content 非空検査を通る抽出済み plan。
+const makePlan = (overrides = {}) => ({
+  dir: ".claude/workspace/planning/2026-07-03-sample",
+  outcome: "sample outcome",
+  decisions: [],
+  assumptions: ["assumption-1"],
+  units: [
+    {
+      id: "U-001",
+      goal: "sample goal",
+      files: ["sample.js"],
+      contract: "sample contract",
+      tests: [
+        {
+          id: "T-001",
+          name: "sample spec statement",
+          given: "sample given",
+          when: "sample when",
+          // BDD の given/when/then フィールドであり thenable ではない
+          // oxlint-disable-next-line unicorn/no-thenable
+          then: "sample then",
+        },
+      ],
+      depends_on: [],
+    },
+  ],
+  test_command: "echo test",
+  preconditions: [{ path: "sample.js", pattern: "sampleSymbol" }],
+  backlog_candidates: [],
+  ...overrides,
+});
+
+// agent 呼び出しを schema の形で分類する。label 文字列への結合を避け、
+// FETCH_SCHEMA {found, body} / EXTRACT_SCHEMA (units + preconditions) /
+// REVALIDATE_SCHEMA {results} / BACKLOG {posted} / SHIP {pr_url} を判別する。
+const kindOf = (opts) => {
+  const p = (opts && opts.schema && opts.schema.properties) || null;
+  if (!p) return "plain";
+  if ("found" in p && "body" in p) return "fetch";
+  if ("units" in p) return "extract";
+  if ("results" in p) return "revalidate";
+  if ("posted" in p) return "backlog";
+  if ("pr_url" in p) return "ship";
+  return "plain";
+};
+
+// happy path stub 一式。overrides の kind ごとに差し替える。
+const makeStubs = ({
+  body,
+  plan,
+  revalidate,
+  agentOverrides = {},
+  workflowOverrides = {},
+} = {}) => ({
+  agent: (prompt, opts) => {
+    const kind = kindOf(opts);
+    if (kind in agentOverrides) return agentOverrides[kind](prompt, opts);
+    switch (kind) {
+      case "fetch":
+        return { found: true, body: body ?? bodyFor(["U-001"], ["T-001"]) };
+      case "extract":
+        return plan ?? makePlan();
+      case "revalidate":
+        return (
+          revalidate ?? {
+            results: [{ path: "sample.js", pattern: "sampleSymbol", exists: true, matches: true }],
+          }
+        );
+      case "backlog":
+        return { posted: [], deferred: [] };
+      case "ship":
+        return { committed: true, pr_url: "https://example.com/pr/1" };
+      default:
+        return "feat/sample-branch";
+    }
+  },
+  workflow: (name, wfArgs) => {
+    if (name in workflowOverrides) return workflowOverrides[name](wfArgs);
+    if (name === "code")
+      return { completed: ["U-001"], anomalies: [], tests_pass: true, gates_pass: true };
+    if (name === "audit") return { findings: [], assignments: [] };
+    if (name === "polish")
+      return {
+        codex_available: false,
+        survivors: [],
+        needs_context: [],
+        cleanup: { tests_pass: true },
+      };
+    return {};
+  },
+});
+
+const agentCallsOf = (calls, kind) => calls.agent.filter((c) => kindOf(c.opts) === kind);
+
+// ---- T-012 ----
+test("args 空は stopped: no-issue、Plan 節なし本文は stopped: no-plan で fail-close する", async () => {
+  const empty = await runWorkflow(buildJs, { args: {}, stubs: makeStubs() });
+  assert.equal(empty.result.stopped, "no-issue", "args 空で stopped: no-issue");
+  assert.equal(empty.calls.workflow.length, 0, "no-issue 後に入れ子 workflow が走らない");
+  assert.ok(
+    empty.calls.phase.every((p) => p === "Load"),
+    "no-issue 後に Load 以外の phase が走らない",
+  );
+
+  const noPlan = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ body: "Plan 見出しの無い issue 本文。\n\n## Context\n\n説明のみ。" }),
+  });
+  assert.equal(noPlan.result.stopped, "no-plan", "## Plan 見出し無しで stopped: no-plan");
+  assert.equal(noPlan.calls.workflow.length, 0, "no-plan 後に入れ子 workflow が走らない");
+  assert.equal(
+    agentCallsOf(noPlan.calls, "extract").length,
+    0,
+    "Plan 見出し検査は extract agent より前に走る (決定論)",
+  );
+});
+
+// ---- T-013 ----
+test("構造欠陥と content 空 (contract / given) はいずれも stopped: invalid-plan になる", async () => {
+  const variants = [
+    { plan: makePlan({ units: [] }), expect: /units/ },
+    {
+      plan: makePlan({
+        units: [{ ...makePlan().units[0], contract: "" }],
+      }),
+      expect: /contract/,
+    },
+    {
+      plan: makePlan({
+        units: [
+          {
+            ...makePlan().units[0],
+            tests: [{ ...makePlan().units[0].tests[0], given: "" }],
+          },
+        ],
+      }),
+      expect: /given/,
+    },
+  ];
+  for (const { plan, expect } of variants) {
+    const { result } = await runWorkflow(buildJs, {
+      args: { issue: "123" },
+      stubs: makeStubs({ plan }),
+    });
+    assert.equal(result.stopped, "invalid-plan", `variant ${expect} で stopped: invalid-plan`);
+    assert.ok(Array.isArray(result.blockers), "blockers が配列で返る");
+    assert.ok(
+      result.blockers.some((b) => expect.test(String(b))),
+      `blockers に ${expect} を含むエラー文言が載る`,
+    );
+  }
+});
+
+// ---- T-014 ----
+test("抽出での unit / test の silent drop は stopped: extraction-mismatch で決定論検出される", async () => {
+  const body = bodyFor(["U-001", "U-002"], ["T-001", "T-002", "T-003"]);
+  const base = makePlan().units[0];
+
+  // case A: unit U-002 を silent drop (test id は全部返す)
+  const unitDrop = makePlan({
+    units: [
+      {
+        ...base,
+        tests: [
+          { ...base.tests[0], id: "T-001" },
+          { ...base.tests[0], id: "T-002" },
+          { ...base.tests[0], id: "T-003" },
+        ],
+      },
+    ],
+  });
+  const a = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ body, plan: unitDrop }),
+  });
+  assert.equal(
+    a.result.stopped,
+    "extraction-mismatch",
+    "unit drop で stopped: extraction-mismatch",
+  );
+  assert.ok(
+    JSON.stringify(a.result.detail).includes("U-002"),
+    "不一致 unit id U-002 が detail に載る",
+  );
+
+  // case B: test id T-003 を 1 件 silent drop (unit id は全部返す)
+  const testDrop = makePlan({
+    units: [
+      { ...base, tests: [{ ...base.tests[0], id: "T-001" }] },
+      {
+        ...base,
+        id: "U-002",
+        tests: [{ ...base.tests[0], id: "T-002" }],
+      },
+    ],
+  });
+  const b = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ body, plan: testDrop }),
+  });
+  assert.equal(
+    b.result.stopped,
+    "extraction-mismatch",
+    "test drop で stopped: extraction-mismatch",
+  );
+  assert.ok(
+    JSON.stringify(b.result.detail).includes("T-003"),
+    "不一致 test id T-003 が detail に載る",
+  );
+});
+
+// ---- T-015 ----
+test("Revalidate は 1 miss で stopped: plan-drift、全 pass で Branch へ進み、preconditions 空なら agent を呼ばない", async () => {
+  // miss case: exists: false を 1 件含む
+  const driftPlan = makePlan({
+    preconditions: [
+      { path: "sample.js", pattern: "sampleSymbol" },
+      { path: "missing.js", pattern: "goneSymbol" },
+    ],
+  });
+  const miss = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({
+      plan: driftPlan,
+      revalidate: {
+        results: [
+          { path: "sample.js", pattern: "sampleSymbol", exists: true, matches: true },
+          { path: "missing.js", pattern: "goneSymbol", exists: false, matches: false },
+        ],
+      },
+    }),
+  });
+  assert.equal(miss.result.stopped, "plan-drift", "1 miss で stopped: plan-drift");
+  assert.ok(
+    JSON.stringify(miss.result).includes("missing.js"),
+    "drift 一覧に miss した path が載る",
+  );
+  assert.ok(!miss.calls.phase.includes("Branch"), "plan-drift 後に Branch へ進まない");
+
+  // all-pass case: Branch phase に到達する
+  const pass = await runWorkflow(buildJs, { args: { issue: "123" }, stubs: makeStubs() });
+  assert.ok(pass.calls.phase.includes("Branch"), "全 pass で Branch phase に到達する");
+
+  // 空 case: revalidate agent が呼ばれず Branch に到達する
+  const empty = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ plan: makePlan({ preconditions: [] }) }),
+  });
+  assert.equal(
+    agentCallsOf(empty.calls, "revalidate").length,
+    0,
+    "preconditions 空で revalidate agent が呼ばれない",
+  );
+  assert.ok(empty.calls.phase.includes("Branch"), "preconditions 空でも Branch phase に到達する");
+});
+
+// ---- T-016 ----
+test("happy path の phase 順が Load → Revalidate → Branch → Code → Audit → Polish → Backlog → Ship で、code に model: sonnet が渡り challenge / think / research が呼ばれない", async () => {
+  const { calls } = await runWorkflow(buildJs, { args: { issue: "123" }, stubs: makeStubs() });
+
+  assert.deepEqual(
+    calls.phase,
+    ["Load", "Revalidate", "Branch", "Code", "Audit", "Polish", "Backlog", "Ship"],
+    "phase 順が Load → Revalidate → Branch → Code → Audit → Polish → Backlog → Ship",
+  );
+
+  const codeCalls = calls.workflow.filter((c) => c.name === "code");
+  assert.equal(codeCalls.length, 1, "workflow('code') が 1 回呼ばれる");
+  assert.equal(codeCalls[0].args.model, "sonnet", "code に model: sonnet が渡る");
+  assert.ok(
+    !("preconditions" in codeCalls[0].args.plan),
+    "code へ渡す plan から preconditions が strip される",
+  );
+
+  const names = new Set(calls.workflow.map((c) => c.name));
+  assert.deepEqual(
+    [...names].sort(),
+    ["audit", "code", "polish"],
+    "workflow capture に code / audit / polish のみが現れる",
+  );
+  for (const banned of ["challenge", "think", "research"]) {
+    assert.ok(!names.has(banned), `workflow('${banned}') が呼ばれない`);
+  }
+});
+
+// ---- T-017 ----
+test("stopped 値集合の snapshot が 9 値と exact match し Explore agent が残っていない", () => {
+  const source = readFileSync(buildJs, "utf8");
+  const stopped = new Set();
+  for (const m of source.matchAll(/stopped:\s*"([^"]+)"/g)) stopped.add(m[1]);
+  assert.deepEqual(
+    [...stopped].sort(),
+    [
+      "code-failed",
+      "extraction-failed",
+      "extraction-mismatch",
+      "invalid-plan",
+      "no-issue",
+      "no-issue-body",
+      "no-plan",
+      "plan-drift",
+      "revalidate-failed",
+    ],
+    "stopped リテラル集合が 9 値と exact match する",
+  );
+  const explore = source.match(/agentType:\s*"Explore"/g) || [];
+  assert.equal(explore.length, 0, 'agentType: "Explore" が 0 件');
+});
+
+// ---- T-018 ----
+test("Backlog 候補源が source: issue に復帰し challenge / think / plan-gate 由来が消えている", async () => {
+  const plan = makePlan({
+    backlog_candidates: [{ summary: "issue 由来の scope 外候補" }],
+  });
+  const { calls } = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ plan }),
+  });
+
+  const backlogCalls = agentCallsOf(calls, "backlog");
+  assert.equal(backlogCalls.length, 1, "backlog agent が 1 回呼ばれる");
+  assert.match(
+    backlogCalls[0].prompt,
+    /source['"]?\s*:\s*['"]?issue/,
+    "backlog prompt に source: issue の候補が含まれる",
+  );
+  assert.ok(
+    backlogCalls[0].prompt.includes("issue 由来の scope 外候補"),
+    "backlog prompt に extract 由来の候補 summary が含まれる",
+  );
+
+  const source = readFileSync(buildJs, "utf8");
+  for (const banned of ["challenge", "think", "plan-gate"]) {
+    const hits = source.match(new RegExp(`source:\\s*"${banned}"`, "g")) || [];
+    assert.equal(hits.length, 0, `source: "${banned}" が build.js に 0 件`);
+  }
+});
+
+// ---- T-019 (manual acceptance、done 前必須) ----
+test("実環境で Plan 節付き issue が Load → Revalidate → Branch → Code と進み、Plan 節なし issue が stopped: no-plan を返す (manual acceptance、done 前必須)", () => {
+  // harness green だけで完了にしないための manual gate。実際に build workflow を
+  // Plan 節付き / Plan 節なしの実 issue で起動し、前者の phase log が
+  // Load → Revalidate → Branch → Code の順に出て後者が stopped: no-plan を返すことを
+  // 確認したら U004_MANUAL_ACCEPTANCE=pass を付けてテストを実行する。
+  assert.equal(
+    process.env.U004_MANUAL_ACCEPTANCE,
+    "pass",
+    "manual acceptance 未実施。実 issue で build workflow を起動して確認後、U004_MANUAL_ACCEPTANCE=pass で再実行する",
+  );
+});

--- a/.ja/workflows/tests/code.model.test.mjs
+++ b/.ja/workflows/tests/code.model.test.mjs
@@ -1,0 +1,94 @@
+// U-003: code.js が任意 input.model を Red / Green 実装 agent にのみ伝播することの行動検証。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "./run-workflow.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "..", "..", "..");
+const codeJs = join(here, "..", "code.js");
+
+const plan = {
+  test_command: "echo test",
+  units: [
+    {
+      id: "U-1",
+      goal: "sample goal",
+      files: ["sample.js"],
+      contract: "sample contract",
+      depends_on: [],
+      tests: [],
+    },
+  ],
+};
+
+// red / green は 1 回目に失敗を返して retry (red2 / green2) を発火させ、
+// 4 呼び出し (red, red2, green, green2) すべてを capture させる stub。
+const retryingAgentStub = (prompt, opts) => {
+  const label = opts.label ?? "";
+  if (label.startsWith("red2:"))
+    return { red_confirmed: true, test_files: ["t.test.js"], notes: "" };
+  if (label.startsWith("red:"))
+    return { red_confirmed: false, test_files: [], notes: "passed unexpectedly" };
+  if (label.startsWith("green2:")) return { green: true, notes: "" };
+  if (label.startsWith("green:")) return { green: false, notes: "still failing" };
+  if (label === "verify") return { tests_pass: true, gates_pass: true, output_tail: "" };
+  throw new Error(`unexpected label: ${label}`);
+};
+
+// red / green とも 1 回目で成功する stub。
+const happyAgentStub = (prompt, opts) => {
+  const label = opts.label ?? "";
+  if (label.startsWith("red:"))
+    return { red_confirmed: true, test_files: ["t.test.js"], notes: "" };
+  if (label.startsWith("green:")) return { green: true, notes: "" };
+  if (label === "verify") return { tests_pass: true, gates_pass: true, output_tail: "" };
+  throw new Error(`unexpected label: ${label}`);
+};
+
+test("model 指定時に Red / Green とその retry の 4 呼び出しへ伝播し Verify へは渡らない", async () => {
+  const { calls } = await runWorkflow(codeJs, {
+    args: { plan, repo: "", model: "sonnet" },
+    stubs: { agent: retryingAgentStub },
+  });
+
+  const redGreen = calls.agent.filter((c) => /^(red|red2|green|green2):/.test(c.opts.label));
+  assert.equal(redGreen.length, 4, "red / red2 / green / green2 の 4 呼び出しがある");
+  for (const call of redGreen) {
+    assert.equal(call.opts.model, "sonnet", `${call.opts.label} の opts に model: "sonnet" がある`);
+  }
+
+  const verify = calls.agent.find((c) => c.opts.label === "verify");
+  assert.ok(verify, "verify 呼び出しがある");
+  assert.ok(!("model" in verify.opts), "verify の opts に model キーが無い");
+});
+
+test("model 未指定で agent opts に model キーが存在せず既存呼び出し形が完走する", async () => {
+  const { result, calls } = await runWorkflow(codeJs, {
+    args: { plan, repo: "" },
+    stubs: { agent: happyAgentStub },
+  });
+
+  for (const call of calls.agent) {
+    assert.ok(!("model" in call.opts), `${call.opts.label} の opts に model キーが無い`);
+  }
+  assert.deepEqual(result.completed, ["U-1"], "completed に unit id が入る");
+  assert.equal(result.tests_pass, true, "verify の tests_pass がそのまま返る");
+});
+
+test("静的 gate が JA / EN の code.js と tests/*.mjs で pass する", () => {
+  const targets = [
+    join(root, ".ja", "workflows", "code.js"),
+    join(root, "workflows", "code.js"),
+    join(root, ".ja", "workflows", "tests", "run-workflow.mjs"),
+    join(root, "workflows", "tests", "run-workflow.mjs"),
+    join(root, ".ja", "workflows", "tests", "code.model.test.mjs"),
+    join(root, "workflows", "tests", "code.model.test.mjs"),
+  ];
+  for (const file of targets) {
+    execFileSync("node", ["--check", file], { cwd: root });
+  }
+  execFileSync("npx", ["oxlint", ...targets], { cwd: root });
+});

--- a/.ja/workflows/tests/index.js
+++ b/.ja/workflows/tests/index.js
@@ -1,0 +1,12 @@
+// Node v26 は `node --test <dir>` でディレクトリを走査せず entry module として spawn する。
+// この index がディレクトリ解決の入口になり、配下の全 *.test.js / *.test.mjs を読み込む。
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+for (const name of readdirSync(here)
+  .filter((f) => f.endsWith(".test.js") || f.endsWith(".test.mjs"))
+  .sort()) {
+  await import(pathToFileURL(join(here, name)).href);
+}

--- a/.ja/workflows/tests/issue-skill.test.js
+++ b/.ja/workflows/tests/issue-skill.test.js
@@ -1,0 +1,103 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const targets = {
+  ja: join(root, ".ja", "skills", "issue", "SKILL.md"),
+  en: join(root, "skills", "issue", "SKILL.md"),
+};
+const planSectionRefs = {
+  ja: join(root, ".ja", "skills", "issue", "references", "plan-section.md"),
+  en: join(root, "skills", "issue", "references", "plan-section.md"),
+};
+
+function read(path) {
+  assert.ok(existsSync(path), `${path} が存在する`);
+  return readFileSync(path, "utf8");
+}
+
+function executionSection(doc, heading) {
+  const start = doc.indexOf(`\n${heading}\n`);
+  assert.ok(start >= 0, `${heading} 節がある`);
+  const rest = doc.slice(start + heading.length + 2);
+  const end = rest.indexOf("\n## ");
+  return end >= 0 ? rest.slice(0, end) : rest;
+}
+
+function countSteps(section) {
+  return section.split("\n").filter((line) => /^\d+\.\s/.test(line)).length;
+}
+
+test("フロー順が challenge → research → think → plan 書き下ろし → preview → 起票 の順である", () => {
+  const exec = executionSection(read(targets.ja), "## 実行");
+  const order = ["challenge", "research", "think", "書き下ろし", "プレビュー", "起票"];
+  const indexes = order.map((keyword) => exec.indexOf(keyword));
+  order.forEach((keyword, i) => {
+    assert.ok(indexes[i] >= 0, `実行リストに ${keyword} がある`);
+  });
+  for (let i = 1; i < order.length; i++) {
+    assert.ok(indexes[i - 1] < indexes[i], `${order[i - 1]} が ${order[i]} より先に現れる`);
+  }
+});
+
+test("research / think のループ上限 2 回と上限到達時の扱いが明記されている", () => {
+  const ja = read(targets.ja);
+  assert.match(ja, /unresearchable[\s\S]{0,160}最大 2 回/, "ja: unresearchable 壁打ち最大 2 回");
+  assert.match(ja, /ready\s*=\s*false[\s\S]{0,160}最大 2 回/, "ja: ready=false 決着最大 2 回");
+  assert.match(ja, /仮マーク[^。]{0,20}残/, "ja: 上限到達時の仮マーク残置");
+  assert.match(ja, /ユーザー[^。]{0,20}委ね/, "ja: 上限到達時のユーザー委任");
+});
+
+test("skip 分岐が基準・該当例・非該当例・/fix フッター注記付きで定義されている", () => {
+  const ja = read(targets.ja);
+  assert.match(
+    ja,
+    /docs[\s\S]{0,60}chore[\s\S]{0,200}(飛ばす|飛ばし|スキップ)/,
+    "ja: docs / chore スキップ",
+  );
+  assert.match(
+    ja,
+    /research[^。]{0,20}think[^。]{0,60}(飛ばす|飛ばし|スキップ)/,
+    "ja: research / think を飛ばす",
+  );
+  assert.match(ja, /1 ファイル/, "ja: 軽微 bug 基準 1 ファイル");
+  assert.match(ja, /再現[^。]{0,10}確定/, "ja: 軽微 bug 基準 再現確定");
+  assert.match(ja, /横断調査[^。]{0,10}不要/, "ja: 軽微 bug 基準 横断調査不要");
+  assert.match(ja, /typo/, "ja: 該当例 typo 修正");
+  assert.match(ja, /(intermittent|間欠)/, "ja: 非該当例 intermittent bug");
+  assert.match(ja, /原因未特定/, "ja: 非該当例 原因未特定");
+  assert.match(ja, /\/fix で処理/, "ja: /fix で処理 注記");
+  assert.match(ja, /フッター/, "ja: フッター注記");
+});
+
+test("round-trip fidelity check が突合フィールドと書き直し上限付きで手順化されている", () => {
+  const ja = read(targets.ja);
+  assert.match(ja, /突合/, "ja: think plan との突合");
+  assert.match(ja, /unit id/, "ja: 突合フィールド unit id 集合");
+  assert.match(ja, /depends_on/, "ja: 突合フィールド depends_on");
+  assert.match(ja, /test id/, "ja: 突合フィールド test id 集合");
+  assert.match(ja, /(test name|テスト名)/, "ja: 突合フィールド test name");
+  assert.match(ja, /test_command/, "ja: 突合フィールド test_command");
+  assert.match(
+    ja,
+    /(書き直し[^。]{0,40}最大 2 回|最大 2 回[^。]{0,40}書き直)/,
+    "ja: 不一致時の書き直し最大 2 回",
+  );
+  assert.match(ja, /ユーザーに提示/, "ja: 解消しなければユーザーに提示");
+});
+
+test("EN ミラーが JA と構造 parity を保つ", () => {
+  const jaSteps = countSteps(executionSection(read(targets.ja), "## 実行"));
+  const enSteps = countSteps(executionSection(read(targets.en), "## Execution"));
+  assert.equal(jaSteps, 15, "ja: 実行 step が 15");
+  assert.equal(enSteps, jaSteps, "en: 実行 step 数が JA と同数");
+  const en = read(targets.en);
+  assert.match(en, /Plan/, "en: Plan 節への言及");
+  assert.match(en, /Backlog candidates/, "en: Backlog candidates 節への言及");
+  assert.match(en, /plan-section\.md/, "en: plan-section.md 参照");
+  assert.ok(existsSync(planSectionRefs.ja), "ja: references/plan-section.md が存在");
+  assert.ok(existsSync(planSectionRefs.en), "en: references/plan-section.md が存在");
+});

--- a/.ja/workflows/tests/plan-section.test.js
+++ b/.ja/workflows/tests/plan-section.test.js
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const targets = {
+  ja: join(root, ".ja", "skills", "issue", "references", "plan-section.md"),
+  en: join(root, "skills", "issue", "references", "plan-section.md"),
+};
+
+function read(path) {
+  assert.ok(existsSync(path), `${path} が存在する`);
+  return readFileSync(path, "utf8");
+}
+
+test("plan-section.md が Plan 節の構成 (id 記法・前提小節・受け入れテスト・test_command・Backlog candidates) を定義している", () => {
+  for (const [lang, path] of Object.entries(targets)) {
+    const doc = read(path);
+    assert.match(doc, /### U-/, `${lang}: ### U- 記法`);
+    assert.match(doc, /T-NNN/, `${lang}: T-NNN 記法`);
+    if (lang === "ja") {
+      assert.match(doc, /^### 前提/m, "ja: 前提小節");
+    } else {
+      assert.match(doc, /^### Preconditions/m, "en: Preconditions 小節");
+    }
+    assert.match(doc, /given/i, `${lang}: given`);
+    assert.match(doc, /when/i, `${lang}: when`);
+    assert.match(doc, /then/i, `${lang}: then`);
+    assert.match(doc, /test_command/, `${lang}: test_command の置き場`);
+    assert.match(doc, /^## Backlog candidates/m, `${lang}: ## Backlog candidates`);
+  }
+});
+
+test("precondition の authoring 規則が stable anchor と投稿前実在検証を含む", () => {
+  const ja = read(targets.ja);
+  assert.match(ja, /既存.{0,10}依存先のみ/, "ja: 既存依存先のみ");
+  assert.match(ja, /新規作成ファイル.{0,20}載せない/, "ja: 新規作成ファイルは載せない");
+  assert.match(ja, /stable anchor/, "ja: stable anchor");
+  assert.match(ja, /(exported|公開シンボル)/, "ja: exported / 公開シンボル名");
+  assert.match(
+    ja,
+    /安定.{0,10}シンボルが無ければ.{0,10}path のみ/,
+    "ja: 安定シンボルが無ければ path のみ",
+  );
+  assert.match(ja, /test -f/, "ja: test -f 実在検証");
+  assert.match(ja, /ugrep -F/, "ja: ugrep -F 実在検証");
+
+  const en = read(targets.en);
+  assert.match(en, /existing dependenc/i, "en: existing dependencies only");
+  assert.match(en, /newly created/i, "en: do not list newly created files");
+  assert.match(en, /stable anchor/i, "en: stable anchor");
+  assert.match(en, /exported/i, "en: exported / public symbol");
+  assert.match(en, /path only/i, "en: path only fallback");
+  assert.match(en, /test -f/, "en: test -f existence check");
+  assert.match(en, /ugrep -F/, "en: ugrep -F existence check");
+});
+
+test("抽出 contract が共有可能で machine block の残骸が無い", () => {
+  const fields = [
+    /\bdir\b/,
+    /\boutcome\b/,
+    /\bdecisions\b/,
+    /\bassumptions\b/,
+    /\bnon_goals\b/,
+    /\bconstraints\b/,
+    /\bunits\b/,
+    /\bid\b/,
+    /\bgoal\b/,
+    /\bfiles\b/,
+    /\bcontract\b/,
+    /\btests\b/,
+    /\bname\b/,
+    /\bgiven\b/,
+    /\bwhen\b/,
+    /\bthen\b/,
+    /\bdepends_on\b/,
+    /\btest_command\b/,
+    /\bpreconditions\b/,
+    /\bpath\b/,
+    /\bpattern\b/,
+    /\bbacklog_candidates\b/,
+  ];
+  for (const [lang, path] of Object.entries(targets)) {
+    const doc = read(path);
+    for (const field of fields) {
+      assert.match(doc, field, `${lang}: 抽出 contract フィールド ${field}`);
+    }
+    assert.ok(!doc.includes("build-plan:v1"), `${lang}: build-plan:v1 残骸なし`);
+    assert.ok(!doc.includes("<details>"), `${lang}: <details> 残骸なし`);
+    assert.ok(!doc.includes("```json"), `${lang}: json fence 指定なし`);
+  }
+});

--- a/.ja/workflows/tests/run-workflow.mjs
+++ b/.ja/workflows/tests/run-workflow.mjs
@@ -1,0 +1,38 @@
+// workflow script (workflows/*.js) を node:test から行動検証するための harness。
+// script は `export const meta` + top-level return + agent/workflow/parallel/phase/log の
+// 注入 global という形で書かれているため、ESM import では実行できない。
+// ソースの `export const meta` を `const meta` に置換し、AsyncFunction の body として
+// 実行することで top-level return と注入 global の両方を再現する。
+import { readFileSync } from "node:fs";
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+// runWorkflow(scriptPath, { args, stubs }) -> { result, calls, logs }
+// stubs.agent / stubs.workflow は (prompt|name, opts|args) を受けて stub 結果を返す。
+// calls は agent / workflow / phase の呼び出し capture。
+export async function runWorkflow(scriptPath, { args = {}, stubs = {} } = {}) {
+  const source = readFileSync(scriptPath, "utf8").replace(/^export const meta/m, "const meta");
+  const calls = { agent: [], workflow: [], phase: [] };
+  const logs = [];
+
+  const agent = async (prompt, opts = {}) => {
+    calls.agent.push({ prompt, opts });
+    return stubs.agent ? stubs.agent(prompt, opts) : undefined;
+  };
+  const workflow = async (name, wfArgs) => {
+    calls.workflow.push({ name, args: wfArgs });
+    return stubs.workflow ? stubs.workflow(name, wfArgs) : undefined;
+  };
+  const parallel = async (tasks) =>
+    Promise.all(tasks.map((t) => (typeof t === "function" ? t() : t)));
+  const phase = (title) => {
+    calls.phase.push(title);
+  };
+  const log = (message) => {
+    logs.push(message);
+  };
+
+  const run = new AsyncFunction("args", "agent", "workflow", "parallel", "phase", "log", source);
+  const result = await run(args, agent, workflow, parallel, phase, log);
+  return { result, calls, logs };
+}

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: issue
-description: Generate GitHub Issue with structured title and body. Premise check + critic-design challenge verify drafted claims before posting.
-when_to_use: Issue作って, Issue書いて, Issue作成, GitHub Issue
-allowed-tools: Bash(gh:*) Bash(cat:*) Bash(ugrep:*) Read Task Skill AskUserQuestion
+description: Generate GitHub Issue with structured title and body. The receptacle for the refine-with-a-human stage; the premise check and the challenge workflow's GO act as the exit gate, refining the issue to the level the build workflow can consume.
+when_to_use: Issue作って, Issue書いて, Issue作成, GitHub Issue, refine an issue, prepare for build
+allowed-tools: Bash(gh:*) Bash(cat:*) Bash(ugrep:*) Bash(test:*) Read Task Skill Workflow AskUserQuestion
 model: opus
 argument-hint: "[issue description]"
 ---
 
 # /issue - GitHub Issue Generator
 
-Generate a GitHub Issue with a structured title and body, verifying drafted claims via premise check and critic-design challenge before posting.
+Generate a GitHub Issue with a structured title and body, verifying drafted claims via premise check and challenge before posting. The refine-with-a-human stage completes here: after the challenge workflow's GO, the research / think workflows run and the plan is written out as a `## Plan` section, finishing an issue the build workflow can extract the plan from as-is.
 
 ## Input
 
@@ -22,16 +22,34 @@ Read `language` from `${CLAUDE_SKILL_DIR}/../../settings.json` and translate the
 ## Execution
 
 1. Read `.claude/OUTCOME.md`; if absent, generate the stub via `/outcome`
-2. Detect type from description (§ Type Detection)
-3. Select the template (§ Template Source)
-4. Generate title + body following template; mark fixed/tentative (§ Confidence Marking)
-5. Assess whether the issue is epic-sized and should split (§ Split Assessment)
-6. Filter drafted claims via premise check (§ Premise Check)
-7. Refine body inline against `${CLAUDE_SKILL_DIR}/references/prose-review.md` plus the empty-phrase file matching the body language (`${CLAUDE_SKILL_DIR}/references/phrases.ja.md` for Japanese, `${CLAUDE_SKILL_DIR}/references/phrases.en.md` for English)
-8. Verify premises via `/challenge` (GO / NO-GO), feature / bug only (§ Adversarial Challenge)
-9. Preview issue + tentative items → AskUserQuestion: "Create this issue?"
-10. Write the body to a temp file, attach labels, run `gh issue create --body-file`, and capture the issue URL from its output (§ Labels; sandbox-compatible, avoids escaping a long body)
-11. If split was approved in step 5, hand the published issue to /slice (§ Split Assessment)
+2. If the Why (who needs this, what pain exists, what counts as success) is not readable from the description, pin it down through wall-bouncing via AskUserQuestion (§ Why Wall-Bouncing), feature / bug only
+3. Detect type from description (§ Type Detection) and judge whether the skip branch applies (§ Skip Branch)
+4. Select the template (§ Template Source)
+5. Generate title + body following template; mark fixed/tentative (§ Confidence Marking)
+6. Assess whether the issue is epic-sized and should split (§ Split Assessment)
+7. Filter drafted claims via premise check (§ Premise Check)
+8. Refine body inline against `${CLAUDE_SKILL_DIR}/references/prose-review.md` plus the empty-phrase file matching the body language (`${CLAUDE_SKILL_DIR}/references/phrases.ja.md` for Japanese, `${CLAUDE_SKILL_DIR}/references/phrases.en.md` for English). After the Plan section is appended at step 12, apply the same criteria to it as well
+9. Verify premises via the challenge workflow (GO / NO-GO), feature / bug only. On NO-GO, revise the body through wall-bouncing and re-run (§ Adversarial Challenge)
+10. Run the research workflow for pre-implementation research (§ Research). When the skip branch applies, skip steps 10-12
+11. Generate the structured plan via the think workflow (§ Think)
+12. Write the structured plan out into the body as a `## Plan` section, then run the round-trip fidelity check and the precondition existence check (§ Plan Write-Out)
+13. Preview issue + tentative items → AskUserQuestion: "Create this issue?"
+14. Write the body to a temp file, attach labels, run `gh issue create --body-file`, and capture the issue URL from its output (§ Labels; sandbox-compatible, avoids escaping a long body)
+15. If split was approved in step 6, hand the published issue to /slice (§ Split Assessment)
+
+## Why Wall-Bouncing
+
+Establish the issue's Why before drafting the body. Skip for docs / chore. If all three points below are readable from the description, proceed without asking.
+
+| Question                                    | Where it lands in the body |
+| ------------------------------------------- | -------------------------- |
+| Who needs this?                             | What & Why                 |
+| What pain exists, and what is the evidence? | What & Why                 |
+| What measurable result counts as success?   | Acceptance Criteria        |
+
+- One question per message, attaching a hypothesis (the answer you expect) as the recommended option. The user only has to correct the hypothesis
+- Questions the codebase can answer are explored via Read / ugrep before asking
+- Once you can predict the answers to the questions you would ask next, understanding is sufficient. Stop asking and move to drafting
 
 ## Type Detection
 
@@ -43,6 +61,16 @@ Default to `feature` if unclear. The title takes a bracketed prefix of the capit
 | feature | New capability or enhancement request                   |
 | docs    | Documentation additions or corrections                  |
 | chore   | Maintenance, config, or dependency updates              |
+
+## Skip Branch
+
+docs / chore and minor bugs skip research / think / plan write-out (steps 10-12). A qualifying example of a minor bug is a typo fix. A non-qualifying example is an intermittent bug with the root cause unidentified; that case does not skip and runs steps 10-12 as usual. A skipped issue gets a footer note in the body, "minor; may be handled via /fix", keeping the /fix path visible. A bug qualifies as minor only when all three criteria below hold.
+
+| Criterion     | Content                                   |
+| ------------- | ----------------------------------------- |
+| Change extent | Fits within 1 file                        |
+| Reproduction  | The reproduction steps are settled        |
+| Investigation | No cross-codebase investigation is needed |
 
 ## Template Source
 
@@ -66,7 +94,7 @@ Mark which parts of the body are fixed vs tentative, so the implementer can tell
 
 ## Split Assessment
 
-When two or more criteria are each independently implementable, ask via AskUserQuestion whether to split, offering "keep as one issue" or "split into an epic + child issues". Do not count fine-grained checks that only verify one deliverable; they stay within one issue. Never auto-split, since publishing N issues is hard to unwind. On approval, publish this issue as the epic and run the rest of the flow from the premise check onward unchanged on it. Once its number is captured, run `Skill("slice", "#<epic-number>")` at step 10.
+When two or more criteria are each independently implementable, ask via AskUserQuestion whether to split, offering "keep as one issue" or "split into an epic + child issues". Do not count fine-grained checks that only verify one deliverable; they stay within one issue. Never auto-split, since publishing N issues is hard to unwind. On approval, publish this issue as the epic and run the rest of the flow from the premise check onward unchanged on it. Once its number is captured, run `Skill("slice", "#<epic-number>")` at step 15.
 
 ## Premise Check
 
@@ -83,12 +111,31 @@ Sifts the claims already drafted into the body. Not a discovery phase. No agent 
 
 ## Adversarial Challenge
 
-Run `Skill("challenge", <drafted title + body>)` only for feature or bug (skip when empty). The returned verdict and findings never enter the issue body; collect them into the preview's challenge block. They are review material at confirm time, and the final call to fold or dismiss stays with the user.
+Run `Workflow({name: "challenge", args: {task: <drafted title + body>}})` only for feature or bug (skip when empty). Passing the same verification the build workflow uses (premise → 2 attacks → verdict + script gate) up front means a GO issue can be handed to build as-is. The returned verdict and findings never enter the issue body; collect them into the preview's challenge block.
 
 | Verdict | Handling                                                                                                                     |
 | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | GO      | Proceed to preview. If conditions are appended, present them as ephemeral critique; fold only what belongs in the body, once |
-| NO-GO   | Present the refuting evidence at preview; leave post / revise / drop to the user                                             |
+| NO-GO   | Enter the wall-bouncing loop (below)                                                                                         |
+
+The NO-GO wall-bouncing loop. Using why and gate (when the script gate downgraded, its rule and detail carry the list of residuals) as material, ask a hypothesis-attached decision via AskUserQuestion per residual, fold the answers into the body, and re-run the challenge workflow. Repeat until GO (at most 3 re-runs). If GO is not reached in 3 runs, or the user chooses "post as-is", present the NO-GO evidence at preview and leave post / drop to the user. Do not game the gate: a revision that merely deletes residuals from the body is not a fix. A residual either becomes a decision or stays in the body under a tentative mark.
+
+## Research
+
+For feature / bug where the skip branch does not apply, run `Workflow({name: "research", args: {question: <research question derived from the issue body>, repo: <target repository>}})` and fold the key results into the body's evidence and think's input. When stopped: unresearchable comes back, wall-bounce each missing item via AskUserQuestion with a hypothesis attached, fold the answers in, and re-run. This wall-bouncing runs at most 2 times. Items still unresolved at the cap stay in the body under a tentative mark, with their handling left to the user.
+
+## Think
+
+Run `Workflow({name: "think", args: {task: <title + body>, research: <research summary>}})` with the research results attached, obtaining the structured plan. When ready=false comes back, settle each blocker via AskUserQuestion with a hypothesis attached and re-run. Settling ready=false runs at most 2 times. Items still not ready at the cap stay in the body under a tentative mark, with how to proceed left to the user.
+
+## Plan Write-Out
+
+Write the structured plan the think workflow returned out into the body as a `## Plan` section in natural language, following the format in `${CLAUDE_SKILL_DIR}/references/plan-section.md`. No machine-only hidden blocks.
+
+1. Write-out. Transfer units / tests / preconditions / test_command into the plan-section.md skeleton
+2. Round-trip fidelity check. Re-extract the structure from the written Plan section per the plan-section.md extraction contract and reconcile it against the think plan. The reconciled fields are the unit id set / depends_on / test id set / test name / test_command. On mismatch, rewrite the Plan section. Rewriting runs at most 2 times; if the mismatch persists, present the diff to the user for judgment
+3. Precondition existence check. Verify each line of the preconditions subsection, path via `test -f <path>` and anchor via `ugrep -F '<pattern>' <path>`; fix or drop any failing line
+4. Append the `## Backlog candidates` section. List the candidates the plan carved out of scope; write "none" when there are none
 
 ## Labels
 

--- a/skills/issue/references/plan-section.md
+++ b/skills/issue/references/plan-section.md
@@ -1,0 +1,91 @@
+# Plan Section Format
+
+Defines the format of the `## Plan` section in an issue body and the contract by which the build workflow (via think) extracts a structured plan from it. This is the shared source for the issue SKILL.md and build.js; change the format here first, then propagate to both. The Plan section consists of human-readable markdown only, with no hidden machine block.
+
+## Plan section structure
+
+| Element            | Location                 | Content                                                                                       |
+| ------------------ | ------------------------ | --------------------------------------------------------------------------------------------- |
+| Intro prose        | Directly under `## Plan` | One outcome line (done state, implementation-independent, observable) + one test_command line |
+| Preconditions      | `### Preconditions`      | Bullet list of existing code the units depend on                                              |
+| Unit subsections   | `### U-NNN` (sequential) | Declarative goal + files + contract prose + acceptance tests + dependencies                   |
+| Backlog candidates | `## Backlog candidates`  | Bullet list of candidates to carve out of this issue's scope. "None" if empty                 |
+
+Skeleton example.
+
+```markdown
+## Plan
+
+Outcome: <one line describing the done state>
+test_command: <one-line test command, e.g. cargo test / node --test tests/>
+
+### Preconditions
+
+- `src/storage/mod.rs` `open_db`
+- `src/config.rs`
+
+### U-001 <unit title>
+
+<One declarative goal line: the behavior this unit delivers>
+
+- files: `src/foo.rs`, `tests/foo.test.rs`
+- contract: <public interface prose: signature / CLI flag / schema sketch>
+- depends_on: none
+
+Acceptance tests.
+
+- T-001 <statement of the spec being verified; becomes the test name>
+  - given: <initial state>
+  - when: <action>
+  - then: <expected result>
+
+## Backlog candidates
+
+- <candidate to carve out of scope>
+```
+
+### Id notation
+
+| Id    | Target             | Rule                                                  |
+| ----- | ------------------ | ----------------------------------------------------- |
+| U-NNN | Unit (`### U-NNN`) | Sequential from 001. Unique within the plan           |
+| T-NNN | Acceptance test    | Unique across the whole plan (not restarted per unit) |
+
+### Precondition authoring rules
+
+Apply these 5 rules to `### Preconditions`.
+
+1. List existing dependencies only. Files newly created by a unit are never listed as preconditions
+2. Anchors are limited to a stable anchor (an exported / public symbol name). Do not anchor on private implementation details or comment strings
+3. When no stable symbol exists, write the line as path only
+4. Each line takes one of two forms: path only, or path + stable anchor
+5. Verify existence before posting the issue: check each path with `test -f <path>` and each anchor with `ugrep -F '<pattern>' <path>`; fix or drop any line that fails
+
+## Extraction contract
+
+The build workflow reads the Plan section and assembles a structured plan isomorphic to the think workflow's PLAN_SCHEMA. Each Plan section element maps to a field as follows.
+
+| Plan section element                              | Field                               | Type              |
+| ------------------------------------------------- | ----------------------------------- | ----------------- |
+| Planning dir (decided by the workflow)            | dir                                 | string            |
+| Outcome line in the intro prose                   | outcome                             | string            |
+| Decisions in the issue body                       | decisions                           | string[]          |
+| Provisional marks / assumptions in the issue body | assumptions                         | string[]          |
+| Non-goals in the issue body                       | non_goals                           | string[]          |
+| Constraints in the issue body                     | constraints                         | string[]          |
+| Sequence of `### U-NNN` subsections               | units                               | object[]          |
+| U-NNN id                                          | units[].id                          | string            |
+| Declarative goal line                             | units[].goal                        | string            |
+| files bullet                                      | units[].files                       | string[]          |
+| contract prose                                    | units[].contract                    | string            |
+| Sequence of acceptance tests                      | units[].tests                       | object[]          |
+| T-NNN id                                          | units[].tests[].id                  | string            |
+| Test statement                                    | units[].tests[].name                | string            |
+| given / when / then lines                         | units[].tests[].given / when / then | string            |
+| depends_on line ("none" means empty array)        | units[].depends_on                  | string[]          |
+| Each line under `### Preconditions`               | preconditions                       | object[]          |
+| Path of a precondition line                       | preconditions[].path                | string            |
+| Stable anchor of a precondition line              | preconditions[].pattern             | string (optional) |
+| Each line under `## Backlog candidates`           | backlog_candidates                  | string[]          |
+
+preconditions and backlog_candidates are not required fields of PLAN_SCHEMA (think.js); they are extra information the build workflow picks up from the Plan section. Extraction relies solely on markdown heading and bullet structure and requires no special marker or comment notation.

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -1,90 +1,240 @@
 export const meta = {
   name: "build",
   description:
-    "Autonomous end-to-end build. challenge / branch / research / think / code / audit / polish / ship run headless as deterministic script stages, so every machinery fan-out fires instead of being inlined. Review at the draft PR.",
+    "Autonomous end-to-end build. Taking an issue with a Plan section refined via /issue as input, Load (verbatim fetch -> deterministic id collection -> extract -> validate + id cross-check) / Revalidate / Branch / Code / Audit / Polish / Backlog / Ship run headlessly as deterministic script stages. Review happens on a draft PR.",
   whenToUse:
-    "Fire-and-forget implementation. You walk away and come back to a draft PR, where you review the logged assumptions and the audit result. Reach for this when the task is specified enough to advance residual choices on best-guess; when it needs live steering mid-flight, drive the phases interactively instead.",
+    'Fire-and-forget implementation. Finish the refine-with-a-human stage in /issue, then pass that issue number ("123" / "#123") / URL / {issue, repo} as args. Step away and come back to a draft PR with recorded assumptions, audit results, and backlog issues to review. If in-flight steering is needed, drive the phases interactively.',
   phases: [
-    { title: "Challenge" },
+    { title: "Load" },
+    { title: "Revalidate" },
     { title: "Branch" },
-    { title: "Research" },
-    { title: "Think" },
     { title: "Code" },
     { title: "Audit" },
     { title: "Polish" },
+    { title: "Backlog" },
     { title: "Ship" },
   ],
 };
 
-// Autonomous build owns each phase's fan-out at the script level, because a
-// spawned agent cannot spawn its own sub-agents (nested spawn is blocked). The
-// interactive /build skill relies on that nesting (challenge -> critic-design,
-// audit -> reviewer swarm); here the script flattens it to one level, except
-// audit, which delegates to workflow("audit") so it keeps /audit's full routing
-// table (nesting a workflow is one level deep, which is allowed). Fidelity cuts
-// are deliberate and logged, not silent: code runs a single implementer rather
-// than /code's RGRC machinery, and interactive gates are replaced by best-guess
-// assumptions surfaced at the draft PR.
+// Assuming the upstream /issue finished premise verification and human refinement,
+// build does not reinvent the plan. The issue body's ## Plan section is the single
+// planning source; extraction is left to the LLM but verification belongs to the
+// script: the Plan heading check and U/T id collection are deterministic regexes,
+// structural validation is validate(), and silent drops in extraction are rejected
+// by exact id-set comparison. Code moving between issue filing and build launch is
+// caught fail-closed by Revalidate (exists/matches checks on preconditions). Stages
+// whose fan-out lives inside them are delegated to nested workflows (code / audit /
+// polish; one level of nesting is allowed).
 
-const task = typeof args === "string" ? args : (args && args.task) || "";
-if (!task) {
-  return { stopped: "no-task", why: "Pass the implementation task as args (string or {task})." };
+phase("Load");
+
+const input = typeof args === "object" && args ? args : {};
+const issueRef = String(typeof args === "string" ? args : input.issue || "").trim();
+// Deterministically pull the issue number from the tail of "123" / "#123" / an issue URL.
+const issueNumber = (issueRef.match(/(\d+)\D*$/) || [])[1] || "";
+if (!issueRef || !issueNumber) {
+  return {
+    stopped: "no-issue",
+    why: 'Pass the issue as args ("123" / "#123" / URL / {issue, repo}).',
+  };
 }
 
-// Optional repo target. When set, the build runs against a repository other than
-// the session cwd. Every filesystem / git / build step must be anchored there;
-// relying on "subagents inherit the session cwd" is model-discretion and would
-// misfire when the build is launched from elsewhere. anchor() prepends an
-// absolute cd so the starting cwd is irrelevant rather than assumed. guard is a
-// deterministic backstop for the hard-to-reverse steps (branch, commit, push,
-// PR): confirm the repo root before mutating, since the run completes headless
-// with no chance to intervene mid-flight.
-const repo = typeof args === "object" && args && typeof args.repo === "string" ? args.repo : "";
+// When repo is set, pin every step to that repository regardless of the session cwd.
+// Relying on "subagents inherit the session cwd" is model discretion and breaks when
+// launched from elsewhere. anchor() prepends an absolute cd so the starting cwd is
+// irrelevant. guard is a deterministic backstop for the hard-to-reverse steps
+// (branch / commit / push / PR): with no chance to intervene during a headless run,
+// it makes the agent confirm the repo root before mutating git.
+const repo = typeof input.repo === "string" ? input.repo : "";
 const anchor = (p) =>
   repo
-    ? `Run every git, file, and build command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`, which persists for that command's own follow-ups).\n\n${p}`
+    ? `Run every git, file, and build command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`).\n\n${p}`
     : p;
 const guard = repo
-  ? ` Before this step's first commit, push, or branch mutation, run \`cd ${repo} && git rev-parse --show-toplevel\` and confirm it prints ${repo}; if it prints anything else, abort without mutating git and report the mismatch.`
+  ? ` Before the first commit / push / branch change in this step, run \`cd ${repo} && git rev-parse --show-toplevel\` and confirm the output is ${repo}. If it differs, abort without mutating git and report the mismatch.`
   : "";
 
-const VERDICT_SCHEMA = {
+const FETCH_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["verdict", "why", "decisions", "assumptions"],
+  required: ["found", "body"],
   properties: {
-    verdict: { type: "string", enum: ["GO", "NO-GO"] },
-    why: { type: "string" },
-    decisions: { type: "array", items: { type: "string" } },
-    tradeoffs: { type: "array", items: { type: "string" } },
-    assumptions: {
-      type: "array",
-      items: { type: "string" },
-      description: "residual preferences advanced on best-guess; user veto targets at the PR",
+    found: { type: "boolean" },
+    body: {
+      type: "string",
+      description: "The issue body verbatim. No summarizing or reformatting",
     },
   },
 };
 
-const CRITIQUE_SCHEMA = {
+// Equivalent to think.js's PLAN_SCHEMA + preconditions + backlog_candidates.
+// Extraction structures the plan written in the issue; it is not re-planning.
+const EXTRACT_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["verdict", "weaknesses"],
-  properties: {
-    verdict: { type: "string" },
-    weaknesses: { type: "array", items: { type: "string" } },
-  },
-};
-
-const PLANNING_SCHEMA = {
-  type: "object",
-  additionalProperties: false,
-  required: ["dir", "summary"],
+  required: [
+    "dir",
+    "outcome",
+    "decisions",
+    "assumptions",
+    "units",
+    "test_command",
+    "preconditions",
+    "backlog_candidates",
+  ],
   properties: {
     dir: {
       type: "string",
-      description: "planning dir, e.g. .claude/workspace/planning/YYYY-MM-DD-slug",
+      description: "Planning dir, e.g. .claude/workspace/planning/YYYY-MM-DD-slug",
     },
-    summary: { type: "string" },
+    outcome: {
+      type: "string",
+      description:
+        "One-line description of the done state (implementation-independent, observable)",
+    },
+    decisions: { type: "array", items: { type: "string" } },
+    assumptions: {
+      type: "array",
+      items: { type: "string" },
+      description: "Best-guess residuals recorded in the issue. The user's veto targets on the PR",
+    },
+    non_goals: { type: "array", items: { type: "string" } },
+    constraints: { type: "array", items: { type: "string" } },
+    units: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "goal", "files", "contract", "tests", "depends_on"],
+        properties: {
+          id: {
+            type: "string",
+            description: "U-001 format. Use the ids from the issue body as-is",
+          },
+          goal: {
+            type: "string",
+            description: "One-line description of the behavior this unit delivers",
+          },
+          files: {
+            type: "array",
+            items: { type: "string" },
+            description: "File paths to create or modify",
+          },
+          contract: {
+            type: "string",
+            description: "Public interface: a sketch of signatures / CLI flags / schemas",
+          },
+          tests: {
+            type: "array",
+            items: {
+              type: "object",
+              additionalProperties: false,
+              required: ["id", "name", "given", "when", "then"],
+              properties: {
+                id: { type: "string", description: "T-001 format (unique across the plan)" },
+                name: {
+                  type: "string",
+                  description: "Statement of the spec being verified. Becomes the test name",
+                },
+                given: { type: "string" },
+                when: { type: "string" },
+                // JSON Schema property definition, not a thenable (BDD given/when/then)
+                // oxlint-disable-next-line unicorn/no-thenable
+                then: { type: "string" },
+              },
+            },
+          },
+          depends_on: {
+            type: "array",
+            items: { type: "string" },
+            description: "Ids of prerequisite units. Empty array if none",
+          },
+        },
+      },
+    },
+    test_command: { type: "string", description: "Test command, e.g. cargo test / bun test" },
+    preconditions: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["path"],
+        properties: {
+          path: { type: "string", description: "Existing file the plan presupposes" },
+          pattern: {
+            type: "string",
+            description: "Symbol / string expected to exist in that file",
+          },
+        },
+      },
+      description: "Existing code the issue's plan presupposes. Empty array if none",
+    },
+    backlog_candidates: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["summary"],
+        properties: {
+          summary: { type: "string" },
+        },
+      },
+      description: "Out-of-scope candidates written in the issue. Empty array if none",
+    },
+  },
+};
+
+const REVALIDATE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["results"],
+  properties: {
+    results: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["path", "pattern", "exists", "matches"],
+        properties: {
+          path: { type: "string" },
+          pattern: { type: "string" },
+          exists: { type: "boolean" },
+          matches: { type: "boolean" },
+        },
+      },
+    },
+  },
+};
+
+const BACKLOG_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["posted", "deferred"],
+  properties: {
+    posted: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "url"],
+        properties: {
+          title: { type: "string" },
+          url: { type: "string" },
+        },
+      },
+    },
+    deferred: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "reason"],
+        properties: {
+          title: { type: "string" },
+          reason: { type: "string" },
+        },
+      },
+    },
   },
 };
 
@@ -99,150 +249,308 @@ const SHIP_SCHEMA = {
   },
 };
 
-// ---- Challenge: premise -> two critic-design attacks -> GO/NO-GO ----
-phase("Challenge");
-const premise = await agent(
-  anchor(`You are the premise-analysis stage of an autonomous build. Task: "${task}".\n`) +
-    `Read .claude/OUTCOME.md if present for the outcome axis. List the open questions in the task, sort each into fact (evidence settles it) or preference (needs a choice). Verify the facts against the codebase. Report a one-line approach summary, the architectural decisions that crystallised, the trade-offs, and the residual preferences you would otherwise ask the user (these become logged assumptions).\n` +
-    `Return that package as your final text.`,
-  { label: "premise", phase: "Challenge" },
-);
-const critiques = await parallel([
-  () =>
-    agent(
-      anchor(
-        `critic-design, internal attack. Attack this build premise on its own terms (hidden weaknesses, failure modes). Premise:\n${premise}`,
-      ),
-      { agentType: "critic-design", phase: "Challenge", schema: CRITIQUE_SCHEMA },
-    ),
-  () =>
-    agent(
-      anchor(
-        `critic-design, outcome attack. Read .claude/OUTCOME.md and attack whether this premise reaches the outcome (outcome fit, non-goal breach, constraint breach). Premise:\n${premise}`,
-      ),
-      { agentType: "critic-design", phase: "Challenge", schema: CRITIQUE_SCHEMA },
-    ),
-]);
-const verdict = await agent(
-  `Reconcile the premise and the two critic-design attacks into a single GO/NO-GO verdict for an autonomous build.\n` +
-    `Premise:\n${premise}\n\nInternal attack:\n${JSON.stringify(critiques[0])}\n\nOutcome attack:\n${JSON.stringify(critiques[1])}\n\n` +
-    `Rule NO-GO only when fact evidence overturns the core (targets a state that already holds, or a verified fact contradicts it). Otherwise GO, proceeding on the surviving part. List residual preferences as assumptions.`,
-  { label: "verdict", phase: "Challenge", schema: VERDICT_SCHEMA },
-);
-if (verdict.verdict === "NO-GO") {
-  return { stopped: "NO-GO", why: verdict.why, decisions: verdict.decisions };
-}
-log(`GO. ${verdict.assumptions.length} residual(s) advanced on best-guess (veto at the PR).`);
+// Port of think.js's validate() + non-empty content checks. Deterministically rejects
+// structural defects (duplicate ids / dangling or cyclic depends_on / missing tests)
+// and empty content (contract / name / given / when / then).
+const validate = (plan) => {
+  const errors = [];
+  const units = plan.units || [];
+  if (!units.length) errors.push("units is empty. Define at least one implementation unit");
+  const ids = new Set(units.map((u) => u.id));
+  if (ids.size !== units.length) errors.push("duplicate unit ids");
+  const testIds = new Set();
+  for (const u of units) {
+    if (!u.tests.length) errors.push(`${u.id} has no test scenario`);
+    if (!u.files.length) errors.push(`${u.id} has no target files`);
+    if (!String(u.goal || "").trim()) errors.push(`${u.id} has an empty goal`);
+    if (!String(u.contract || "").trim()) errors.push(`${u.id} has an empty contract`);
+    for (const t of u.tests) {
+      if (testIds.has(t.id)) errors.push(`duplicate test id ${t.id}`);
+      testIds.add(t.id);
+      for (const field of ["name", "given", "when", "then"]) {
+        if (!String(t[field] || "").trim()) errors.push(`${t.id} has an empty ${field}`);
+      }
+    }
+    for (const d of u.depends_on) {
+      if (!ids.has(d)) errors.push(`${u.id}'s depends_on ${d} points to a nonexistent unit`);
+    }
+  }
+  // Cycle detection (DFS)
+  const state = new Map();
+  const visit = (id, path) => {
+    if (state.get(id) === "done") return;
+    if (state.get(id) === "visiting") {
+      errors.push(`depends_on cycle: ${[...path, id].join(" -> ")}`);
+      return;
+    }
+    state.set(id, "visiting");
+    const u = units.find((x) => x.id === id);
+    for (const d of (u && u.depends_on) || []) visit(d, [...path, id]);
+    state.set(id, "done");
+  };
+  for (const u of units) visit(u.id, []);
+  return errors;
+};
 
-// ---- Branch ----
+// ---- Load: verbatim fetch -> Plan heading check -> deterministic id collection -> extract -> validate + cross-check ----
+const fetched = await agent(
+  anchor(
+    `Fetch the body of GitHub issue ${issueRef}. Use the gh CLI (e.g. gh issue view ${issueRef} --json body) and return the body verbatim with no summarizing, reformatting, or omission. If the issue is not found or the fetch fails, return found: false.`,
+  ),
+  { label: "fetch", phase: "Load", agentType: "general-purpose", schema: FETCH_SCHEMA },
+);
+if (!fetched || !fetched.found || !String(fetched.body || "").trim()) {
+  return {
+    stopped: "no-issue-body",
+    why: `Could not fetch the body of issue ${issueRef}. Check the issue number and repo.`,
+  };
+}
+const body = fetched.body;
+
+// The Plan heading check and id collection run deterministically in the script,
+// before the extract agent.
+const planHeading = body.match(/^##\s+Plan\b.*$/m);
+if (!planHeading) {
+  return {
+    stopped: "no-plan",
+    why: "The issue body has no ## Plan section. Refine the plan via /issue before launching build.",
+  };
+}
+const afterHeading = body.slice(planHeading.index + planHeading[0].length);
+const nextSection = afterHeading.search(/^##[^#]/m);
+const planSection = nextSection === -1 ? afterHeading : afterHeading.slice(0, nextSection);
+const idSet = (re) => new Set([...planSection.matchAll(re)].map((m) => m[0]));
+const bodyUnitIds = idSet(/\bU-\d{3}\b/g);
+const bodyTestIds = idSet(/\bT-\d{3}\b/g);
+
+const plan = await agent(
+  anchor(
+    `Extract a structured plan from the ## Plan section of the following GitHub issue body. Do not re-plan, summarize, or fill in gaps; structure exactly what is written. ` +
+      `Preserve every unit id (U-NNN) and test id (T-NNN) from the body (omissions are rejected by a downstream deterministic cross-check). ` +
+      `preconditions is the list of {path, pattern} of existing code the plan presupposes; backlog_candidates are out-of-scope candidates written in the issue. Empty arrays if absent from the body.\n\n---\n${body}`,
+  ),
+  { label: "extract", phase: "Load", agentType: "general-purpose", schema: EXTRACT_SCHEMA },
+);
+if (!plan) {
+  return { stopped: "extraction-failed", why: "The extract agent returned no plan." };
+}
+
+const blockers = validate(plan);
+if (blockers.length) {
+  return {
+    stopped: "invalid-plan",
+    blockers,
+    why: "The extracted plan fails structural validation.",
+  };
+}
+
+// Reject silent drops / fabrications in extraction via exact id-set comparison.
+const planUnitIds = new Set(plan.units.map((u) => u.id));
+const planTestIds = new Set(plan.units.flatMap((u) => u.tests.map((t) => t.id)));
+const setDiff = (a, b) => [...a].filter((x) => !b.has(x));
+const mismatch = {
+  units_missing: setDiff(bodyUnitIds, planUnitIds),
+  units_extra: setDiff(planUnitIds, bodyUnitIds),
+  tests_missing: setDiff(bodyTestIds, planTestIds),
+  tests_extra: setDiff(planTestIds, bodyTestIds),
+};
+if (Object.values(mismatch).some((l) => l.length)) {
+  return {
+    stopped: "extraction-mismatch",
+    detail: mismatch,
+    why: "The U/T id sets in the issue body and the extraction do not match.",
+  };
+}
+log(
+  `Plan extracted: ${plan.units.length} unit(s), ${planTestIds.size} test scenario(s), id cross-check pass.`,
+);
+
+// ---- Revalidate: re-verify preconditions against the current codebase (evidence + script gate) ----
+// Catches, fail-closed, the possibility that the presupposed code moved between issue
+// filing and build launch. Misses are decided by the script's filter, not by the
+// agent's self-report.
+phase("Revalidate");
+const preconditions = plan.preconditions || [];
+if (preconditions.length) {
+  const reval = await agent(
+    anchor(
+      `Re-verify the plan's preconditions against the current codebase. For each {path, pattern}, actually run commands to check the path's existence (exists) and the pattern's grep match (matches; with no pattern, same as exists), and return all ${preconditions.length} in results. Do not be lenient.\n${JSON.stringify(preconditions)}`,
+    ),
+    {
+      label: "revalidate",
+      phase: "Revalidate",
+      agentType: "general-purpose",
+      schema: REVALIDATE_SCHEMA,
+    },
+  );
+  if (!reval || !Array.isArray(reval.results) || reval.results.length !== preconditions.length) {
+    return {
+      stopped: "revalidate-failed",
+      detail: reval,
+      why: "The revalidate agent did not return results for every precondition.",
+    };
+  }
+  const drift = reval.results.filter((r) => !r.exists || !r.matches);
+  if (drift.length) {
+    return {
+      stopped: "plan-drift",
+      drift,
+      why: "Code the issue's plan presupposes is absent from the current codebase. Update the issue and relaunch.",
+    };
+  }
+  log(`Revalidate: all ${preconditions.length} precondition(s) pass.`);
+}
+
+// ---- Branch: check out a working branch ----
 phase("Branch");
 const branch = await agent(
   anchor(
-    `Check out a new git working branch for: "${task}". Choose a conventional branch name (type then short slug) from the task and run git checkout -b with that name. If already off the default branch, keep the current branch. Report the branch name as your final text.${guard}`,
+    `Check out a new git working branch for issue #${issueNumber} "${plan.outcome}". Pick a conventional branch name (type + short slug) and run git checkout -b with it. If already on a non-default branch, keep the current branch. Report the branch name as your final text.${guard}`,
   ),
   { label: "checkout", phase: "Branch", agentType: "general-purpose" },
 );
 
-// ---- Research (light; skips cleanly when there are no unknowns) ----
-phase("Research");
-const research = await parallel([
-  () =>
-    agent(
-      anchor(
-        `Explore the codebase for prior art, patterns, and constraints relevant to: "${task}". Report file:line anchors. medium breadth.`,
-      ),
-      { agentType: "Explore", phase: "Research", label: "explore:patterns" },
-    ),
-  () =>
-    agent(
-      anchor(
-        `Explore the codebase for integration points, existing helpers to reuse, and edge cases relevant to: "${task}". Report file:line anchors. medium breadth.`,
-      ),
-      { agentType: "Explore", phase: "Research", label: "explore:integration" },
-    ),
-]);
-const researchDigest = research.filter(Boolean).join("\n\n");
-
-// ---- Think: SOW/Spec -> critic-design ----
-phase("Think");
-const planning = await agent(
-  anchor(`Generate a SOW and Spec for an autonomous build of: "${task}".\n`) +
-    `Inputs. Challenge decisions: ${JSON.stringify(verdict.decisions)}. Trade-offs: ${JSON.stringify(verdict.tradeoffs || [])}. Assumptions (log these in the SOW Why): ${JSON.stringify(verdict.assumptions)}.\n` +
-    `Research:\n${researchDigest}\n\n` +
-    `Run \`date -u +%Y-%m-%d\` for the slug. Write .claude/workspace/planning/<date>-<slug>/sow.md (AC-N ids) and spec.md (FR-001 / T-001 / NFR-001 ids). Return the dir and a one-line summary.`,
-  { label: "plan", phase: "Think", agentType: "general-purpose", schema: PLANNING_SCHEMA },
-);
-await agent(
-  anchor(
-    `critic-design. Attack the SOW and Spec at ${planning.dir} for hidden weaknesses, unstated assumptions, and outcome drift. Report a verdict table and actionable items.`,
-  ),
-  { agentType: "critic-design", phase: "Think", label: "critic:spec" },
-);
-// ---- Code: single implementer (fidelity cut vs /code RGRC machinery) ----
+// ---- Code: delegated to workflow("code") (per-unit Red -> Green + independent verify) ----
+// preconditions / backlog_candidates are consumed on the build side, so code receives
+// only the PLAN_SCHEMA equivalent.
 phase("Code");
-log("Code phase runs a single implementer agent, not /code's full RGRC machinery.");
-await agent(
-  anchor(
-    `Implement the SOW and Spec at ${planning.dir}. Test-first (TDD): write failing tests from the T-NNN scenarios, implement to green, refactor. Run the project's lint / type-check / test gates and keep going until every AC is met and tests pass. Do not commit.`,
-  ),
-  { label: "implement", phase: "Code", agentType: "general-purpose" },
-);
+const stripPreconditions = (p) =>
+  Object.fromEntries(
+    Object.entries(p).filter(([k]) => k !== "preconditions" && k !== "backlog_candidates"),
+  );
+const code =
+  (await workflow("code", { plan: stripPreconditions(plan), repo, model: "sonnet" })) || null;
+if (!code || code.stopped) {
+  return { stopped: "code-failed", detail: code, planning: plan.dir };
+}
+if (!code.tests_pass || !code.gates_pass)
+  log(
+    `code's independent verify failed (tests=${code.tests_pass} gates=${code.gates_pass}). Advancing to audit; it surfaces on the PR.`,
+  );
 
-// ---- Audit: delegate to the deterministic audit workflow (full routing) ----
-// workflow("audit") owns the fan-out: it ports /audit's glob routing table to
-// JS and fires every routed reviewer -> critic-audit -> critic-evidence ->
-// team-integration. Nesting a workflow is one level deep, which is allowed, so
-// build keeps /audit fidelity here instead of the old 6-reviewer cut. No scope
-// is passed, so audit routes the uncommitted diff (code has not committed yet),
-// which is the whole implementation.
+// ---- Audit ∥ Polish review -> fix -> re-audit loop (at most 3 audit runs) ----
+// The audit fan-out is owned by workflow("audit") (/audit's glob routing table +
+// reviewer -> challenge -> verify -> integrate). No scope is passed, so it routes
+// the uncommitted diff, i.e. the whole implementation. The code phase already got
+// tests green, so preflight is skipped. Polish's review mode is read-only, so the
+// external Codex lens runs on the same diff alongside the audit.
 phase("Audit");
-const audit = (await workflow("audit", { repo })) || { findings: [] };
+const [audit0, review] = await parallel([
+  () => workflow("audit", { repo, skipPreflight: true }),
+  () => workflow("polish", { repo, mode: "review" }),
+]);
+let audit = audit0 || { findings: [] };
 log(
-  `Audit fired ${(audit.assignments || []).length} reviewer group(s), ${(audit.skipped || []).length} skipped.`,
+  `Audit fired ${(audit.assignments || []).length} reviewer group(s); polish lens ${review && review.codex_available ? "active" : "inactive"}.`,
 );
-const blocking = (audit.findings || []).filter(
-  (f) => f.severity === "critical" || f.severity === "high",
-);
-if (blocking.length) {
-  log(`Fixing ${blocking.length} critical/high finding(s).`);
+const criticalHigh = (a) =>
+  (a.findings || []).filter((f) => f.severity === "critical" || f.severity === "high");
+const polishSurvivors = ((review && review.survivors) || []).map((f) => ({
+  severity: f.severity === "P1" ? "high" : "medium",
+  summary: `${f.title}: ${f.detail}`,
+  file: f.file || "",
+}));
+// Loop fix -> re-audit until 0 critical/high. The old version fixed once with no
+// re-audit, i.e. the fixes were never verified. Only the final round's fixes stay
+// unverified (the re-audit budget is spent) and surface on the PR.
+let toFix = [...criticalHigh(audit), ...polishSurvivors];
+let reaudited = true;
+for (let round = 1; round <= 3 && toFix.length; round++) {
+  log(`Fix round ${round}: fixing ${toFix.length} finding(s).`);
   await agent(
+    anchor(`Fix these review findings and confirm tests pass:\n${JSON.stringify(toFix)}`),
+    { agentType: "general-purpose", phase: "Audit", label: `fix:${round}` },
+  );
+  if (round === 3) {
+    reaudited = false;
+    log("Fix round cap reached. The final round's fixes are not re-audited and surface on the PR.");
+    break;
+  }
+  audit = (await workflow("audit", { repo, skipPreflight: true })) || { findings: [] };
+  toFix = criticalHigh(audit);
+}
+const residualBlocking = reaudited ? criticalHigh(audit) : [];
+
+// ---- Polish: cleanup only (simplify -> enhancer-code -> test validation) ----
+// The review lens was consumed in the Audit phase, so only the mutators run here.
+phase("Polish");
+const cleanup = await workflow("polish", { repo, mode: "cleanup" });
+
+// ---- Backlog: file out-of-scope discoveries as issues (hybrid) ----
+// Candidate sources are the out-of-scope candidates written in the issue body
+// (source: issue) plus discoveries during the build. Cross-check against existing
+// issues and auto-post only the ones confidently new. Uncertain candidates go to the
+// PR body for human triage. Mass-producing duplicate issues erodes trust in the
+// automation, so when in doubt lean toward deferred.
+phase("Backlog");
+const backlogCandidates = [
+  ...(plan.backlog_candidates || []).map((c) => ({ ...c, source: "issue" })),
+  ...(code.anomalies || []).map((a) => ({
+    source: "code",
+    summary: `Red unconfirmed in ${a.unit} (${a.kind}): ${a.notes}`,
+  })),
+  ...(audit.findings || [])
+    .filter((f) => f.severity === "medium" || f.severity === "low")
+    .map((f) => ({ source: "audit", summary: f.summary, file: f.file, severity: f.severity })),
+  ...((review && review.needs_context) || []).map((f) => ({
+    source: "polish",
+    summary: `${f.title}: ${f.why || f.detail}`,
+  })),
+];
+let backlog = { posted: [], deferred: [] };
+if (backlogCandidates.length) {
+  backlog = (await agent(
     anchor(
-      `Fix these critical/high audit findings, then confirm tests still pass:\n${JSON.stringify(blocking)}`,
+      `Backlog stage: file GitHub issues for out-of-scope problems discovered during the build. Originating build issue: #${issueNumber}. Candidates:\n${JSON.stringify(backlogCandidates)}\n` +
+        `For each candidate: (1) judge whether it deserves an issue (actionable, outside this build's scope, non-trivial; merge duplicates and rephrasings into one). ` +
+        `(2) Cross-check against existing issues via the gh CLI issue search (state open, keywords from the candidate).\n` +
+        `File issues only for candidates you are confident are new (at most 5). Apply the label build-discovered; if the repo lacks it, set it up first via gh's label subcommand (color BFD4F2, description "out-of-scope problems discovered by autonomous builds"; if that fails, file without the label). Note the source and the originating build issue #${issueNumber} in the issue body.\n` +
+        `Defer any candidate that looks like a possible duplicate or that you are unsure about, with a reason, instead of posting. If gh is unavailable, defer every candidate.`,
     ),
-    { agentType: "general-purpose", phase: "Audit", label: "fix" },
+    { label: "backlog", phase: "Backlog", agentType: "general-purpose", schema: BACKLOG_SCHEMA },
+  )) || {
+    posted: [],
+    deferred: backlogCandidates.map((c) => ({
+      title: `[${c.source}] ${c.summary}`,
+      reason: "the backlog agent returned nothing",
+    })),
+  };
+  log(
+    `Backlog: posted ${backlog.posted.length} issue(s), ${backlog.deferred.length} to the PR body.`,
   );
 }
 
-// ---- Polish: external Codex + enhancer-code cleanup ----
-phase("Polish");
-await agent(
-  anchor(
-    `Run external Codex review on the uncommitted diff if the \`codex\` CLI is installed (a non-Claude lens against self-enhancement bias), apply its safe fixes, then run enhancer-code style cleanup (simplify, clarify). If codex is not installed, do cleanup only. If any fix breaks tests, revert that fix. Do not commit.`,
-  ),
-  { label: "polish", phase: "Polish", agentType: "general-purpose" },
-);
-
 // ---- Ship: commit + draft PR (outward-facing, so draft = reversible) ----
 phase("Ship");
-const shipPrompt = anchor(
-  `Commit all changes (planning artifacts + implementation) in one Conventional Commits commit. ` +
-    `Then push the branch and open a draft pull request using the gh CLI in draft mode. ` +
-    `The PR body must list the logged assumptions so the user can veto: ${JSON.stringify(verdict.assumptions)}. ` +
-    `Report committed status and the PR url.${guard}`,
+const ship = await agent(
+  anchor(
+    `Turn all changes (planning artifacts + implementation) into a single Conventional Commits commit. ` +
+      `Push the branch and open a draft pull request via the gh CLI.\n` +
+      `The PR body must include all of the following. (1) The closing reference to the originating issue: "Closes #${issueNumber}". ` +
+      `(2) Assumptions recorded in the plan (the user's veto targets): ${JSON.stringify(plan.assumptions)}. ` +
+      `(3) Issues posted by the backlog stage: ${JSON.stringify(backlog.posted)}. ` +
+      `(4) Backlog candidates awaiting human triage: ${JSON.stringify(backlog.deferred)}. ` +
+      `(5) Unresolved critical/high findings: ${JSON.stringify(residualBlocking)}${reaudited ? "" : " (state clearly that the final fix round has not been re-audited)"}. ` +
+      `(6) code's Red-unconfirmed anomalies: ${JSON.stringify(code.anomalies || [])}. ` +
+      `(7) code's independent verify result (tests=${code.tests_pass} gates=${code.gates_pass})${code.tests_pass && code.gates_pass ? "" : `; failure detail: ${JSON.stringify(code.verify_output)}`}.\n` +
+      `Report the committed state and the PR url.${guard}`,
+  ),
+  { label: "ship", phase: "Ship", agentType: "general-purpose", schema: SHIP_SCHEMA },
 );
-const ship = await agent(shipPrompt, {
-  label: "ship",
-  phase: "Ship",
-  agentType: "general-purpose",
-  schema: SHIP_SCHEMA,
-});
 
 return {
-  verdict: verdict.verdict,
+  issue: issueNumber,
   branch,
-  planning: planning.dir,
+  planning: plan.dir,
+  units_completed: code.completed.length,
+  code_anomalies: (code.anomalies || []).length,
+  code_verified: code.tests_pass && code.gates_pass,
   audit_findings: (audit.findings || []).length,
-  assumptions: verdict.assumptions,
+  residual_blocking: residualBlocking.length,
+  polish_cleanup: cleanup && cleanup.cleanup ? cleanup.cleanup.tests_pass : null,
+  backlog_posted: backlog.posted,
+  backlog_deferred: backlog.deferred.length,
+  assumptions: plan.assumptions,
   pr_url: ship.pr_url,
   committed: ship.committed,
 };

--- a/workflows/code.js
+++ b/workflows/code.js
@@ -1,0 +1,227 @@
+export const meta = {
+  name: "code",
+  description:
+    'TDD workflow that takes the think workflow\'s structured plan and runs Red -> Green per unit under script enforcement. An unconfirmed Red (tests passing from the start) is recorded as an anomaly, and at the end an independent agent verifies the full suite + lint + type-check. Writing tests after the fact and skipping Red cannot happen structurally. Callable standalone or nested from build via workflow("code").',
+  whenToUse:
+    "Headless TDD implementation. args is {plan, repo, model}; plan is the plan returned by the think workflow (with units / test_command). model (optional) propagates only to the Red / Green implementation agents.",
+  phases: [{ title: "Implement" }, { title: "Verify" }],
+};
+
+// RGRC at the main loop's discretion can degrade: tests written in bulk afterwards,
+// Red confirmation skipped. This workflow has the script's loop own
+// the per-unit Red -> Green, receiving the Red confirmation via schema and recording
+// it. Green's self-report is not trusted: an independent agent uninvolved in the
+// implementation re-runs the full suite at the end (reward-hack countermeasure).
+
+// args may arrive as an object or, if a caller stringifies it, as a JSON string.
+// Normalize once. Keep the object branch: nested workflow("code", {plan}) arrives as an object.
+const input = (() => {
+  if (typeof args === "object" && args) return args;
+  if (typeof args !== "string") return {};
+  const s = args.trim();
+  if (s.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(s);
+      if (parsed && typeof parsed === "object") return parsed;
+    } catch {
+      // malformed JSON: fall through and fail-close as no-plan
+    }
+  }
+  return {};
+})();
+const plan = input.plan;
+if (!plan || !Array.isArray(plan.units) || !plan.units.length) {
+  return {
+    stopped: "no-plan",
+    why: "Pass the think workflow's plan (units required) as args.plan.",
+  };
+}
+const repo = typeof input.repo === "string" ? input.repo : "";
+const anchor = (p) =>
+  repo
+    ? `Run every git, file, and build command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`).\n\n${p}`
+    : p;
+
+const RED_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["red_confirmed", "test_files", "notes"],
+  properties: {
+    red_confirmed: {
+      type: "boolean",
+      description: "true when you ran the tests you wrote and confirmed they fail as expected",
+    },
+    test_files: { type: "array", items: { type: "string" } },
+    notes: {
+      type: "string",
+      description: "when red_confirmed is false, the reason (e.g. the behavior already exists)",
+    },
+  },
+};
+
+const GREEN_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["green", "notes"],
+  properties: {
+    green: { type: "boolean", description: "true when all of the unit's tests pass" },
+    notes: { type: "string" },
+  },
+};
+
+const VERIFY_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["tests_pass", "gates_pass", "output_tail"],
+  properties: {
+    tests_pass: { type: "boolean" },
+    gates_pass: { type: "boolean", description: "true when lint / type-check pass" },
+    output_tail: { type: "string", description: "on failure, the tail of the failing output" },
+  },
+};
+
+// Order by dependency (already validated by think, but fail-close on a malformed
+// plan from a standalone call).
+const units = [];
+const placed = new Set();
+let progressed = true;
+while (progressed && units.length < plan.units.length) {
+  progressed = false;
+  for (const u of plan.units) {
+    if (placed.has(u.id)) continue;
+    if ((u.depends_on || []).every((d) => placed.has(d))) {
+      units.push(u);
+      placed.add(u.id);
+      progressed = true;
+    }
+  }
+}
+if (units.length < plan.units.length) {
+  const stuck = plan.units.filter((u) => !placed.has(u.id)).map((u) => u.id);
+  return { stopped: "invalid-plan", why: `unresolvable depends_on for units: ${stuck.join(", ")}` };
+}
+
+const testCmd = plan.test_command || "";
+const completed = [];
+const anomalies = [];
+
+// ---- Implement: Red -> Green per unit (serial; the working tree is shared) ----
+phase("Implement");
+for (const unit of units) {
+  const ctx =
+    `Unit ${unit.id}: ${unit.goal}\nTarget files: ${JSON.stringify(unit.files)}\n` +
+    `Contract: ${unit.contract}\nTest scenarios: ${JSON.stringify(unit.tests)}\n` +
+    `Test command: ${testCmd}\n` +
+    (completed.length ? `Units already implemented: ${completed.join(", ")}\n` : "");
+
+  // Red: write tests and confirm failure by running them. Write no implementation.
+  let red = await agent(
+    anchor(
+      `TDD Red step. ${ctx}` +
+        `Write each test scenario (T-NNN) as a failing test. Use the scenario's name verbatim as the test name. ` +
+        `Write no implementation code whatsoever. Run the tests and confirm they fail as expected, then report. ` +
+        `If the tests do not fail, do not implement; write the reason in notes.`,
+    ),
+    {
+      label: `red:${unit.id}`,
+      phase: `Unit ${unit.id}`,
+      agentType: "general-purpose",
+      schema: RED_SCHEMA,
+      ...(input.model ? { model: input.model } : {}),
+    },
+  );
+  if (red && !red.red_confirmed) {
+    // Red unconfirmed = either the behavior already exists or the test is vacuous.
+    // Scrutinize exactly once.
+    red = await agent(
+      anchor(
+        `TDD Red step retry. ${ctx}` +
+          `Last time the tests did not fail: ${red.notes}\n` +
+          `Scrutinize whether the tests really verify the target behavior (assertions are not empty, the target code is invoked). ` +
+          `If the behavior is unimplemented they should fail. If after scrutiny the tests still pass, judge the behavior as already implemented and keep red_confirmed=false with the reason in notes.`,
+      ),
+      {
+        label: `red2:${unit.id}`,
+        phase: `Unit ${unit.id}`,
+        agentType: "general-purpose",
+        schema: RED_SCHEMA,
+        ...(input.model ? { model: input.model } : {}),
+      },
+    );
+  }
+  if (!red) return { stopped: "red-failed", unit: unit.id, completed, anomalies };
+  if (!red.red_confirmed) {
+    anomalies.push({ unit: unit.id, kind: "no-red", notes: red.notes });
+    log(`${unit.id}: Red unconfirmed (${red.notes}). Skipping the implement step.`);
+    completed.push(unit.id);
+    continue;
+  }
+
+  // Green: implement until the tests pass, then refactor. Do not modify the tests.
+  let green = await agent(
+    anchor(
+      `TDD Green step. ${ctx}` +
+        `Write the minimal implementation that makes the failing tests in ${JSON.stringify(red.test_files)} pass. ` +
+        `Weakening, skipping, or deleting test assertions is forbidden (if the test structure needs fixing, write it in notes and return green=false). ` +
+        `After passing, refactor while keeping the tests green. Re-run the unit's tests and report.`,
+    ),
+    {
+      label: `green:${unit.id}`,
+      phase: `Unit ${unit.id}`,
+      agentType: "general-purpose",
+      schema: GREEN_SCHEMA,
+      ...(input.model ? { model: input.model } : {}),
+    },
+  );
+  if (green && !green.green) {
+    green = await agent(
+      anchor(
+        `TDD Green step retry. ${ctx}` +
+          `Last time the tests did not pass: ${green.notes}\nIdentify the cause, fix the implementation, and make the unit's tests pass. Weakening tests is forbidden.`,
+      ),
+      {
+        label: `green2:${unit.id}`,
+        phase: `Unit ${unit.id}`,
+        agentType: "general-purpose",
+        schema: GREEN_SCHEMA,
+        ...(input.model ? { model: input.model } : {}),
+      },
+    );
+  }
+  if (!green || !green.green) {
+    return {
+      stopped: "unit-failed",
+      unit: unit.id,
+      why: (green && green.notes) || "the green agent returned no result",
+      completed,
+      anomalies,
+    };
+  }
+  completed.push(unit.id);
+  log(`${unit.id}: Red -> Green done (${completed.length}/${units.length}).`);
+}
+
+// ---- Verify: an independent agent uninvolved in the implementation re-runs everything ----
+phase("Verify");
+const verify = (await agent(
+  anchor(
+    `Verification stage. You were not involved in the implementation. Run the full test suite (${testCmd}) and the project's lint / type-check gates, and report the results as they are. Do not fix anything.`,
+  ),
+  { label: "verify", phase: "Verify", agentType: "general-purpose", schema: VERIFY_SCHEMA },
+)) || {
+  tests_pass: false,
+  gates_pass: false,
+  output_tail: "the verify agent returned no result",
+};
+
+log(
+  `code: ${completed.length}/${units.length} unit(s) done, ${anomalies.length} anomaly(ies), verify tests=${verify.tests_pass} gates=${verify.gates_pass}.`,
+);
+
+return {
+  completed,
+  anomalies,
+  tests_pass: verify.tests_pass,
+  gates_pass: verify.gates_pass,
+  verify_output: verify.output_tail,
+};

--- a/workflows/tests/build.behavior.test.mjs
+++ b/workflows/tests/build.behavior.test.mjs
@@ -1,0 +1,379 @@
+// U-004: build.js が Load (fetch -> 決定論 id 収集 -> extract -> validate + id cross-check) /
+// Revalidate / Branch / Code (sonnet) / Audit / Polish / Backlog (source: issue) / Ship の
+// 実行ループになることの行動検証。fail-close 分岐・phase 順・stopped 値 snapshot を自動検証する。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "./run-workflow.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const buildJs = join(here, "..", "build.js");
+
+// ---- fixtures ----
+
+// Plan 節付き issue body。unitIds / testIds は決定論 id 収集の対象になるリテラル。
+const bodyFor = (unitIds, testIds) =>
+  [
+    "Issue の背景説明。",
+    "",
+    "## Plan",
+    "",
+    ...unitIds.map((u) => `### ${u}: unit の見出し`),
+    ...testIds.map((t) => `- ${t}: test scenario`),
+    "",
+    "test_command: echo test",
+    "",
+  ].join("\n");
+
+// think.js validate() 相当 + content 非空検査を通る抽出済み plan。
+const makePlan = (overrides = {}) => ({
+  dir: ".claude/workspace/planning/2026-07-03-sample",
+  outcome: "sample outcome",
+  decisions: [],
+  assumptions: ["assumption-1"],
+  units: [
+    {
+      id: "U-001",
+      goal: "sample goal",
+      files: ["sample.js"],
+      contract: "sample contract",
+      tests: [
+        {
+          id: "T-001",
+          name: "sample spec statement",
+          given: "sample given",
+          when: "sample when",
+          // BDD の given/when/then フィールドであり thenable ではない
+          // oxlint-disable-next-line unicorn/no-thenable
+          then: "sample then",
+        },
+      ],
+      depends_on: [],
+    },
+  ],
+  test_command: "echo test",
+  preconditions: [{ path: "sample.js", pattern: "sampleSymbol" }],
+  backlog_candidates: [],
+  ...overrides,
+});
+
+// agent 呼び出しを schema の形で分類する。label 文字列への結合を避け、
+// FETCH_SCHEMA {found, body} / EXTRACT_SCHEMA (units + preconditions) /
+// REVALIDATE_SCHEMA {results} / BACKLOG {posted} / SHIP {pr_url} を判別する。
+const kindOf = (opts) => {
+  const p = (opts && opts.schema && opts.schema.properties) || null;
+  if (!p) return "plain";
+  if ("found" in p && "body" in p) return "fetch";
+  if ("units" in p) return "extract";
+  if ("results" in p) return "revalidate";
+  if ("posted" in p) return "backlog";
+  if ("pr_url" in p) return "ship";
+  return "plain";
+};
+
+// happy path stub 一式。overrides の kind ごとに差し替える。
+const makeStubs = ({
+  body,
+  plan,
+  revalidate,
+  agentOverrides = {},
+  workflowOverrides = {},
+} = {}) => ({
+  agent: (prompt, opts) => {
+    const kind = kindOf(opts);
+    if (kind in agentOverrides) return agentOverrides[kind](prompt, opts);
+    switch (kind) {
+      case "fetch":
+        return { found: true, body: body ?? bodyFor(["U-001"], ["T-001"]) };
+      case "extract":
+        return plan ?? makePlan();
+      case "revalidate":
+        return (
+          revalidate ?? {
+            results: [{ path: "sample.js", pattern: "sampleSymbol", exists: true, matches: true }],
+          }
+        );
+      case "backlog":
+        return { posted: [], deferred: [] };
+      case "ship":
+        return { committed: true, pr_url: "https://example.com/pr/1" };
+      default:
+        return "feat/sample-branch";
+    }
+  },
+  workflow: (name, wfArgs) => {
+    if (name in workflowOverrides) return workflowOverrides[name](wfArgs);
+    if (name === "code")
+      return { completed: ["U-001"], anomalies: [], tests_pass: true, gates_pass: true };
+    if (name === "audit") return { findings: [], assignments: [] };
+    if (name === "polish")
+      return {
+        codex_available: false,
+        survivors: [],
+        needs_context: [],
+        cleanup: { tests_pass: true },
+      };
+    return {};
+  },
+});
+
+const agentCallsOf = (calls, kind) => calls.agent.filter((c) => kindOf(c.opts) === kind);
+
+// ---- T-012 ----
+test("args 空は stopped: no-issue、Plan 節なし本文は stopped: no-plan で fail-close する", async () => {
+  const empty = await runWorkflow(buildJs, { args: {}, stubs: makeStubs() });
+  assert.equal(empty.result.stopped, "no-issue", "args 空で stopped: no-issue");
+  assert.equal(empty.calls.workflow.length, 0, "no-issue 後に入れ子 workflow が走らない");
+  assert.ok(
+    empty.calls.phase.every((p) => p === "Load"),
+    "no-issue 後に Load 以外の phase が走らない",
+  );
+
+  const noPlan = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ body: "Plan 見出しの無い issue 本文。\n\n## Context\n\n説明のみ。" }),
+  });
+  assert.equal(noPlan.result.stopped, "no-plan", "## Plan 見出し無しで stopped: no-plan");
+  assert.equal(noPlan.calls.workflow.length, 0, "no-plan 後に入れ子 workflow が走らない");
+  assert.equal(
+    agentCallsOf(noPlan.calls, "extract").length,
+    0,
+    "Plan 見出し検査は extract agent より前に走る (決定論)",
+  );
+});
+
+// ---- T-013 ----
+test("構造欠陥と content 空 (contract / given) はいずれも stopped: invalid-plan になる", async () => {
+  const variants = [
+    { plan: makePlan({ units: [] }), expect: /units/ },
+    {
+      plan: makePlan({
+        units: [{ ...makePlan().units[0], contract: "" }],
+      }),
+      expect: /contract/,
+    },
+    {
+      plan: makePlan({
+        units: [
+          {
+            ...makePlan().units[0],
+            tests: [{ ...makePlan().units[0].tests[0], given: "" }],
+          },
+        ],
+      }),
+      expect: /given/,
+    },
+  ];
+  for (const { plan, expect } of variants) {
+    const { result } = await runWorkflow(buildJs, {
+      args: { issue: "123" },
+      stubs: makeStubs({ plan }),
+    });
+    assert.equal(result.stopped, "invalid-plan", `variant ${expect} で stopped: invalid-plan`);
+    assert.ok(Array.isArray(result.blockers), "blockers が配列で返る");
+    assert.ok(
+      result.blockers.some((b) => expect.test(String(b))),
+      `blockers に ${expect} を含むエラー文言が載る`,
+    );
+  }
+});
+
+// ---- T-014 ----
+test("抽出での unit / test の silent drop は stopped: extraction-mismatch で決定論検出される", async () => {
+  const body = bodyFor(["U-001", "U-002"], ["T-001", "T-002", "T-003"]);
+  const base = makePlan().units[0];
+
+  // case A: unit U-002 を silent drop (test id は全部返す)
+  const unitDrop = makePlan({
+    units: [
+      {
+        ...base,
+        tests: [
+          { ...base.tests[0], id: "T-001" },
+          { ...base.tests[0], id: "T-002" },
+          { ...base.tests[0], id: "T-003" },
+        ],
+      },
+    ],
+  });
+  const a = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ body, plan: unitDrop }),
+  });
+  assert.equal(
+    a.result.stopped,
+    "extraction-mismatch",
+    "unit drop で stopped: extraction-mismatch",
+  );
+  assert.ok(
+    JSON.stringify(a.result.detail).includes("U-002"),
+    "不一致 unit id U-002 が detail に載る",
+  );
+
+  // case B: test id T-003 を 1 件 silent drop (unit id は全部返す)
+  const testDrop = makePlan({
+    units: [
+      { ...base, tests: [{ ...base.tests[0], id: "T-001" }] },
+      {
+        ...base,
+        id: "U-002",
+        tests: [{ ...base.tests[0], id: "T-002" }],
+      },
+    ],
+  });
+  const b = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ body, plan: testDrop }),
+  });
+  assert.equal(
+    b.result.stopped,
+    "extraction-mismatch",
+    "test drop で stopped: extraction-mismatch",
+  );
+  assert.ok(
+    JSON.stringify(b.result.detail).includes("T-003"),
+    "不一致 test id T-003 が detail に載る",
+  );
+});
+
+// ---- T-015 ----
+test("Revalidate は 1 miss で stopped: plan-drift、全 pass で Branch へ進み、preconditions 空なら agent を呼ばない", async () => {
+  // miss case: exists: false を 1 件含む
+  const driftPlan = makePlan({
+    preconditions: [
+      { path: "sample.js", pattern: "sampleSymbol" },
+      { path: "missing.js", pattern: "goneSymbol" },
+    ],
+  });
+  const miss = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({
+      plan: driftPlan,
+      revalidate: {
+        results: [
+          { path: "sample.js", pattern: "sampleSymbol", exists: true, matches: true },
+          { path: "missing.js", pattern: "goneSymbol", exists: false, matches: false },
+        ],
+      },
+    }),
+  });
+  assert.equal(miss.result.stopped, "plan-drift", "1 miss で stopped: plan-drift");
+  assert.ok(
+    JSON.stringify(miss.result).includes("missing.js"),
+    "drift 一覧に miss した path が載る",
+  );
+  assert.ok(!miss.calls.phase.includes("Branch"), "plan-drift 後に Branch へ進まない");
+
+  // all-pass case: Branch phase に到達する
+  const pass = await runWorkflow(buildJs, { args: { issue: "123" }, stubs: makeStubs() });
+  assert.ok(pass.calls.phase.includes("Branch"), "全 pass で Branch phase に到達する");
+
+  // 空 case: revalidate agent が呼ばれず Branch に到達する
+  const empty = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ plan: makePlan({ preconditions: [] }) }),
+  });
+  assert.equal(
+    agentCallsOf(empty.calls, "revalidate").length,
+    0,
+    "preconditions 空で revalidate agent が呼ばれない",
+  );
+  assert.ok(empty.calls.phase.includes("Branch"), "preconditions 空でも Branch phase に到達する");
+});
+
+// ---- T-016 ----
+test("happy path の phase 順が Load → Revalidate → Branch → Code → Audit → Polish → Backlog → Ship で、code に model: sonnet が渡り challenge / think / research が呼ばれない", async () => {
+  const { calls } = await runWorkflow(buildJs, { args: { issue: "123" }, stubs: makeStubs() });
+
+  assert.deepEqual(
+    calls.phase,
+    ["Load", "Revalidate", "Branch", "Code", "Audit", "Polish", "Backlog", "Ship"],
+    "phase 順が Load → Revalidate → Branch → Code → Audit → Polish → Backlog → Ship",
+  );
+
+  const codeCalls = calls.workflow.filter((c) => c.name === "code");
+  assert.equal(codeCalls.length, 1, "workflow('code') が 1 回呼ばれる");
+  assert.equal(codeCalls[0].args.model, "sonnet", "code に model: sonnet が渡る");
+  assert.ok(
+    !("preconditions" in codeCalls[0].args.plan),
+    "code へ渡す plan から preconditions が strip される",
+  );
+
+  const names = new Set(calls.workflow.map((c) => c.name));
+  assert.deepEqual(
+    [...names].sort(),
+    ["audit", "code", "polish"],
+    "workflow capture に code / audit / polish のみが現れる",
+  );
+  for (const banned of ["challenge", "think", "research"]) {
+    assert.ok(!names.has(banned), `workflow('${banned}') が呼ばれない`);
+  }
+});
+
+// ---- T-017 ----
+test("stopped 値集合の snapshot が 9 値と exact match し Explore agent が残っていない", () => {
+  const source = readFileSync(buildJs, "utf8");
+  const stopped = new Set();
+  for (const m of source.matchAll(/stopped:\s*"([^"]+)"/g)) stopped.add(m[1]);
+  assert.deepEqual(
+    [...stopped].sort(),
+    [
+      "code-failed",
+      "extraction-failed",
+      "extraction-mismatch",
+      "invalid-plan",
+      "no-issue",
+      "no-issue-body",
+      "no-plan",
+      "plan-drift",
+      "revalidate-failed",
+    ],
+    "stopped リテラル集合が 9 値と exact match する",
+  );
+  const explore = source.match(/agentType:\s*"Explore"/g) || [];
+  assert.equal(explore.length, 0, 'agentType: "Explore" が 0 件');
+});
+
+// ---- T-018 ----
+test("Backlog 候補源が source: issue に復帰し challenge / think / plan-gate 由来が消えている", async () => {
+  const plan = makePlan({
+    backlog_candidates: [{ summary: "issue 由来の scope 外候補" }],
+  });
+  const { calls } = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ plan }),
+  });
+
+  const backlogCalls = agentCallsOf(calls, "backlog");
+  assert.equal(backlogCalls.length, 1, "backlog agent が 1 回呼ばれる");
+  assert.match(
+    backlogCalls[0].prompt,
+    /source['"]?\s*:\s*['"]?issue/,
+    "backlog prompt に source: issue の候補が含まれる",
+  );
+  assert.ok(
+    backlogCalls[0].prompt.includes("issue 由来の scope 外候補"),
+    "backlog prompt に extract 由来の候補 summary が含まれる",
+  );
+
+  const source = readFileSync(buildJs, "utf8");
+  for (const banned of ["challenge", "think", "plan-gate"]) {
+    const hits = source.match(new RegExp(`source:\\s*"${banned}"`, "g")) || [];
+    assert.equal(hits.length, 0, `source: "${banned}" が build.js に 0 件`);
+  }
+});
+
+// ---- T-019 (manual acceptance、done 前必須) ----
+test("実環境で Plan 節付き issue が Load → Revalidate → Branch → Code と進み、Plan 節なし issue が stopped: no-plan を返す (manual acceptance、done 前必須)", () => {
+  // harness green だけで完了にしないための manual gate。実際に build workflow を
+  // Plan 節付き / Plan 節なしの実 issue で起動し、前者の phase log が
+  // Load → Revalidate → Branch → Code の順に出て後者が stopped: no-plan を返すことを
+  // 確認したら U004_MANUAL_ACCEPTANCE=pass を付けてテストを実行する。
+  assert.equal(
+    process.env.U004_MANUAL_ACCEPTANCE,
+    "pass",
+    "manual acceptance 未実施。実 issue で build workflow を起動して確認後、U004_MANUAL_ACCEPTANCE=pass で再実行する",
+  );
+});

--- a/workflows/tests/code.model.test.mjs
+++ b/workflows/tests/code.model.test.mjs
@@ -1,0 +1,95 @@
+// U-003: behavior test that code.js propagates an optional input.model only to the
+// Red / Green implementation agents.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "./run-workflow.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "..", "..");
+const codeJs = join(here, "..", "code.js");
+
+const plan = {
+  test_command: "echo test",
+  units: [
+    {
+      id: "U-1",
+      goal: "sample goal",
+      files: ["sample.js"],
+      contract: "sample contract",
+      depends_on: [],
+      tests: [],
+    },
+  ],
+};
+
+// red / green fail on the first call to fire the retries (red2 / green2), so all
+// 4 calls (red, red2, green, green2) get captured.
+const retryingAgentStub = (prompt, opts) => {
+  const label = opts.label ?? "";
+  if (label.startsWith("red2:"))
+    return { red_confirmed: true, test_files: ["t.test.js"], notes: "" };
+  if (label.startsWith("red:"))
+    return { red_confirmed: false, test_files: [], notes: "passed unexpectedly" };
+  if (label.startsWith("green2:")) return { green: true, notes: "" };
+  if (label.startsWith("green:")) return { green: false, notes: "still failing" };
+  if (label === "verify") return { tests_pass: true, gates_pass: true, output_tail: "" };
+  throw new Error(`unexpected label: ${label}`);
+};
+
+// red / green both succeed on the first call.
+const happyAgentStub = (prompt, opts) => {
+  const label = opts.label ?? "";
+  if (label.startsWith("red:"))
+    return { red_confirmed: true, test_files: ["t.test.js"], notes: "" };
+  if (label.startsWith("green:")) return { green: true, notes: "" };
+  if (label === "verify") return { tests_pass: true, gates_pass: true, output_tail: "" };
+  throw new Error(`unexpected label: ${label}`);
+};
+
+test("model 指定時に Red / Green とその retry の 4 呼び出しへ伝播し Verify へは渡らない", async () => {
+  const { calls } = await runWorkflow(codeJs, {
+    args: { plan, repo: "", model: "sonnet" },
+    stubs: { agent: retryingAgentStub },
+  });
+
+  const redGreen = calls.agent.filter((c) => /^(red|red2|green|green2):/.test(c.opts.label));
+  assert.equal(redGreen.length, 4, "red / red2 / green / green2 calls are all present");
+  for (const call of redGreen) {
+    assert.equal(call.opts.model, "sonnet", `${call.opts.label} opts carries model: "sonnet"`);
+  }
+
+  const verify = calls.agent.find((c) => c.opts.label === "verify");
+  assert.ok(verify, "verify call is present");
+  assert.ok(!("model" in verify.opts), "verify opts has no model key");
+});
+
+test("model 未指定で agent opts に model キーが存在せず既存呼び出し形が完走する", async () => {
+  const { result, calls } = await runWorkflow(codeJs, {
+    args: { plan, repo: "" },
+    stubs: { agent: happyAgentStub },
+  });
+
+  for (const call of calls.agent) {
+    assert.ok(!("model" in call.opts), `${call.opts.label} opts has no model key`);
+  }
+  assert.deepEqual(result.completed, ["U-1"], "completed contains the unit id");
+  assert.equal(result.tests_pass, true, "verify tests_pass is returned as-is");
+});
+
+test("静的 gate が JA / EN の code.js と tests/*.mjs で pass する", () => {
+  const targets = [
+    join(root, ".ja", "workflows", "code.js"),
+    join(root, "workflows", "code.js"),
+    join(root, ".ja", "workflows", "tests", "run-workflow.mjs"),
+    join(root, "workflows", "tests", "run-workflow.mjs"),
+    join(root, ".ja", "workflows", "tests", "code.model.test.mjs"),
+    join(root, "workflows", "tests", "code.model.test.mjs"),
+  ];
+  for (const file of targets) {
+    execFileSync("node", ["--check", file], { cwd: root });
+  }
+  execFileSync("npx", ["oxlint", ...targets], { cwd: root });
+});

--- a/workflows/tests/index.js
+++ b/workflows/tests/index.js
@@ -1,0 +1,12 @@
+// Node v26 does not scan directories passed to `node --test <dir>`; it spawns them as entry modules.
+// This index is the directory's module entry point and loads every *.test.js / *.test.mjs beneath it.
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+for (const name of readdirSync(here)
+  .filter((f) => f.endsWith(".test.js") || f.endsWith(".test.mjs"))
+  .sort()) {
+  await import(pathToFileURL(join(here, name)).href);
+}

--- a/workflows/tests/issue-skill.test.js
+++ b/workflows/tests/issue-skill.test.js
@@ -1,0 +1,103 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const targets = {
+  ja: join(root, ".ja", "skills", "issue", "SKILL.md"),
+  en: join(root, "skills", "issue", "SKILL.md"),
+};
+const planSectionRefs = {
+  ja: join(root, ".ja", "skills", "issue", "references", "plan-section.md"),
+  en: join(root, "skills", "issue", "references", "plan-section.md"),
+};
+
+function read(path) {
+  assert.ok(existsSync(path), `${path} が存在する`);
+  return readFileSync(path, "utf8");
+}
+
+function executionSection(doc, heading) {
+  const start = doc.indexOf(`\n${heading}\n`);
+  assert.ok(start >= 0, `${heading} 節がある`);
+  const rest = doc.slice(start + heading.length + 2);
+  const end = rest.indexOf("\n## ");
+  return end >= 0 ? rest.slice(0, end) : rest;
+}
+
+function countSteps(section) {
+  return section.split("\n").filter((line) => /^\d+\.\s/.test(line)).length;
+}
+
+test("フロー順が challenge → research → think → plan 書き下ろし → preview → 起票 の順である", () => {
+  const exec = executionSection(read(targets.ja), "## 実行");
+  const order = ["challenge", "research", "think", "書き下ろし", "プレビュー", "起票"];
+  const indexes = order.map((keyword) => exec.indexOf(keyword));
+  order.forEach((keyword, i) => {
+    assert.ok(indexes[i] >= 0, `実行リストに ${keyword} がある`);
+  });
+  for (let i = 1; i < order.length; i++) {
+    assert.ok(indexes[i - 1] < indexes[i], `${order[i - 1]} が ${order[i]} より先に現れる`);
+  }
+});
+
+test("research / think のループ上限 2 回と上限到達時の扱いが明記されている", () => {
+  const ja = read(targets.ja);
+  assert.match(ja, /unresearchable[\s\S]{0,160}最大 2 回/, "ja: unresearchable 壁打ち最大 2 回");
+  assert.match(ja, /ready\s*=\s*false[\s\S]{0,160}最大 2 回/, "ja: ready=false 決着最大 2 回");
+  assert.match(ja, /仮マーク[^。]{0,20}残/, "ja: 上限到達時の仮マーク残置");
+  assert.match(ja, /ユーザー[^。]{0,20}委ね/, "ja: 上限到達時のユーザー委任");
+});
+
+test("skip 分岐が基準・該当例・非該当例・/fix フッター注記付きで定義されている", () => {
+  const ja = read(targets.ja);
+  assert.match(
+    ja,
+    /docs[\s\S]{0,60}chore[\s\S]{0,200}(飛ばす|飛ばし|スキップ)/,
+    "ja: docs / chore スキップ",
+  );
+  assert.match(
+    ja,
+    /research[^。]{0,20}think[^。]{0,60}(飛ばす|飛ばし|スキップ)/,
+    "ja: research / think を飛ばす",
+  );
+  assert.match(ja, /1 ファイル/, "ja: 軽微 bug 基準 1 ファイル");
+  assert.match(ja, /再現[^。]{0,10}確定/, "ja: 軽微 bug 基準 再現確定");
+  assert.match(ja, /横断調査[^。]{0,10}不要/, "ja: 軽微 bug 基準 横断調査不要");
+  assert.match(ja, /typo/, "ja: 該当例 typo 修正");
+  assert.match(ja, /(intermittent|間欠)/, "ja: 非該当例 intermittent bug");
+  assert.match(ja, /原因未特定/, "ja: 非該当例 原因未特定");
+  assert.match(ja, /\/fix で処理/, "ja: /fix で処理 注記");
+  assert.match(ja, /フッター/, "ja: フッター注記");
+});
+
+test("round-trip fidelity check が突合フィールドと書き直し上限付きで手順化されている", () => {
+  const ja = read(targets.ja);
+  assert.match(ja, /突合/, "ja: think plan との突合");
+  assert.match(ja, /unit id/, "ja: 突合フィールド unit id 集合");
+  assert.match(ja, /depends_on/, "ja: 突合フィールド depends_on");
+  assert.match(ja, /test id/, "ja: 突合フィールド test id 集合");
+  assert.match(ja, /(test name|テスト名)/, "ja: 突合フィールド test name");
+  assert.match(ja, /test_command/, "ja: 突合フィールド test_command");
+  assert.match(
+    ja,
+    /(書き直し[^。]{0,40}最大 2 回|最大 2 回[^。]{0,40}書き直)/,
+    "ja: 不一致時の書き直し最大 2 回",
+  );
+  assert.match(ja, /ユーザーに提示/, "ja: 解消しなければユーザーに提示");
+});
+
+test("EN ミラーが JA と構造 parity を保つ", () => {
+  const jaSteps = countSteps(executionSection(read(targets.ja), "## 実行"));
+  const enSteps = countSteps(executionSection(read(targets.en), "## Execution"));
+  assert.equal(jaSteps, 15, "ja: 実行 step が 15");
+  assert.equal(enSteps, jaSteps, "en: 実行 step 数が JA と同数");
+  const en = read(targets.en);
+  assert.match(en, /Plan/, "en: Plan 節への言及");
+  assert.match(en, /Backlog candidates/, "en: Backlog candidates 節への言及");
+  assert.match(en, /plan-section\.md/, "en: plan-section.md 参照");
+  assert.ok(existsSync(planSectionRefs.ja), "ja: references/plan-section.md が存在");
+  assert.ok(existsSync(planSectionRefs.en), "en: references/plan-section.md が存在");
+});

--- a/workflows/tests/plan-section.test.js
+++ b/workflows/tests/plan-section.test.js
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const targets = {
+  ja: join(root, ".ja", "skills", "issue", "references", "plan-section.md"),
+  en: join(root, "skills", "issue", "references", "plan-section.md"),
+};
+
+function read(path) {
+  assert.ok(existsSync(path), `${path} が存在する`);
+  return readFileSync(path, "utf8");
+}
+
+test("plan-section.md が Plan 節の構成 (id 記法・前提小節・受け入れテスト・test_command・Backlog candidates) を定義している", () => {
+  for (const [lang, path] of Object.entries(targets)) {
+    const doc = read(path);
+    assert.match(doc, /### U-/, `${lang}: ### U- 記法`);
+    assert.match(doc, /T-NNN/, `${lang}: T-NNN 記法`);
+    if (lang === "ja") {
+      assert.match(doc, /^### 前提/m, "ja: 前提小節");
+    } else {
+      assert.match(doc, /^### Preconditions/m, "en: Preconditions 小節");
+    }
+    assert.match(doc, /given/i, `${lang}: given`);
+    assert.match(doc, /when/i, `${lang}: when`);
+    assert.match(doc, /then/i, `${lang}: then`);
+    assert.match(doc, /test_command/, `${lang}: test_command の置き場`);
+    assert.match(doc, /^## Backlog candidates/m, `${lang}: ## Backlog candidates`);
+  }
+});
+
+test("precondition の authoring 規則が stable anchor と投稿前実在検証を含む", () => {
+  const ja = read(targets.ja);
+  assert.match(ja, /既存.{0,10}依存先のみ/, "ja: 既存依存先のみ");
+  assert.match(ja, /新規作成ファイル.{0,20}載せない/, "ja: 新規作成ファイルは載せない");
+  assert.match(ja, /stable anchor/, "ja: stable anchor");
+  assert.match(ja, /(exported|公開シンボル)/, "ja: exported / 公開シンボル名");
+  assert.match(
+    ja,
+    /安定.{0,10}シンボルが無ければ.{0,10}path のみ/,
+    "ja: 安定シンボルが無ければ path のみ",
+  );
+  assert.match(ja, /test -f/, "ja: test -f 実在検証");
+  assert.match(ja, /ugrep -F/, "ja: ugrep -F 実在検証");
+
+  const en = read(targets.en);
+  assert.match(en, /existing dependenc/i, "en: existing dependencies only");
+  assert.match(en, /newly created/i, "en: do not list newly created files");
+  assert.match(en, /stable anchor/i, "en: stable anchor");
+  assert.match(en, /exported/i, "en: exported / public symbol");
+  assert.match(en, /path only/i, "en: path only fallback");
+  assert.match(en, /test -f/, "en: test -f existence check");
+  assert.match(en, /ugrep -F/, "en: ugrep -F existence check");
+});
+
+test("抽出 contract が共有可能で machine block の残骸が無い", () => {
+  const fields = [
+    /\bdir\b/,
+    /\boutcome\b/,
+    /\bdecisions\b/,
+    /\bassumptions\b/,
+    /\bnon_goals\b/,
+    /\bconstraints\b/,
+    /\bunits\b/,
+    /\bid\b/,
+    /\bgoal\b/,
+    /\bfiles\b/,
+    /\bcontract\b/,
+    /\btests\b/,
+    /\bname\b/,
+    /\bgiven\b/,
+    /\bwhen\b/,
+    /\bthen\b/,
+    /\bdepends_on\b/,
+    /\btest_command\b/,
+    /\bpreconditions\b/,
+    /\bpath\b/,
+    /\bpattern\b/,
+    /\bbacklog_candidates\b/,
+  ];
+  for (const [lang, path] of Object.entries(targets)) {
+    const doc = read(path);
+    for (const field of fields) {
+      assert.match(doc, field, `${lang}: 抽出 contract フィールド ${field}`);
+    }
+    assert.ok(!doc.includes("build-plan:v1"), `${lang}: build-plan:v1 残骸なし`);
+    assert.ok(!doc.includes("<details>"), `${lang}: <details> 残骸なし`);
+    assert.ok(!doc.includes("```json"), `${lang}: json fence 指定なし`);
+  }
+});

--- a/workflows/tests/run-workflow.mjs
+++ b/workflows/tests/run-workflow.mjs
@@ -1,0 +1,38 @@
+// Harness for behavior-testing workflow scripts (workflows/*.js) from node:test.
+// Scripts are written as `export const meta` + top-level return + injected globals
+// (agent/workflow/parallel/phase/log), so they cannot run via ESM import.
+// Replacing the source's `export const meta` with `const meta` and executing it as
+// an AsyncFunction body reproduces both the top-level return and the injected globals.
+import { readFileSync } from "node:fs";
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+// runWorkflow(scriptPath, { args, stubs }) -> { result, calls, logs }
+// stubs.agent / stubs.workflow receive (prompt|name, opts|args) and return the stub result.
+// calls captures the agent / workflow / phase invocations.
+export async function runWorkflow(scriptPath, { args = {}, stubs = {} } = {}) {
+  const source = readFileSync(scriptPath, "utf8").replace(/^export const meta/m, "const meta");
+  const calls = { agent: [], workflow: [], phase: [] };
+  const logs = [];
+
+  const agent = async (prompt, opts = {}) => {
+    calls.agent.push({ prompt, opts });
+    return stubs.agent ? stubs.agent(prompt, opts) : undefined;
+  };
+  const workflow = async (name, wfArgs) => {
+    calls.workflow.push({ name, args: wfArgs });
+    return stubs.workflow ? stubs.workflow(name, wfArgs) : undefined;
+  };
+  const parallel = async (tasks) =>
+    Promise.all(tasks.map((t) => (typeof t === "function" ? t() : t)));
+  const phase = (title) => {
+    calls.phase.push(title);
+  };
+  const log = (message) => {
+    logs.push(message);
+  };
+
+  const run = new AsyncFunction("args", "agent", "workflow", "parallel", "phase", "log", source);
+  const result = await run(args, agent, workflow, parallel, phase, log);
+  return { result, calls, logs };
+}


### PR DESCRIPTION
## 概要

/issue を refine の受け皿として拡張し、challenge GO 後に research / think を回して自然言語の Plan 節 (U-NNN / T-NNN 記法) を issue 本文へ書き下ろす 15 step にする。build.js は issue 番号だけを受ける実行ループ (Load / Revalidate / Branch / Code / Audit / Polish / Backlog / Ship) へ縮小する。

## 背景

AI コーディングで実装は速くなる分、ボトルネックは人間の計画とレビューに寄る。計画 (なぜ / なにを / どう作るか) は /issue で人間と決着させ、実装ループは sonnet 指定の headless build で完走させる分業にする。

## 変更点

| 対象 | 変更 |
| --- | --- |
| skills/issue | 15 step 化。research (壁打ち最大 2 回) / think (決着最大 2 回) / plan 書き下ろし + round-trip fidelity check + 前提実在検証。docs / chore / 軽微 bug は skip し /fix 導線を注記 |
| skills/issue/references/plan-section.md | Plan 節フォーマット、前提の stable anchor 規則、抽出 contract を codify (issue と build の共有 source) |
| workflows/build.js | challenge / think / Research (Explore 2 体) を削除。Load は fetch (verbatim) → 決定論 id 収集 → extract → validate + id 集合 cross-check の fail-close。Revalidate は evidence agent + script gate (1 miss → stopped: plan-drift) |
| workflows/code.js | input.model を Red / Green とその retry の 4 呼び出しにのみ伝播。Verify は据え置き (cross-model decorrelation) |
| workflows/tests/ | 行動 harness (node --test)。fail-close 分岐 / phase 順 / stopped 9 値 snapshot / model 伝播 / markdown 構造を検証。JA / EN 両方を回し EN parity を兼ねる |

## テスト

- node --check + oxlint 全対象 pass
- node --test 36/38 pass。red は T-019 の manual acceptance gate のみ (`U004_MANUAL_ACCEPTANCE=pass` で 38/38)
- T-019 no-plan 側は実 issue #128 で `stopped: "no-plan"` を観測済み (fetch 1 agent、後続 phase なし)
- T-019 Plan 節あり側 (Load → Revalidate → Branch → Code の実走) は次の実 issue の build 実走で観測する。観測までこの PR は draft

https://claude.ai/code/session_01BicnvsGohHhocvKMZKRpiN