### PR TITLE
veto helpers.bash に SC2034 の shellcheck disable を追加

### DIFF
--- a/.ja/hooks/veto/tests/helpers.bash
+++ b/.ja/hooks/veto/tests/helpers.bash
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2034  # VETO/PRE/AUDIT は load 先の .bats が参照する
 # veto bats スイート共通 setup: スクリプトパス + テストごとの新規 audit store。
 # `load helpers` で読み込む。各スイートの setup() が common_setup を呼んでから FIX dir を足す。
 common_setup() {

--- a/hooks/veto/tests/helpers.bash
+++ b/hooks/veto/tests/helpers.bash
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2034  # VETO/PRE/AUDIT are referenced by the .bats files that load this
 # Shared setup for the veto bats suites: script paths + a fresh per-test audit store.
 # Loaded via `load helpers`; each suite's setup() calls common_setup then adds its FIX dir.
 common_setup() {


### PR DESCRIPTION
## 概要と目的

veto の bats 共通 setup (helpers.bash) に SC2034 の shellcheck disable コメントを追加する。VETO/PRE/AUDIT 変数は load 先の .bats ファイルが参照するため、未使用警告は誤検出であり、これを抑止する。

## 変更内容

- `.ja/hooks/veto/tests/helpers.bash` と `hooks/veto/tests/helpers.bash` の先頭に `# shellcheck disable=SC2034` を理由コメント付きで追加 (JA/EN ミラー同時更新)

## テスト方法

1. `shellcheck hooks/veto/tests/helpers.bash` を実行
2. SC2034 警告が出ないことを確認

https://claude.ai/code/session_014Xtc9hEm8gqcGPTRSGWPHp