### PR TITLE
fix(issue-gate): issue skill に consume 用 PostToolUse:Bash recorder を追加

### DIFF
--- a/.ja/skills/issue/SKILL.md
+++ b/.ja/skills/issue/SKILL.md
@@ -12,6 +12,10 @@ hooks:
         - type: command
           command: "~/.claude/hooks/issue-gate/pre-issue-create.sh"
   PostToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "~/.claude/hooks/issue-gate/record.sh bash"
     - matcher: "AskUserQuestion"
       hooks:
         - type: command

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -12,6 +12,10 @@ hooks:
         - type: command
           command: "~/.claude/hooks/issue-gate/pre-issue-create.sh"
   PostToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "~/.claude/hooks/issue-gate/record.sh bash"
     - matcher: "AskUserQuestion"
       hooks:
         - type: command


### PR DESCRIPTION
## 変更内容

issue skill の frontmatter hooks に `matcher: Bash` → `record.sh bash` の PostToolUse を追加する (.ja canonical + EN mirror 同一コミット)。

## 理由

#162 の settings.json → frontmatter 移行で record.sh bash を challenge / think にのみ配線した。しかし成功した `gh issue create` を拾って bundle / skip を consume する記録は issue skill のコンテキストの Bash 呼び出しで発火する必要があり、配線漏れで single-use が破れていた。

## 実測根拠

throwaway repo (thkt/statuskit-issue-gate-e2e) での e2e allow 検証にて、skip 記録 1 件で同一 title の create が 2 回 allow され issue が重複作成された (consume 記録が audit.jsonl に書かれない)。bats T-019 / T-023 は recorder 直叩きのため配線漏れを検出できない。

## 検証

- 修正はローカルの新 session で skip → create → replay deny の順で実測予定 (frontmatter hooks は session-start snapshot のため本 session では検証不可)
- 既存 bats 14 tests はロジック未変更のため影響なし

https://claude.ai/code/session_01XqSNoa3XkWMz5VGtsiKgys