### PR TITLE
style(workflows): agent prompt を MARKDOWN.md 規約に準拠させる

### DIFF
--- a/.guardrails.json
+++ b/.guardrails.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "sqliConcat": false
+  }
+}

--- a/.ja/workflows/adrift.js
+++ b/.ja/workflows/adrift.js
@@ -44,11 +44,7 @@ const repo = typeof opts.repo === "string" ? opts.repo : "";
 
 // focus は id ("0061" / "ADR-0061") またはキーワードの列。配列と文字列の両方を受ける。
 // id は数値一致、非数値はファイル名 / タイトルへの部分一致で照合する。
-const focus = (
-  Array.isArray(opts.focus)
-    ? opts.focus
-    : String(opts.focus || "").split(/[\s,]+/)
-)
+const focus = (Array.isArray(opts.focus) ? opts.focus : String(opts.focus || "").split(/[\s,]+/))
   .map((t) =>
     String(t)
       .trim()
@@ -79,13 +75,13 @@ const REVIEWERS = {
 // (プレーン文字列 const にするのは guardrails sqli-concat が call 引数の補間 template 内の
 // キーワード語を誤検知するため)。
 const DIRECTION_RULES =
-  "code-fix: ADR が現契約として正しく、コードが drift している / " +
-  "adr-update: コードが現契約として正しく、ADR が陳腐化している / " +
-  "accept: drift が些末、非推奨コメント済み、またはドキュメント済み";
+  "code-fix は ADR が現契約として正しくコードが drift しているとき / " +
+  "adr-update はコードが現契約として正しく ADR が陳腐化しているとき / " +
+  "accept は drift が些末、非推奨コメント済み、またはドキュメント済みのとき";
 const PRIORITY_RULES =
-  "H: 公開 API に影響、または下流利用側が 2 つ以上 / " +
-  "M: 内部 API に影響、下流利用側は 1 つ / " +
-  "L: コメント / docstring のみ、または無効な参照";
+  "H は公開 API に影響するか下流利用側が 2 つ以上のとき / " +
+  "M は内部 API に影響し下流利用側が 1 つのとき / " +
+  "L はコメント / docstring のみか無効な参照のとき";
 const PRIORITY_RANK = { H: 3, M: 2, L: 1 };
 
 const DETECT_SCHEMA = {
@@ -111,8 +107,7 @@ const DETECT_SCHEMA = {
     manifest: { type: "string", enum: ["rust", "ts", "tsx", "other"] },
     adr_refs: {
       type: "array",
-      description:
-        "ADR ディレクトリ外で見つかった ADR-NNNN 参照の生リスト (分類は script が行う)",
+      description: "ADR ディレクトリ外で見つかった ADR-NNNN 参照の生リスト (分類は script が行う)",
       items: {
         type: "object",
         additionalProperties: false,
@@ -200,8 +195,7 @@ const mergeFindings = (lists) => {
   for (const f of lists.flat()) {
     const k = `${f.file}:${f.line}`;
     const prev = map.get(k);
-    if (!prev || PRIORITY_RANK[f.priority] > PRIORITY_RANK[prev.priority])
-      map.set(k, f);
+    if (!prev || PRIORITY_RANK[f.priority] > PRIORITY_RANK[prev.priority]) map.set(k, f);
   }
   return [...map.values()].sort(
     (a, b) =>
@@ -221,7 +215,7 @@ const detect = (await agent(
     `adrift の Detect 段階を担当する。\n` +
       `1. ${dirInstr}\n` +
       `2. ディレクトリ内の NNNN-*.md を列挙し、id (NNNN)、file (相対パス)、title (見出し) を adrs に記録する。\n` +
-      `3. manifest 判定: Cargo.toml があれば rust。package.json があり *.tsx ファイルが存在すれば tsx、無ければ ts。どちらも無ければ other。\n` +
+      `3. manifest を判定する。Cargo.toml があれば rust。package.json があり *.tsx ファイルが存在すれば tsx、無ければ ts。どちらも無ければ other。\n` +
       `4. \`ugrep -rniw 'ADR-[0-9]{4}'\` でリポジトリ全体の ADR 参照を検索し、ADR ディレクトリ自体・fixture・node_modules / target / dist / build / vendor を除外した hit を adr_refs (file, line, id は NNNN の 4 桁) に記録する。ローカル ADR の有無で分類はしない。\n` +
       `ADR 本文の解析はしない。この段階の仕事は検出と列挙だけ。`,
   ),
@@ -339,11 +333,11 @@ const perAdr = await pipeline(
           agent(
             anchor(
               `${rv} として、ADR ${a.id} (${a.title}) の Decision Outcome と現コードの意味的 drift を判定する。clippy や grep で拾える表層ではなく、決定内容と実装の意味的ギャップを見る。\n` +
-                `Decision Outcome:\n${ex.outcome_text}\n\n` +
-                `参照候補 (ugrep hit):\n${JSON.stringify(ex.candidates)}\n\n` +
+                `Decision Outcome は次のとおり。\n${ex.outcome_text}\n\n` +
+                `参照候補 (ugrep hit) は次のとおり。\n${JSON.stringify(ex.candidates)}\n\n` +
                 `各 drift を file:line で特定し、direction と priority を次の基準で付ける。\n` +
-                `direction 基準: ${DIRECTION_RULES}\n` +
-                `priority 基準: ${PRIORITY_RULES}\n` +
+                `direction の基準は ${DIRECTION_RULES}。\n` +
+                `priority の基準は ${PRIORITY_RULES}。\n` +
                 `drift が無ければ findings: [] で返す。ADR 本文の編集もコード修正もしない。`,
             ),
             {
@@ -369,9 +363,7 @@ const perAdr = await pipeline(
 );
 
 const scanned = perAdr.filter(Boolean);
-const allFindings = scanned.flatMap((r) =>
-  r.findings.map((f) => ({ ...f, adr: r.adr.id })),
-);
+const allFindings = scanned.flatMap((r) => r.findings.map((f) => ({ ...f, adr: r.adr.id })));
 const counts = { H: 0, M: 0, L: 0 };
 for (const f of allFindings) counts[f.priority] += 1;
 const unverifiable = scanned.filter((r) => !r.verifiable);
@@ -382,18 +374,18 @@ log(
 // ---- Report: レポート出力 (skill Phase 8。構成は prompt に内包し template を持たない) ----
 phase("Report");
 const focusNote = focus.length
-  ? `Focus スコープ: この実行は focus [${focus.join(", ")}] で対象を ${scanned.length}/${detect.adrs.length} ADR に絞っている。Summary の直後にその旨を 1 行で明記する。\n\n`
+  ? `この実行は focus [${focus.join(", ")}] で対象を ${scanned.length}/${detect.adrs.length} ADR に絞っている。Summary の直後にその旨を 1 行で明記する。\n\n`
   : "";
 const report = (await agent(
   anchor(
     `adrift の Report 段階を担当する。以下の findings JSON から次の構成のレポートを書く。\n` +
-      `手順: \`mkdir -p docs/audit\` の後、\`STAMP=$(date -u +%Y-%m-%d-%H%M%S)\` で docs/audit/\${STAMP}-adr-drift.md に書く。\n` +
-      `構成: 見出しは "# ADR Drift Scan: {STAMP}"。セクションは "## Summary" (Metric | Value の表。行は ADRs scanned / Drift findings / H priority / M priority / L priority / Unverifiable ADRs)、"## Per-ADR Findings"、"## External ADR Dependencies" (File:Line | External ADR ref | Recommended action の表。action は "Promote to local ADR or supersede locally")、"## Follow-up Issue Candidates" (\`- [ ] ADR {id} drift at {file}:{line}: {summary}\` のチェックリスト) の順。\n` +
+      `手順は \`mkdir -p docs/audit\` の後、\`STAMP=$(date -u +%Y-%m-%d-%H%M%S)\` で docs/audit/\${STAMP}-adr-drift.md に書く。\n` +
+      `構成は次のとおり。見出しは "# ADR Drift Scan: {STAMP}"。セクションは "## Summary" (Metric | Value の表。行は ADRs scanned / Drift findings / H priority / M priority / L priority / Unverifiable ADRs)、"## Per-ADR Findings"、"## External ADR Dependencies" (File:Line | External ADR ref | Recommended action の表。action は "Promote to local ADR or supersede locally")、"## Follow-up Issue Candidates" (\`- [ ] ADR {id} drift at {file}:{line}: {summary}\` のチェックリスト) の順。\n` +
       `Per-ADR Findings では drift の無い ADR を "ADRs {ids}: no drift." の 1 行に束ね、drift / unverifiable の ADR にのみ "### ADR {id}: {title}" サブセクション (Status / Result 行 + File:Line | Description | Direction | Priority の表。unverifiable は理由を Result に書き表を省略) を立てる。\n` +
-      `完全性の要件: (1) 全 ADR を Per-ADR Findings に漏れなく記載する。(2) 各 drift に file:line / direction / priority を記録する。(3) superseded な ADR の Status に Superseded を反映する。(4) external_refs が空なら External ADR Dependencies を、H 優先度が 0 件なら Follow-up Issue Candidates を、見出しごと省略する。\n\n` +
+      `完全性の要件は次の 4 つ。(1) 全 ADR を Per-ADR Findings に漏れなく記載する。(2) 各 drift に file:line / direction / priority を記録する。(3) superseded な ADR の Status に Superseded を反映する。(4) external_refs が空なら External ADR Dependencies を、H 優先度が 0 件なら Follow-up Issue Candidates を、見出しごと省略する。\n\n` +
       focusNote +
-      `Summary 件数 (この値をそのまま使う): ADRs scanned=${scanned.length}, findings=${allFindings.length}, H=${counts.H}, M=${counts.M}, L=${counts.L}, unverifiable=${unverifiable.length}\n\n` +
-      `Per-ADR 結果:\n${JSON.stringify(
+      `Summary 件数は次の値をそのまま使う。ADRs scanned=${scanned.length}, findings=${allFindings.length}, H=${counts.H}, M=${counts.M}, L=${counts.L}, unverifiable=${unverifiable.length}\n\n` +
+      `Per-ADR 結果は次のとおり。\n${JSON.stringify(
         scanned.map((r) => ({
           id: r.adr.id,
           title: r.adr.title,
@@ -404,7 +396,7 @@ const report = (await agent(
           findings: r.findings,
         })),
       )}\n\n` +
-      `External ADR 参照 (external_refs):\n${JSON.stringify(externalRefs)}`,
+      `External ADR 参照 (external_refs) は次のとおり。\n${JSON.stringify(externalRefs)}`,
   ),
   {
     agentType: "general-purpose",

--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -78,11 +78,7 @@ const mergeIssues = (findings) => {
       .replace(/^\[|\]$/g, "");
     const sev = SEVERITY_MAP[key] === undefined ? null : SEVERITY_MAP[key];
     if (!sev) continue;
-    const sources = Array.isArray(f.source)
-      ? f.source
-      : f.source
-        ? [f.source]
-        : [];
+    const sources = Array.isArray(f.source) ? f.source : f.source ? [f.source] : [];
     const k = `${f.file || ""}:${f.line || 0}`;
     const prev = groups.get(k);
     if (!prev) {
@@ -121,8 +117,7 @@ const BOOTSTRAP_SCHEMA = {
     scope_files: { type: "array", items: { type: "string" } },
     outcome: {
       type: "string",
-      description:
-        "OUTCOME.md の Behavior / Non-goals / Constraints 要約。不在なら absent",
+      description: "OUTCOME.md の Behavior / Non-goals / Constraints 要約。不在なら absent",
     },
     worktree_ok: { type: "boolean" },
     worktree_path: { type: "string" },
@@ -342,11 +337,7 @@ try {
   // target mode は path を素通しする。audit の Route は git diff ベースなので target mode では
   // 列挙が痩せる可能性がある (既知の制約。Codex review と adversarial は明示 file list で補う)。
   const auditScope =
-    boot.mode === "diff"
-      ? boot.diff_kind === "branch"
-        ? `${base}...HEAD`
-        : ""
-      : scope;
+    boot.mode === "diff" ? (boot.diff_kind === "branch" ? `${base}...HEAD` : "") : scope;
   const codexScopeInstr =
     boot.mode === "target"
       ? `target mode なので scope flag を付けず、対象ファイル一覧を PROMPT で指名して \`codex review "Review these files: ${boot.scope_files.join(", ")}"\` を実行する。`
@@ -373,14 +364,11 @@ try {
           schema: CODEX_REVIEW_SCHEMA,
         },
       );
-      const findings = ((codexReview && codexReview.findings) || []).map(
-        (f) => ({
-          ...f,
-          source: "codex",
-        }),
-      );
-      if (!findings.length)
-        return { codexFindings: findings, challenged: null, verified: null };
+      const findings = ((codexReview && codexReview.findings) || []).map((f) => ({
+        ...f,
+        source: "codex",
+      }));
+      if (!findings.length) return { codexFindings: findings, challenged: null, verified: null };
       // ---- Challenge: Codex findings への challenger ∥ verifier ----
       // 各 agent の opts.phase が Challenge group を指定する。bare phase() は audit thunk と
       // 並走して global phase state を race させるため呼ばない (audit.js の workaround と同旨)。
@@ -389,7 +377,7 @@ try {
         () =>
           agent(
             anchor(
-              `critic-audit として、外部 Codex review の finding を challenge し false positive を刈る。finding は事実ではなく、立証されるべき主張として扱う。各 finding は file:line で参照する。Findings:\n${codexJson}`,
+              `critic-audit として、外部 Codex review の finding を challenge し false positive を刈る。finding は事実ではなく、立証されるべき主張として扱う。各 finding は file:line で参照する。Findings は次のとおり。\n${codexJson}`,
             ),
             {
               agentType: "critic-audit",
@@ -401,7 +389,7 @@ try {
         () =>
           agent(
             anchor(
-              `critic-evidence として、外部 Codex review の finding を検証する。直感ではなく、具体的な実行経路を辿った positive evidence に基づく。各 finding を file:line で参照し、実行経路の evidence と severity を与える。Findings:\n${codexJson}`,
+              `critic-evidence として、外部 Codex review の finding を検証する。直感ではなく、具体的な実行経路を辿った positive evidence に基づく。各 finding を file:line で参照し、実行経路の evidence と severity を与える。Findings は次のとおり。\n${codexJson}`,
             ),
             {
               agentType: "critic-evidence",
@@ -425,9 +413,7 @@ try {
   }));
   log(
     `Evidence: codex ${codexFindings.length} 件 / audit ${auditFindings.length} 件` +
-      (codexReview && codexReview.ran === false
-        ? " (codex review 失敗、audit のみ)"
-        : ""),
+      (codexReview && codexReview.ran === false ? " (codex review 失敗、audit のみ)" : ""),
   );
 
   // ---- Triage: 失敗 adversarial テストの intent 照合 ----
@@ -449,8 +435,8 @@ try {
           agent(
             anchor(
               `assert の intent triage を担当する。失敗した adversarial テスト 1 件が「実バグの発見」か「テスト側の誤った期待」かを判定する。\n` +
-                `テスト: ${JSON.stringify(t)}\n` +
-                `対象コード (${t.target}) を前後 30 行読み、intent source を上から順に探す: .claude/OUTCOME.md、.claude/workspace/planning/ の SOW / Spec、docs/decisions/ 等の ADR、対象ファイルの git log、対象コード近傍 10 行のコメント、対象関数の docstring、README、同関数の既存テスト名。\n` +
+                `テストは次のとおり。${JSON.stringify(t)}\n` +
+                `対象コード (${t.target}) を前後 30 行読み、intent source を上から順に探す。順序は .claude/OUTCOME.md、.claude/workspace/planning/ の SOW / Spec、docs/decisions/ 等の ADR、対象ファイルの git log、対象コード近傍 10 行のコメント、対象関数の docstring、README、同関数の既存テスト名。\n` +
                 `intent source がテストの期待と矛盾すれば exclude (reason に source を引用)、それ以外は promote。`,
             ),
             {
@@ -466,8 +452,7 @@ try {
     advFails.forEach((t, i) => {
       const v = verdicts[i];
       // triage が stall したら fail-close で promote する (見逃しより誤検知を取る)
-      if (v && v.verdict === "exclude")
-        excluded.push({ ...t, reason: v.reason });
+      if (v && v.verdict === "exclude") excluded.push({ ...t, reason: v.reason });
       else
         promoted.push({
           file: (t.target || "").split(":")[0],
@@ -497,13 +482,13 @@ try {
   synth = await agent(
     anchor(
       `enhancer-evidence として、静的 findings、outcome evidence、adversarial 結果を root cause と最終 issues 集合に統合する。\n` +
-        `Outcome 基準 (OUTCOME.md):\n${boot.outcome}\n\n` +
-        `audit workflow の統合済み findings (critic 検証済み。そのまま issues に含める):\n${JSON.stringify(auditFindings)}\n\n` +
-        `Codex findings への challenge pass (membership はこの pass が決める。false positive として刈られた finding は verification pass が evidence を見つけていても復活させない):\n${challenged || "(challenge stall / findings なし)"}\n\n` +
-        `Codex findings への verification pass (survivor への実行経路 evidence と severity 付与のみ):\n${verified || "(verify stall / findings なし)"}\n\n` +
+        `Outcome 基準 (OUTCOME.md) は次のとおり。\n${boot.outcome}\n\n` +
+        `audit workflow の統合済み findings (critic 検証済み。そのまま issues に含める) は次のとおり。\n${JSON.stringify(auditFindings)}\n\n` +
+        `Codex findings への challenge pass (membership はこの pass が決める。false positive として刈られた finding は verification pass が evidence を見つけていても復活させない) は次のとおり。\n${challenged || "(challenge stall / findings なし)"}\n\n` +
+        `Codex findings への verification pass (survivor への実行経路 evidence と severity 付与のみ) は次のとおり。\n${verified || "(verify stall / findings なし)"}\n\n` +
         `${challengeStalled ? "challenger / verifier が双方 stall したため、Codex findings は未検証。issues に含めず report で表面化する。\n\n" : ""}` +
-        `Promoted adversarial findings (そのまま issues に含める):\n${JSON.stringify(promoted)}\n\n` +
-        `動的 evidence: build=${buildCol}, tests=${testsCol}${testRun && testRun.notes ? ` (${testRun.notes})` : ""}\n\n` +
+        `Promoted adversarial findings (そのまま issues に含める) は次のとおり。\n${JSON.stringify(promoted)}\n\n` +
+        `動的 evidence は build=${buildCol}, tests=${testsCol}${testRun && testRun.notes ? ` (${testRun.notes})` : ""}。\n\n` +
         `Constraint 違反や Non-goal 侵犯は出所を問わず issues に同格で含める。report には evidence table (Build / Tests / Issues / Adversarial)、root causes、issue ごとの fix 提案を書く。gate の判定はしない (script が規則で計算する)。`,
     ),
     {
@@ -520,12 +505,7 @@ try {
   // gate 規則 (skill phase-4 § Gate Rule)。build smoke fail / test fail / issues 1 件以上は
   // NotReady。severity は修正優先度のヒントに留まり、gate には影響しない。caveat は動的
   // evidence が env 起因などで欠けたときだけで、issues 0 が前提。
-  if (
-    buildCol === "fail" ||
-    testsCol === "fail" ||
-    issues.length > 0 ||
-    challengeStalled
-  ) {
+  if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
   } else if (!envFail && (testsCol === "pass" || testsCol === "no-runner")) {
     gate = "Ready";
@@ -548,9 +528,7 @@ try {
   );
 }
 
-log(
-  `Gate: ${gate} (build=${buildCol}, tests=${testsCol}, issues=${issues.length})`,
-);
+log(`Gate: ${gate} (build=${buildCol}, tests=${testsCol}, issues=${issues.length})`);
 
 return {
   gate,

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -71,7 +71,7 @@ const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped }) => {
         `\`git rev-parse --abbrev-ref HEAD\` から "branch"、\`date -u +%Y-%m-%dT%H:%M:%SZ\` から "generated_at"。` +
         `さらに "delta" を足す。この run の raw_findings を同ディレクトリで直近の audit-*.json と比較し ` +
         `(file + message でマッチ)、{ resolved, new, carried } を件数で記録する。prior snapshot が無ければ全て 0 とし "first run" と注記する。` +
-        `コードの review や finding の変更はしない。Payload:\n${payload}`,
+        `コードの review や finding の変更はしない。Payload は次のとおり。\n${payload}`,
     ),
     {
       agentType: "general-purpose",
@@ -87,15 +87,7 @@ const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped }) => {
 // heuristic を含む。ファイルは classify() で最初にマッチした行に決まる。型の機械的チェック
 // (any / アサーション / strict モード) は gates のリンタが担い、reviewer は持たない。
 const ROUTING = {
-  "*.sh": [
-    "security",
-    "silence",
-    "duplication",
-    "reuse",
-    "efficiency",
-    "operations",
-    "resilience",
-  ],
+  "*.sh": ["security", "silence", "duplication", "reuse", "efficiency", "operations", "resilience"],
   "*.js": [
     "security",
     "silence",
@@ -213,8 +205,7 @@ const classify = (p) => {
   if (e === ".rs") return ROUTING["*.rs"];
   if (e === ".py") return ROUTING["*.py"];
   if (e === ".md") return ROUTING["*.md"];
-  if (e === ".yaml" || e === ".yml" || e === ".json")
-    return ROUTING["*.yaml,*.json"];
+  if (e === ".yaml" || e === ".yml" || e === ".json") return ROUTING["*.yaml,*.json"];
   if (e === ".css" || e === ".html") return ROUTING["*.css,*.html"];
   return ROUTING.default;
 };
@@ -398,9 +389,9 @@ const raw = await parallel(
     (u) => () =>
       agent(
         anchor(
-          `reviewer-${u.reviewer} として、次のファイルを review する: ${u.files.join(", ")}。` +
+          `reviewer-${u.reviewer} として、次のファイルを review する。対象は ${u.files.join(", ")}。` +
             `review の根拠は \`git diff ${scope || "HEAD"}\` の該当 path に置く。finding には必ず file:line を付け、severity を添えて返す。\n` +
-            `Churn (fix commit の数。多いほど壊れやすい):\n${churnMap}\n\n${RELIABILITY}`,
+            `Churn (fix commit の数。多いほど壊れやすい) は次のとおり。\n${churnMap}\n\n${RELIABILITY}`,
         ),
         {
           agentType: `reviewer-${u.reviewer}`,
@@ -454,7 +445,7 @@ const [challenged, verified] = await parallel([
   () =>
     agent(
       anchor(
-        `critic-audit として、これらの finding を challenge し false positive を刈る。finding は事実ではなく、立証されるべき主張として扱う。各 finding は file:line で参照する。Findings:\n${findingsJson}`,
+        `critic-audit として、これらの finding を challenge し false positive を刈る。finding は事実ではなく、立証されるべき主張として扱う。各 finding は file:line で参照する。Findings は次のとおり。\n${findingsJson}`,
       ),
       {
         agentType: "critic-audit",
@@ -466,7 +457,7 @@ const [challenged, verified] = await parallel([
   () =>
     agent(
       anchor(
-        `critic-evidence として、これらの finding を検証する。直感ではなく、具体的な実行経路を辿った positive evidence に基づく。各 finding を file:line で参照し、実行経路の evidence と severity を与える。Findings:\n${findingsJson}`,
+        `critic-evidence として、これらの finding を検証する。直感ではなく、具体的な実行経路を辿った positive evidence に基づく。各 finding を file:line で参照し、実行経路の evidence と severity を与える。Findings は次のとおり。\n${findingsJson}`,
       ),
       {
         agentType: "critic-evidence",
@@ -482,8 +473,8 @@ const integrated = await agent(
   anchor(
     `enhancer-integration として、同じ findings に対する独立した 2 つの pass を file:line で突き合わせ、cross-domain の root cause と severity 順のリストに reconcile する。\n` +
       `Membership 規則。どの finding を残すかは challenge pass が決める。challenge pass が false positive として刈った finding は、verification pass が evidence を見つけていても刈られたままにする。verification pass の役割は survivor に実行経路の evidence と severity を与えることだけで、刈られた finding を復活させない。\n` +
-      `Challenge pass (membership / false positive の刈り込み):\n${challenged}\n\n` +
-      `Verification pass (実行経路の evidence + severity):\n${verified}`,
+      `Challenge pass (membership / false positive の刈り込み) は次のとおり。\n${challenged}\n\n` +
+      `Verification pass (実行経路の evidence + severity) は次のとおり。\n${verified}`,
   ),
   {
     agentType: "enhancer-integration",

--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -382,30 +382,46 @@ log(
 // チェック (test -f + literal grep) は推論不要で、workflow runtime に無い shell アクセスだけを
 // 要するので、agent は preconditions を流し込んで verifier の stdout をそのまま返すだけの
 // 起動役にする。drift 判定は下の script の filter が持つ。
+// Branch (checkout) とは相互独立 (両者とも plan にしか依存しない) なので並列に走らせる。
+// トレードオフ: Revalidate が drift で stop した場合、checkout 済み branch が残る
+// (作成のみで commit は無いので回収は容易)。stopped return に branch を含めて可視化する。
 phase("Revalidate");
 const preconditions = plan.preconditions || [];
-if (preconditions.length) {
-  const reval = await agent(
-    anchor(
-      `plan の preconditions を決定論 verifier で再検証する。exists/matches を自分で判定しない。` +
-        `手順: (1) この JSON をそのまま temp file に書き出す。(2) repository root から ` +
-        `\`python3 "$HOME/.claude/workflows/build/revalidate.py" < <tempfile>\` を実行する。` +
-        `(3) verifier の stdout "results" 配列を verbatim で返す (全 ${preconditions.length} 件、追加・削除・編集をしない)。` +
-        `verifier は {"results":[{path,pattern,exists,matches}]} を出力する。\n` +
-        `Preconditions JSON:\n${JSON.stringify(preconditions)}`,
+const [reval, branch] = await parallel([
+  () =>
+    preconditions.length
+      ? agent(
+          anchor(
+            `plan の preconditions を決定論 verifier で再検証する。exists/matches を自分で判定しない。` +
+              `手順は、(1) この JSON をそのまま temp file に書き出す。(2) repository root から ` +
+              `\`python3 "$HOME/.claude/workflows/build/revalidate.py" < <tempfile>\` を実行する。` +
+              `(3) verifier の stdout "results" 配列を verbatim で返す (全 ${preconditions.length} 件、追加・削除・編集をしない)。` +
+              `verifier は {"results":[{path,pattern,exists,matches}]} を出力する。\n` +
+              `Preconditions JSON は次のとおり。\n${JSON.stringify(preconditions)}`,
+          ),
+          {
+            label: "revalidate",
+            phase: "Revalidate",
+            agentType: "general-purpose",
+            schema: REVALIDATE_SCHEMA,
+            model: "haiku",
+          },
+        )
+      : Promise.resolve(null),
+  () =>
+    agent(
+      anchor(
+        `issue #${issueNumber} "${plan.outcome}" のための新しい git 作業 branch を checkout する。conventional な branch 名 (type + 短い slug) を選び、その名前で git checkout -b を実行する。既に default branch 以外に居るなら現在の branch を維持する。branch 名を最終テキストで報告する。${guard}`,
+      ),
+      { label: "checkout", phase: "Branch", agentType: "general-purpose", model: "haiku" },
     ),
-    {
-      label: "revalidate",
-      phase: "Revalidate",
-      agentType: "general-purpose",
-      schema: REVALIDATE_SCHEMA,
-      model: "haiku",
-    },
-  );
+]);
+if (preconditions.length) {
   if (!reval || !Array.isArray(reval.results)) {
     return {
       stopped: "revalidate-failed",
       detail: reval,
+      branch,
       why: "revalidate agent が results 配列を返さなかった。",
     };
   }
@@ -424,20 +440,17 @@ if (preconditions.length) {
     return {
       stopped: "plan-drift",
       drift,
+      branch,
       why: "issue の plan が前提とするコードが現在の codebase に無い。issue を更新してから再起動する。",
     };
   }
   log(`revalidate: preconditions ${preconditions.length} 件 全 pass。`);
 }
 
-// ---- Branch: 作業 branch を checkout ----
+// checkout agent は上で Revalidate と並列に実行済み。phase マーカーは drift gate の後で
+// 発火させ、観測可能な trace を Load → Revalidate → Branch → Code に保つ
+// (plan-drift stop は Branch に到達しない)。
 phase("Branch");
-const branch = await agent(
-  anchor(
-    `issue #${issueNumber} "${plan.outcome}" のための新しい git 作業 branch を checkout する。conventional な branch 名 (type + 短い slug) を選び、その名前で git checkout -b を実行する。既に default branch 以外に居るなら現在の branch を維持する。branch 名を最終テキストで報告する。${guard}`,
-  ),
-  { label: "checkout", phase: "Branch", agentType: "general-purpose" },
-);
 
 // ---- Code: workflow("code") に委譲 (unit ごとの Red -> Green + 独立 verify) ----
 // preconditions / backlog_candidates は build 側で消費済みなので、code へは
@@ -491,7 +504,7 @@ for (let round = 1; round <= 3 && toFix.length; round++) {
   log(`fix round ${round}: ${toFix.length} 件を修正。`);
   await agent(
     anchor(
-      `これらの review findings を修正し、テストが通ることを確認する:\n${JSON.stringify(toFix)}`,
+      `これらの review findings を修正し、テストが通ることを確認する。findings は次のとおり。\n${JSON.stringify(toFix)}`,
     ),
     { agentType: "general-purpose", phase: "Audit", label: `fix:${round}` },
   );
@@ -572,10 +585,10 @@ const shipPayload = {
 const ship = await agent(
   anchor(
     `全変更 (planning 成果物 + 実装) を 1 つの Conventional Commits commit にする。commit メッセージは自分で書く (diff を要約する)。` +
-      `branch を push し、draft pull request を開く。body は自分で書く人間向け Summary と、データから決定論生成した事実セクションの 2 部構成にする (事実セクションは手書きしない):\n` +
-      `(1) 人間レビュアー向けの簡潔な "## Summary" を body file に書く — 散文の段落でなく markdown の箇条書きで: この PR が何を実装したか (outcome: ${JSON.stringify(plan.outcome)})、アプローチを 1 行、レビューで注視すべき箇所。最大 5 項目程度、冗長表現も事実の捏造もしない。\n` +
-      `(2) この JSON をそのまま temp file に書き出す:\n${JSON.stringify(shipPayload)}\n` +
-      `(3) 事実 tail の追記と PR 作成を 1 つの \`&&\` チェーンで行い、renderer 失敗時は PR を作る前に中断する — repository root から ` +
+      `branch を push し、draft pull request を開く。body は自分で書く人間向け Summary と、データから決定論生成した事実セクションの 2 部構成にする (事実セクションは手書きしない)。手順は次のとおり。\n` +
+      `(1) 人間レビュアー向けの簡潔な "## Summary" を body file に書く。散文の段落でなく markdown の箇条書きで、この PR が何を実装したか (outcome は ${JSON.stringify(plan.outcome)})、アプローチを 1 行、レビューで注視すべき箇所を書く。最大 5 項目程度、冗長表現も事実の捏造もしない。\n` +
+      `(2) この JSON をそのまま temp file に書き出す。\n${JSON.stringify(shipPayload)}\n` +
+      `(3) 事実 tail の追記と PR 作成を 1 つの \`&&\` チェーンで行い、renderer 失敗時は PR を作る前に中断する。repository root から ` +
       `\`python3 "$HOME/.claude/workflows/build/pr-body.py" < <tempfile> >> <bodyfile> && gh pr create --draft --title "<commit subject>" --body-file <bodyfile>\` を実行する。\n` +
       `pr-body.py は payload が不正・必須フィールド欠落なら非 0 で終了し (何も出力しない)。チェーンが失敗したら他の手段で PR を作らず、committed と空の pr_url とエラーを報告する。tail の欠けた PR を出すより欠落を surface する。\n` +
       `committed 状態と PR url を報告する。${guard}`,

--- a/.ja/workflows/code.js
+++ b/.ja/workflows/code.js
@@ -48,14 +48,12 @@ const RED_SCHEMA = {
   properties: {
     red_confirmed: {
       type: "boolean",
-      description:
-        "書いたテストを実行し、期待どおり fail することを確認できたら true",
+      description: "書いたテストを実行し、期待どおり fail することを確認できたら true",
     },
     test_files: { type: "array", items: { type: "string" } },
     notes: {
       type: "string",
-      description:
-        "red_confirmed が false の場合はその理由 (既に振る舞いが存在する等)",
+      description: "red_confirmed が false の場合はその理由 (既に振る舞いが存在する等)",
     },
   },
 };
@@ -118,10 +116,10 @@ const anomalies = [];
 phase("Implement");
 for (const unit of units) {
   const ctx =
-    `Unit ${unit.id}: ${unit.goal}\n対象ファイル: ${JSON.stringify(unit.files)}\n` +
-    `Contract: ${unit.contract}\nTest scenarios: ${JSON.stringify(unit.tests)}\n` +
-    `テスト実行: ${testCmd}\n` +
-    (completed.length ? `実装済み unit: ${completed.join(", ")}\n` : "");
+    `Unit ${unit.id} のゴールは「${unit.goal}」。対象ファイルは ${JSON.stringify(unit.files)}。\n` +
+    `contract は ${unit.contract}。test scenarios は ${JSON.stringify(unit.tests)}。\n` +
+    `テスト実行コマンドは ${testCmd}。\n` +
+    (completed.length ? `実装済み unit は ${completed.join(", ")}。\n` : "");
 
   // Red: テストを書き、fail を実行で確認する。実装は書かない。
   let red = await agent(
@@ -144,7 +142,7 @@ for (const unit of units) {
     red = await agent(
       anchor(
         `TDD の Red step 再試行。${ctx}` +
-          `前回テストが fail しなかった: ${red.notes}\n` +
+          `前回テストが fail しなかった。理由は ${red.notes}。\n` +
           `テストが対象の振る舞いを本当に検証しているか精査する (assertion が空でないか、対象コードを呼んでいるか)。` +
           `振る舞いが未実装なら fail するはずである。精査後もテストが pass するなら、振る舞いは実装済みと judged し red_confirmed=false のまま理由を notes に書く。`,
       ),
@@ -157,13 +155,10 @@ for (const unit of units) {
       },
     );
   }
-  if (!red)
-    return { stopped: "red-failed", unit: unit.id, completed, anomalies };
+  if (!red) return { stopped: "red-failed", unit: unit.id, completed, anomalies };
   if (!red.red_confirmed) {
     anomalies.push({ unit: unit.id, kind: "no-red", notes: red.notes });
-    log(
-      `${unit.id}: Red 未確認 (${red.notes})。実装 step を skip して次の unit へ。`,
-    );
+    log(`${unit.id}: Red 未確認 (${red.notes})。実装 step を skip して次の unit へ。`);
     completed.push(unit.id);
     continue;
   }
@@ -173,7 +168,7 @@ for (const unit of units) {
     anchor(
       `TDD の Green step。${ctx}` +
         `テストファイル ${JSON.stringify(red.test_files)} の failing test を pass させる最小の実装を書く。` +
-        `テストの assertion を弱める・skip する・削除する変更は禁止 (テスト構造の修正が必要なら notes に書いて green=false で返す)。` +
+        `テストの assertion を弱める / skip する / 削除する変更は禁止 (テスト構造の修正が必要なら notes に書いて green=false で返す)。` +
         `pass 後、テストを green に保ったまま refactor する。unit のテストを再実行して報告する。`,
     ),
     {
@@ -188,7 +183,7 @@ for (const unit of units) {
     green = await agent(
       anchor(
         `TDD の Green step 再試行。${ctx}` +
-          `前回 pass しなかった: ${green.notes}\n原因を特定して実装を修正し、unit のテストを pass させる。テストの弱体化は禁止。`,
+          `前回 pass しなかった。理由は ${green.notes}。\n原因を特定して実装を修正し、unit のテストを pass させる。テストの弱体化は禁止。`,
       ),
       {
         label: `green2:${unit.id}`,

--- a/.ja/workflows/polish.js
+++ b/.ja/workflows/polish.js
@@ -4,12 +4,7 @@ export const meta = {
     'Codex review + cleanup を決定論的に行う workflow。Codex の findings は critic-audit の challenge を必ず通り、triage (confirmed / disputed / downgraded / needs_context) は script が判定するため、fact 扱いの集約や challenge の skip が起きない。単体でも、build から workflow("polish") 経由の入れ子でも呼べる。',
   whenToUse:
     "diff の外部レンズ review と AI slop 除去を headless に行う。args は scope 文字列、または {scope, repo, mode}。mode: full (既定) は review -> fix -> cleanup、review は challenge 済み findings を返すだけ (fix しない)、cleanup は simplify + enhancer-code + テスト検証のみ。内部 reviewer の深い audit は audit workflow を使う。",
-  phases: [
-    { title: "Review" },
-    { title: "Challenge" },
-    { title: "Fix" },
-    { title: "Cleanup" },
-  ],
+  phases: [{ title: "Review" }, { title: "Challenge" }, { title: "Fix" }, { title: "Cleanup" }],
 };
 
 // /polish skill の flatten。triage 表を script に置くのは、agent に verdict の解釈を任せると
@@ -31,8 +26,7 @@ const opts = (() => {
 })();
 const scope = typeof opts.scope === "string" ? opts.scope : "";
 const repo = typeof opts.repo === "string" ? opts.repo : "";
-const mode =
-  opts.mode === "review" || opts.mode === "cleanup" ? opts.mode : "full";
+const mode = opts.mode === "review" || opts.mode === "cleanup" ? opts.mode : "full";
 
 const anchor = (p) =>
   repo
@@ -170,8 +164,8 @@ if (mode !== "cleanup") {
     const challenged = await agent(
       anchor(
         `critic-audit。外部 Codex review の findings 一式を adversarial に challenge し、finding ごとに verdict を返す。\n` +
-          `verdict の基準: confirmed = 実在し severity も妥当 / disputed = false positive / downgraded = 実在するが severity 過大 (下げた severity を severity に入れる) / needs_context = コードだけでは判定できず人間の文脈が要る。\n` +
-          `Findings:\n${JSON.stringify(codex.findings)}`,
+          `verdict の基準は次のとおり。confirmed = 実在し severity も妥当 / disputed = false positive / downgraded = 実在するが severity 過大 (下げた severity を severity に入れる) / needs_context = コードだけでは判定できず人間の文脈が要る。\n` +
+          `Findings は次のとおり。\n${JSON.stringify(codex.findings)}`,
       ),
       {
         agentType: "critic-audit",
@@ -200,10 +194,8 @@ if (mode !== "cleanup") {
         continue;
       }
       if (v.verdict === "disputed") continue;
-      const severity =
-        v.verdict === "downgraded" && v.severity ? v.severity : f.severity;
-      if (severity === "P1" || severity === "P2")
-        survivors.push({ ...f, severity });
+      const severity = v.verdict === "downgraded" && v.severity ? v.severity : f.severity;
+      if (severity === "P1" || severity === "P2") survivors.push({ ...f, severity });
     }
     log(
       `triage: 生存 ${survivors.length} / needs_context ${needsContext.length} / 棄却 ${codex.findings.length - survivors.length - needsContext.length}`,
@@ -226,7 +218,7 @@ if (mode !== "cleanup") {
       anchor(
         `challenge を生き残った findings を severity の高い順に修正する。${scopeNote}\n` +
           `修正後にプロジェクトのテストコマンドを検出して実行し、テストを壊した fix は git stash で巻き戻す。commit しない。\n` +
-          `Findings:\n${JSON.stringify(survivors)}`,
+          `Findings は次のとおり。\n${JSON.stringify(survivors)}`,
       ),
       {
         label: "fix",

--- a/.ja/workflows/shake.js
+++ b/.ja/workflows/shake.js
@@ -55,8 +55,8 @@ const DIMENSIONS = [
 // invariant check の両 prompt に埋め込む共通規範。
 const INVARIANT_RULES =
   `flaky fix はテストの実行方法を変えるものであり、assert 内容を変えるものではない。\n` +
-  `許容: clock 注入 / fake timers、seed 固定、テストごとの状態隔離、I/O boundary の mock、一意な temp dir / port。\n` +
-  `禁止: assertion の緩和や tolerance の拡大、テストの skip / .only 化 / 除去、常に通る stub への置換、blanket retry の追加、shake コマンドや回数の改変。` +
+  `許容されるのは clock 注入 / fake timers、seed 固定、テストごとの状態隔離、I/O boundary の mock、一意な temp dir / port。\n` +
+  `禁止されるのは assertion の緩和や tolerance の拡大、テストの skip / .only 化 / 除去、常に通る stub への置換、blanket retry の追加、shake コマンドや回数の改変。` +
   `禁止ルートは flaky を silent gap に変換するため、flake そのものより悪い。`;
 
 // skill § Fix direction。trigger と root-cause fix の対応表。
@@ -138,13 +138,7 @@ const SMELL_SCHEMA = {
         properties: {
           smell: {
             type: "string",
-            enum: [
-              "wall-clock",
-              "unseeded-random",
-              "fixed-sleep",
-              "shared-state",
-              "fixed-path-io",
-            ],
+            enum: ["wall-clock", "unseeded-random", "fixed-sleep", "shared-state", "fixed-path-io"],
           },
           location: { type: "string", description: "file:line" },
           evidence: { type: "string" },
@@ -181,12 +175,7 @@ const INVARIANT_SCHEMA = {
 // 全 pass = stable、全 fail = broken (flaky でなく常時失敗、scope 外として報告)、
 // 混在 = flaky。
 const dimVerdict = (result) => {
-  if (
-    !result ||
-    !result.ran ||
-    !Array.isArray(result.runs) ||
-    result.runs.length < RUNS
-  ) {
+  if (!result || !result.ran || !Array.isArray(result.runs) || result.runs.length < RUNS) {
     return "unshaken";
   }
   const passes = result.runs.filter((r) => r.pass).length;
@@ -206,8 +195,8 @@ const route = (await agent(
       `1. ${scopeInstr}\n` +
       `2. project manifest から test ecosystem (cargo test / nextest / jest / vitest 等) を特定する。\n` +
       `3. target ごとに 4 次元のコマンドを組む。各コマンドは対象テストだけを 1 回実行するもので、shake 実行者が ${RUNS} 回ループする前提。文字列 {RUN} を含めると実行時に回番号 (1..${RUNS}) へ置換される。\n` +
-      `   repeat: そのまま繰り返す通常実行 / order: 実行順を毎回異なる seed で randomize ({RUN} を seed に使う) / parallelism: serial と max-worker を交互に切り替え ({RUN} の偶奇で分岐する 1 行コマンド) / seed: suite が明示 seed を受けるなら毎回異なる seed、受けないなら空文字列。\n` +
-      `   例: jest なら order は --shuffle と seed 指定、parallelism は --runInBand と最大 worker の切替。次元が ecosystem 的に構成不能なら空文字列にする。\n` +
+      `   repeat はそのまま繰り返す通常実行 / order は実行順を毎回異なる seed で randomize ({RUN} を seed に使う) / parallelism は serial と max-worker を交互に切り替え ({RUN} の偶奇で分岐する 1 行コマンド) / seed は suite が明示 seed を受けるなら毎回異なる seed、受けないなら空文字列。\n` +
+      `   例として jest なら order は --shuffle と seed 指定、parallelism は --runInBand と最大 worker の切替。次元が ecosystem 的に構成不能なら空文字列にする。\n` +
       `テストの実行も修正もしない。この段階の仕事はコマンドの決定だけ。`,
   ),
   {
@@ -242,8 +231,8 @@ const results = await pipeline(
         agent(
           anchor(
             `shake の静的 smell scan を担当する。対象テスト ${t.file} とその setup / fixture / helper を ugrep で走査し、現在 pass していても潜在 flaky な兆候を報告する。\n` +
-              `smell と grep パターン: wall-clock (Date.now, new Date(, Instant::now, SystemTime::, time.Now) / unseeded-random (Math.random, thread_rng, rand::random, faker) / fixed-sleep (setTimeout, thread::sleep, tokio::time::sleep, sleep() / shared-state (static mut, module-level の可変 global, singleton, per-test reset の欠如) / fixed-path-io (固定 /tmp パス, 固定 port, 実 network, env 読み)。\n` +
-              `hit ごとに file:line、根拠、root-cause fix の方向を書く。fix 方向の対応表:\n${FIX_DIRECTIONS}\n` +
+              `smell と grep パターンは次のとおり。wall-clock (Date.now, new Date(, Instant::now, SystemTime::, time.Now) / unseeded-random (Math.random, thread_rng, rand::random, faker) / fixed-sleep (setTimeout, thread::sleep, tokio::time::sleep, sleep() / shared-state (static mut, module-level の可変 global, singleton, per-test reset の欠如) / fixed-path-io (固定 /tmp パス, 固定 port, 実 network, env 読み)。\n` +
+              `hit ごとに file:line、根拠、root-cause fix の方向を書く。fix 方向の対応表は次のとおり。\n${FIX_DIRECTIONS}\n` +
               `テスト本体のロジックに関する一般レビューはしない。`,
           ),
           {
@@ -263,7 +252,7 @@ const results = await pipeline(
           });
         return agent(
           anchor(
-            `shake の ${d.key} 次元を担当する (露出対象: ${d.exposes})。コマンド \`${d.command}\` を ${RUNS} 回実行する。{RUN} が含まれる場合は回番号 1..${RUNS} に置換する。\n` +
+            `shake の ${d.key} 次元を担当する (露出対象は ${d.exposes})。コマンド \`${d.command}\` を ${RUNS} 回実行する。{RUN} が含まれる場合は回番号 1..${RUNS} に置換する。\n` +
               `各回の pass/fail を runs に 1 回 1 要素で記録する (${RUNS} 要素必須。省略や集計での置き換えは不可)。fail した回は note にエラーの要点を写す。\n` +
               `テストコードもコマンドも変更しない。回数を減らさない。途中で flaky と確信しても ${RUNS} 回すべて実行する。`,
           ),
@@ -284,9 +273,7 @@ const results = await pipeline(
         dimension: d.key,
         verdict,
         fails:
-          verdict === "flaky" || verdict === "broken"
-            ? r.runs.filter((x) => !x.pass).length
-            : 0,
+          verdict === "flaky" || verdict === "broken" ? r.runs.filter((x) => !x.pass).length : 0,
         note: (r && r.notes) || "",
       };
     });
@@ -307,9 +294,7 @@ const results = await pipeline(
     else verdict = "stable";
     log(
       `${t.id}: ${verdict}` +
-        (triggers.length
-          ? ` (trigger: ${triggers.map((d) => d.dimension).join(", ")})`
-          : ""),
+        (triggers.length ? ` (trigger: ${triggers.map((d) => d.dimension).join(", ")})` : ""),
     );
 
     const fix = {
@@ -326,11 +311,11 @@ const results = await pipeline(
         const fixed = await agent(
           anchor(
             `shake の fix 段階を担当する。confirmed-flaky なテスト ${t.file} の root cause を修正する (試行 ${attempt}/${MAX_FIX_ATTEMPTS})。\n` +
-              `trigger 次元: ${triggers.map((d) => `${d.dimension} (${d.fails}/${RUNS} fail)`).join(", ")}\n` +
-              `静的 smell (根本原因の候補):\n${JSON.stringify(smells)}\n` +
-              `fix 方向の対応表:\n${FIX_DIRECTIONS}\n\n${INVARIANT_RULES}\n` +
+              `trigger 次元は ${triggers.map((d) => `${d.dimension} (${d.fails}/${RUNS} fail)`).join(", ")}。\n` +
+              `静的 smell (根本原因の候補) は次のとおり。\n${JSON.stringify(smells)}\n` +
+              `fix 方向の対応表は次のとおり。\n${FIX_DIRECTIONS}\n\n${INVARIANT_RULES}\n` +
               (history
-                ? `\n前回までの試行と失敗理由 (invariant 違反があれば先に巻き戻してから正しく直す):\n${history}`
+                ? `\n前回までの試行と失敗理由は次のとおり (invariant 違反があれば先に巻き戻してから正しく直す)。\n${history}`
                 : ""),
           ),
           {
@@ -342,7 +327,7 @@ const results = await pipeline(
           },
         );
         if (!fixed || !fixed.applied) {
-          history += `試行 ${attempt}: fix 適用に至らず (${(fixed && fixed.summary) || "agent stall"})\n`;
+          history += `試行 ${attempt} は fix 適用に至らず (${(fixed && fixed.summary) || "agent stall"})\n`;
           continue;
         }
         // 独立した invariant check ∥ trigger 次元の re-shake
@@ -378,9 +363,8 @@ const results = await pipeline(
         ]);
         // invariant 違反は fix 成立と認めない (stall も fail-close で違反扱い)
         if (!inv || !inv.held) {
-          fix.invariant =
-            (inv && inv.reason) || "invariant check stall (fail-close)";
-          history += `試行 ${attempt}: invariant 違反。${fix.invariant}\n`;
+          fix.invariant = (inv && inv.reason) || "invariant check stall (fail-close)";
+          history += `試行 ${attempt} は invariant 違反。${fix.invariant}\n`;
           continue;
         }
         const reshakeVerdicts = triggers.map((trg, i) => ({
@@ -394,10 +378,8 @@ const results = await pipeline(
           fix.reshake = `全 trigger 次元 ${RUNS}/${RUNS} stable`;
           break;
         }
-        fix.reshake = residual
-          .map((r) => `${r.dimension}=${r.verdict}`)
-          .join(", ");
-        history += `試行 ${attempt}: re-shake で残存 (${fix.reshake})\n`;
+        fix.reshake = residual.map((r) => `${r.dimension}=${r.verdict}`).join(", ");
+        history += `試行 ${attempt} は re-shake で残存 (${fix.reshake})\n`;
       }
       if (!fix.applied) {
         // skill § Stop point: 3 回の fix 試行を生き延びた flake は弱体化でなく blocker 報告

--- a/workflows/adrift.js
+++ b/workflows/adrift.js
@@ -46,11 +46,7 @@ const repo = typeof opts.repo === "string" ? opts.repo : "";
 
 // focus is a list of ids ("0061" / "ADR-0061") or keywords, accepted as array or string.
 // Ids match numerically; non-numeric tokens substring-match against file name / title.
-const focus = (
-  Array.isArray(opts.focus)
-    ? opts.focus
-    : String(opts.focus || "").split(/[\s,]+/)
-)
+const focus = (Array.isArray(opts.focus) ? opts.focus : String(opts.focus || "").split(/[\s,]+/))
   .map((t) =>
     String(t)
       .trim()
@@ -82,13 +78,13 @@ const REVIEWERS = {
 // consts because guardrails sqli-concat false-positives on keyword words inside interpolated
 // template call arguments).
 const DIRECTION_RULES =
-  "code-fix: the ADR is the correct current contract and the code has drifted / " +
-  "adr-update: the code is the correct current contract and the ADR is stale / " +
-  "accept: the drift is trivial, already marked deprecated in a comment, or documented";
+  "code-fix when the ADR is the correct current contract and the code has drifted / " +
+  "adr-update when the code is the correct current contract and the ADR is stale / " +
+  "accept when the drift is trivial, already marked deprecated in a comment, or documented";
 const PRIORITY_RULES =
-  "H: affects a public API, or 2+ downstream consumers / " +
-  "M: affects an internal API, 1 downstream consumer / " +
-  "L: comment / docstring only, or an invalid reference";
+  "H when it affects a public API or 2+ downstream consumers / " +
+  "M when it affects an internal API with 1 downstream consumer / " +
+  "L when it is comment / docstring only, or an invalid reference";
 const PRIORITY_RANK = { H: 3, M: 2, L: 1 };
 
 const DETECT_SCHEMA = {
@@ -203,8 +199,7 @@ const mergeFindings = (lists) => {
   for (const f of lists.flat()) {
     const k = `${f.file}:${f.line}`;
     const prev = map.get(k);
-    if (!prev || PRIORITY_RANK[f.priority] > PRIORITY_RANK[prev.priority])
-      map.set(k, f);
+    if (!prev || PRIORITY_RANK[f.priority] > PRIORITY_RANK[prev.priority]) map.set(k, f);
   }
   return [...map.values()].sort(
     (a, b) =>
@@ -224,7 +219,7 @@ const detect = (await agent(
     `You handle the Detect stage of adrift.\n` +
       `1. ${dirInstr}\n` +
       `2. List the NNNN-*.md files in the directory and record id (NNNN), file (relative path), and title (heading) in adrs.\n` +
-      `3. Manifest verdict: rust if Cargo.toml exists. If package.json exists, tsx when *.tsx files exist, otherwise ts. Otherwise other.\n` +
+      `3. Decide the manifest verdict. rust if Cargo.toml exists. If package.json exists, tsx when *.tsx files exist, otherwise ts. Otherwise other.\n` +
       `4. Search the whole repository for ADR references with \`ugrep -rniw 'ADR-[0-9]{4}'\` and record the hits in adr_refs (file, line, id as 4-digit NNNN), excluding the ADR directory itself, fixtures, and node_modules / target / dist / build / vendor. Do not classify against local ADRs.\n` +
       `Do not analyze ADR bodies. This stage's job is detection and listing only.`,
   ),
@@ -343,11 +338,11 @@ const perAdr = await pipeline(
           agent(
             anchor(
               `As ${rv}, judge semantic drift between the Decision Outcome of ADR ${a.id} (${a.title}) and the current code. Look at the semantic gap between the decision and the implementation, not surface issues clippy or grep would catch.\n` +
-                `Decision Outcome:\n${ex.outcome_text}\n\n` +
-                `Reference candidates (ugrep hits):\n${JSON.stringify(ex.candidates)}\n\n` +
+                `The Decision Outcome is as follows.\n${ex.outcome_text}\n\n` +
+                `The reference candidates (ugrep hits) are as follows.\n${JSON.stringify(ex.candidates)}\n\n` +
                 `Pin each drift to file:line and assign direction and priority by these criteria.\n` +
-                `direction criteria: ${DIRECTION_RULES}\n` +
-                `priority criteria: ${PRIORITY_RULES}\n` +
+                `The direction criteria are ${DIRECTION_RULES}.\n` +
+                `The priority criteria are ${PRIORITY_RULES}.\n` +
                 `If there is no drift, return findings: []. Do not edit the ADR body or fix the code.`,
             ),
             {
@@ -373,9 +368,7 @@ const perAdr = await pipeline(
 );
 
 const scanned = perAdr.filter(Boolean);
-const allFindings = scanned.flatMap((r) =>
-  r.findings.map((f) => ({ ...f, adr: r.adr.id })),
-);
+const allFindings = scanned.flatMap((r) => r.findings.map((f) => ({ ...f, adr: r.adr.id })));
 const counts = { H: 0, M: 0, L: 0 };
 for (const f of allFindings) counts[f.priority] += 1;
 const unverifiable = scanned.filter((r) => !r.verifiable);
@@ -386,18 +379,18 @@ log(
 // ---- Report: report output (skill Phase 8; the structure lives in the prompt, no template) ----
 phase("Report");
 const focusNote = focus.length
-  ? `Focus scope: this run is narrowed by focus [${focus.join(", ")}] to ${scanned.length}/${detect.adrs.length} ADRs. State this in one line right after the Summary.\n\n`
+  ? `This run is narrowed by focus [${focus.join(", ")}] to ${scanned.length}/${detect.adrs.length} ADRs. State this in one line right after the Summary.\n\n`
   : "";
 const report = (await agent(
   anchor(
     `You handle the Report stage of adrift. Write a report with the following structure from the findings JSON below.\n` +
-      `Steps: after \`mkdir -p docs/audit\`, write to docs/audit/\${STAMP}-adr-drift.md with \`STAMP=$(date -u +%Y-%m-%d-%H%M%S)\`.\n` +
-      `Structure: the title is "# ADR Drift Scan: {STAMP}". Sections in order: "## Summary" (a Metric | Value table with rows ADRs scanned / Drift findings / H priority / M priority / L priority / Unverifiable ADRs), "## Per-ADR Findings", "## External ADR Dependencies" (a File:Line | External ADR ref | Recommended action table; the action is "Promote to local ADR or supersede locally"), "## Follow-up Issue Candidates" (a checklist of \`- [ ] ADR {id} drift at {file}:{line}: {summary}\`).\n` +
+      `The steps are, after \`mkdir -p docs/audit\`, write to docs/audit/\${STAMP}-adr-drift.md with \`STAMP=$(date -u +%Y-%m-%d-%H%M%S)\`.\n` +
+      `The structure is as follows. The title is "# ADR Drift Scan: {STAMP}". Sections in order: "## Summary" (a Metric | Value table with rows ADRs scanned / Drift findings / H priority / M priority / L priority / Unverifiable ADRs), "## Per-ADR Findings", "## External ADR Dependencies" (a File:Line | External ADR ref | Recommended action table; the action is "Promote to local ADR or supersede locally"), "## Follow-up Issue Candidates" (a checklist of \`- [ ] ADR {id} drift at {file}:{line}: {summary}\`).\n` +
       `In Per-ADR Findings, bundle no-drift ADRs into one "ADRs {ids}: no drift." line, and give a "### ADR {id}: {title}" subsection (Status / Result lines + a File:Line | Description | Direction | Priority table; for unverifiable, state the reason in Result and omit the table) only to drifted / unverifiable ADRs.\n` +
-      `Completeness requirements: (1) List every ADR in Per-ADR Findings without omission. (2) Record file:line / direction / priority for each drift. (3) Reflect Superseded in the Status of superseded ADRs. (4) Omit the External ADR Dependencies heading entirely when external_refs is empty, and the Follow-up Issue Candidates heading entirely when there are zero H-priority findings.\n\n` +
+      `The completeness requirements are the following 4. (1) List every ADR in Per-ADR Findings without omission. (2) Record file:line / direction / priority for each drift. (3) Reflect Superseded in the Status of superseded ADRs. (4) Omit the External ADR Dependencies heading entirely when external_refs is empty, and the Follow-up Issue Candidates heading entirely when there are zero H-priority findings.\n\n` +
       focusNote +
-      `Summary counts (use these values as-is): ADRs scanned=${scanned.length}, findings=${allFindings.length}, H=${counts.H}, M=${counts.M}, L=${counts.L}, unverifiable=${unverifiable.length}\n\n` +
-      `Per-ADR results:\n${JSON.stringify(
+      `Use these Summary counts as-is. ADRs scanned=${scanned.length}, findings=${allFindings.length}, H=${counts.H}, M=${counts.M}, L=${counts.L}, unverifiable=${unverifiable.length}\n\n` +
+      `The per-ADR results are as follows.\n${JSON.stringify(
         scanned.map((r) => ({
           id: r.adr.id,
           title: r.adr.title,
@@ -408,7 +401,7 @@ const report = (await agent(
           findings: r.findings,
         })),
       )}\n\n` +
-      `External ADR references (external_refs):\n${JSON.stringify(externalRefs)}`,
+      `The external ADR references (external_refs) are as follows.\n${JSON.stringify(externalRefs)}`,
   ),
   {
     agentType: "general-purpose",

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -81,11 +81,7 @@ const mergeIssues = (findings) => {
       .replace(/^\[|\]$/g, "");
     const sev = SEVERITY_MAP[key] === undefined ? null : SEVERITY_MAP[key];
     if (!sev) continue;
-    const sources = Array.isArray(f.source)
-      ? f.source
-      : f.source
-        ? [f.source]
-        : [];
+    const sources = Array.isArray(f.source) ? f.source : f.source ? [f.source] : [];
     const k = `${f.file || ""}:${f.line || 0}`;
     const prev = groups.get(k);
     if (!prev) {
@@ -124,8 +120,7 @@ const BOOTSTRAP_SCHEMA = {
     scope_files: { type: "array", items: { type: "string" } },
     outcome: {
       type: "string",
-      description:
-        "Digest of OUTCOME.md Behavior / Non-goals / Constraints. absent if missing",
+      description: "Digest of OUTCOME.md Behavior / Non-goals / Constraints. absent if missing",
     },
     worktree_ok: { type: "boolean" },
     worktree_path: { type: "string" },
@@ -286,9 +281,7 @@ const buildCol = envFail ? "skipped" : boot.build;
 const dynamicOk = !envFail && buildCol !== "fail";
 log(
   `Bootstrap: mode=${boot.mode} files=${boot.scope_files.length} build=${buildCol}` +
-    (dynamicOk
-      ? ""
-      : ` (dynamic verification skipped: ${boot.reason || "env fail"})`),
+    (dynamicOk ? "" : ` (dynamic verification skipped: ${boot.reason || "env fail"})`),
 );
 
 let gate = "NotReady";
@@ -351,11 +344,7 @@ try {
   // target mode may under-enumerate (known limitation; Codex review and adversarial
   // compensate with an explicit file list).
   const auditScope =
-    boot.mode === "diff"
-      ? boot.diff_kind === "branch"
-        ? `${base}...HEAD`
-        : ""
-      : scope;
+    boot.mode === "diff" ? (boot.diff_kind === "branch" ? `${base}...HEAD` : "") : scope;
   const codexScopeInstr =
     boot.mode === "target"
       ? `Target mode: run \`codex review "Review these files: ${boot.scope_files.join(", ")}"\` naming the target files in the PROMPT, without a scope flag.`
@@ -384,14 +373,11 @@ try {
           schema: CODEX_REVIEW_SCHEMA,
         },
       );
-      const findings = ((codexReview && codexReview.findings) || []).map(
-        (f) => ({
-          ...f,
-          source: "codex",
-        }),
-      );
-      if (!findings.length)
-        return { codexFindings: findings, challenged: null, verified: null };
+      const findings = ((codexReview && codexReview.findings) || []).map((f) => ({
+        ...f,
+        source: "codex",
+      }));
+      if (!findings.length) return { codexFindings: findings, challenged: null, verified: null };
       // ---- Challenge: challenger ∥ verifier over the Codex findings ----
       // Each agent's opts.phase assigns the Challenge group. A bare phase() would race the
       // global phase state against the audit thunk running concurrently, so it is not called
@@ -401,7 +387,7 @@ try {
         () =>
           agent(
             anchor(
-              `As critic-audit, challenge the external Codex review findings and prune false positives. Treat each finding as a claim to be proven, not a fact. Reference each finding by file:line. Findings:\n${codexJson}`,
+              `As critic-audit, challenge the external Codex review findings and prune false positives. Treat each finding as a claim to be proven, not a fact. Reference each finding by file:line. The findings are as follows.\n${codexJson}`,
             ),
             {
               agentType: "critic-audit",
@@ -413,7 +399,7 @@ try {
         () =>
           agent(
             anchor(
-              `As critic-evidence, verify the external Codex review findings. Base verdicts on positive evidence from tracing concrete execution paths, not intuition. Reference each finding by file:line, and attach execution-path evidence and a severity. Findings:\n${codexJson}`,
+              `As critic-evidence, verify the external Codex review findings. Base verdicts on positive evidence from tracing concrete execution paths, not intuition. Reference each finding by file:line, and attach execution-path evidence and a severity. The findings are as follows.\n${codexJson}`,
             ),
             {
               agentType: "critic-evidence",
@@ -437,9 +423,7 @@ try {
   }));
   log(
     `Evidence: codex ${codexFindings.length} findings / audit ${auditFindings.length} findings` +
-      (codexReview && codexReview.ran === false
-        ? " (codex review failed, audit only)"
-        : ""),
+      (codexReview && codexReview.ran === false ? " (codex review failed, audit only)" : ""),
   );
 
   // ---- Triage: intent matching for failed adversarial tests ----
@@ -462,8 +446,8 @@ try {
           agent(
             anchor(
               `You handle the intent triage of assert. Decide whether one failed adversarial test is "a real bug found" or "a wrong expectation on the test side".\n` +
-                `Test: ${JSON.stringify(t)}\n` +
-                `Read the target code (${t.target}) with 30 lines of context, and look for intent sources top-down: .claude/OUTCOME.md, SOW / Spec under .claude/workspace/planning/, ADRs such as docs/decisions/, git log of the target file, comments within 10 lines of the target code, the target function's docstring, README, names of existing tests of the same function.\n` +
+                `The test is as follows. ${JSON.stringify(t)}\n` +
+                `Read the target code (${t.target}) with 30 lines of context, and look for intent sources top-down. The order is .claude/OUTCOME.md, SOW / Spec under .claude/workspace/planning/, ADRs such as docs/decisions/, git log of the target file, comments within 10 lines of the target code, the target function's docstring, README, names of existing tests of the same function.\n` +
                 `If an intent source contradicts the test's expectation, exclude (quote the source in reason); otherwise promote.`,
             ),
             {
@@ -479,8 +463,7 @@ try {
     advFails.forEach((t, i) => {
       const v = verdicts[i];
       // if triage stalls, promote fail-close (prefer a false positive over a miss)
-      if (v && v.verdict === "exclude")
-        excluded.push({ ...t, reason: v.reason });
+      if (v && v.verdict === "exclude") excluded.push({ ...t, reason: v.reason });
       else
         promoted.push({
           file: (t.target || "").split(":")[0],
@@ -510,13 +493,13 @@ try {
   synth = await agent(
     anchor(
       `As enhancer-evidence, integrate the static findings, outcome evidence, and adversarial results into root causes and a final issues set.\n` +
-        `Outcome criteria (OUTCOME.md):\n${boot.outcome}\n\n` +
-        `Integrated findings from the audit workflow (critic-verified; include them in issues as-is):\n${JSON.stringify(auditFindings)}\n\n` +
-        `Challenge pass over the Codex findings (this pass decides membership; findings pruned as false positives stay pruned even if the verification pass found evidence):\n${challenged || "(challenge stalled / no findings)"}\n\n` +
-        `Verification pass over the Codex findings (only attaches execution-path evidence and severity to survivors):\n${verified || "(verify stalled / no findings)"}\n\n` +
+        `The Outcome criteria (OUTCOME.md) are as follows.\n${boot.outcome}\n\n` +
+        `The integrated findings from the audit workflow (critic-verified; include them in issues as-is) are as follows.\n${JSON.stringify(auditFindings)}\n\n` +
+        `The challenge pass over the Codex findings (this pass decides membership; findings pruned as false positives stay pruned even if the verification pass found evidence) is as follows.\n${challenged || "(challenge stalled / no findings)"}\n\n` +
+        `The verification pass over the Codex findings (only attaches execution-path evidence and severity to survivors) is as follows.\n${verified || "(verify stalled / no findings)"}\n\n` +
         `${challengeStalled ? "Both challenger and verifier stalled, so the Codex findings are unverified. Do not include them in issues; surface this in the report.\n\n" : ""}` +
-        `Promoted adversarial findings (include in issues as-is):\n${JSON.stringify(promoted)}\n\n` +
-        `Dynamic evidence: build=${buildCol}, tests=${testsCol}${testRun && testRun.notes ? ` (${testRun.notes})` : ""}\n\n` +
+        `The promoted adversarial findings (include in issues as-is) are as follows.\n${JSON.stringify(promoted)}\n\n` +
+        `The dynamic evidence is build=${buildCol}, tests=${testsCol}${testRun && testRun.notes ? ` (${testRun.notes})` : ""}.\n\n` +
         `Include Constraint violations and Non-goal incursions in issues on equal footing regardless of origin. The report contains the evidence table (Build / Tests / Issues / Adversarial), root causes, and a fix suggestion per issue. Do not decide the gate (the script computes it by rule).`,
     ),
     {
@@ -534,12 +517,7 @@ try {
   // issues means NotReady. Severity remains a fix-priority hint and never affects the
   // gate. caveat applies only when dynamic evidence is missing for env reasons, and
   // presumes zero issues.
-  if (
-    buildCol === "fail" ||
-    testsCol === "fail" ||
-    issues.length > 0 ||
-    challengeStalled
-  ) {
+  if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
   } else if (!envFail && (testsCol === "pass" || testsCol === "no-runner")) {
     gate = "Ready";
@@ -562,9 +540,7 @@ try {
   );
 }
 
-log(
-  `Gate: ${gate} (build=${buildCol}, tests=${testsCol}, issues=${issues.length})`,
-);
+log(`Gate: ${gate} (build=${buildCol}, tests=${testsCol}, issues=${issues.length})`);
 
 return {
   gate,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -73,7 +73,7 @@ const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped }) => {
         `"branch" from \`git rev-parse --abbrev-ref HEAD\`, and "generated_at" from \`date -u +%Y-%m-%dT%H:%M:%SZ\`. ` +
         `Also add "delta": compare this run's raw_findings to the most recent existing audit-*.json in that directory ` +
         `(match on file + message) and record { resolved, new, carried } as counts; if no prior snapshot exists, use zeros and note "first run". ` +
-        `Do not review code or change any finding. Payload:\n${payload}`,
+        `Do not review code or change any finding. The payload is as follows.\n${payload}`,
     ),
     {
       agentType: "general-purpose",
@@ -89,15 +89,7 @@ const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped }) => {
 // loses react-pattern. A file takes the first matching row via classify(). Mechanical
 // type checks (any / assertions / strict mode) belong to the gates linters, not a reviewer.
 const ROUTING = {
-  "*.sh": [
-    "security",
-    "silence",
-    "duplication",
-    "reuse",
-    "efficiency",
-    "operations",
-    "resilience",
-  ],
+  "*.sh": ["security", "silence", "duplication", "reuse", "efficiency", "operations", "resilience"],
   "*.js": [
     "security",
     "silence",
@@ -215,8 +207,7 @@ const classify = (p) => {
   if (e === ".rs") return ROUTING["*.rs"];
   if (e === ".py") return ROUTING["*.py"];
   if (e === ".md") return ROUTING["*.md"];
-  if (e === ".yaml" || e === ".yml" || e === ".json")
-    return ROUTING["*.yaml,*.json"];
+  if (e === ".yaml" || e === ".yml" || e === ".json") return ROUTING["*.yaml,*.json"];
   if (e === ".css" || e === ".html") return ROUTING["*.css,*.html"];
   return ROUTING.default;
 };
@@ -401,9 +392,9 @@ const raw = await parallel(
     (u) => () =>
       agent(
         anchor(
-          `reviewer-${u.reviewer}. Review these files from the diff: ${u.files.join(", ")}. ` +
+          `reviewer-${u.reviewer}. Review these files from the diff. The targets are ${u.files.join(", ")}. ` +
             `Base the review on \`git diff ${scope || "HEAD"}\` for those paths. Every finding needs file:line. Return findings with severity.\n` +
-            `Churn (fix-commit counts, high = fragile):\n${churnMap}\n\n${RELIABILITY}`,
+            `The churn (fix-commit counts, high = fragile) is as follows.\n${churnMap}\n\n${RELIABILITY}`,
         ),
         {
           agentType: `reviewer-${u.reviewer}`,
@@ -458,7 +449,7 @@ const [challenged, verified] = await parallel([
   () =>
     agent(
       anchor(
-        `critic-audit. Challenge these findings to prune false positives. Each finding is a position to be argued, not a fact. Reference each finding by its file:line. Findings:\n${findingsJson}`,
+        `critic-audit. Challenge these findings to prune false positives. Each finding is a position to be argued, not a fact. Reference each finding by its file:line. The findings are as follows.\n${findingsJson}`,
       ),
       {
         agentType: "critic-audit",
@@ -470,7 +461,7 @@ const [challenged, verified] = await parallel([
   () =>
     agent(
       anchor(
-        `critic-evidence. Verify these findings by tracing concrete execution paths (positive evidence, not intuition). For each finding, reference it by file:line and supply the execution-path evidence plus a severity. Findings:\n${findingsJson}`,
+        `critic-evidence. Verify these findings by tracing concrete execution paths (positive evidence, not intuition). For each finding, reference it by file:line and supply the execution-path evidence plus a severity. The findings are as follows.\n${findingsJson}`,
       ),
       {
         agentType: "critic-evidence",
@@ -486,8 +477,8 @@ const integrated = await agent(
   anchor(
     `enhancer-integration. Reconcile two independent passes over the same findings, matched by file:line, into cross-domain root causes and a severity-ordered list.\n` +
       `Membership rule: the challenge pass decides which findings survive. A finding the challenge pass pruned as a false positive stays pruned even if the verification pass found evidence for it. The verification pass only supplies execution-path evidence and severity for the survivors; it never revives a pruned finding.\n` +
-      `Challenge pass (membership / false-positive pruning):\n${challenged}\n\n` +
-      `Verification pass (execution-path evidence + severity):\n${verified}`,
+      `The challenge pass (membership / false-positive pruning) is as follows.\n${challenged}\n\n` +
+      `The verification pass (execution-path evidence + severity) is as follows.\n${verified}`,
   ),
   {
     agentType: "enhancer-integration",

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -297,7 +297,7 @@ const validate = (plan) => {
 // ---- Load: verbatim fetch -> Plan heading check -> deterministic id collection -> extract -> validate + cross-check ----
 const fetched = await agent(
   anchor(
-    `Fetch the body of GitHub issue ${issueRef} with a fixed command — do not summarize or reformat. ` +
+    `Fetch the body of GitHub issue ${issueRef} with a fixed command; do not summarize or reformat. ` +
       `Run exactly \`gh issue view ${issueRef} --json body --jq .body\` and return its stdout verbatim as body ` +
       `(the --jq extraction is verbatim by construction; do not edit it). If the command exits non-zero (issue not found / fetch failed), return found: false.`,
   ),
@@ -390,30 +390,47 @@ log(
 // grep) needs no reasoning, only shell access the workflow runtime lacks, so the agent is a
 // pure launcher that pipes the preconditions in and echoes the verifier's stdout back. The
 // drift decision then stays in the script's filter below.
+// Runs in parallel with Branch (checkout): the two are mutually independent (both
+// depend only on plan). Trade-off: if Revalidate stops on drift, the checked-out
+// branch is left behind (creation only, no commits, so reclaiming it is trivial).
+// The stopped returns include branch to surface it.
 phase("Revalidate");
 const preconditions = plan.preconditions || [];
-if (preconditions.length) {
-  const reval = await agent(
-    anchor(
-      `Re-verify the plan's preconditions with the deterministic verifier — do not judge exists/matches yourself. ` +
-        `Steps: (1) write this exact JSON to a temp file; (2) from the repository root run ` +
-        `\`python3 "$HOME/.claude/workflows/build/revalidate.py" < <tempfile>\`; ` +
-        `(3) return the verifier's stdout "results" array verbatim (all ${preconditions.length} entries, unchanged — do not add, drop, or edit any). ` +
-        `The verifier prints {"results":[{path,pattern,exists,matches}]}.\n` +
-        `Preconditions JSON:\n${JSON.stringify(preconditions)}`,
+const [reval, branch] = await parallel([
+  () =>
+    preconditions.length
+      ? agent(
+          anchor(
+            `Re-verify the plan's preconditions with the deterministic verifier; do not judge exists/matches yourself. ` +
+              `The steps are, (1) write this exact JSON to a temp file; (2) from the repository root run ` +
+              `\`python3 "$HOME/.claude/workflows/build/revalidate.py" < <tempfile>\`; ` +
+              `(3) return the verifier's stdout "results" array verbatim (all ${preconditions.length} entries, unchanged; do not add, drop, or edit any). ` +
+              `The verifier prints {"results":[{path,pattern,exists,matches}]}.\n` +
+              `The preconditions JSON is as follows.\n${JSON.stringify(preconditions)}`,
+          ),
+          {
+            label: "revalidate",
+            phase: "Revalidate",
+            agentType: "general-purpose",
+            schema: REVALIDATE_SCHEMA,
+            model: "haiku",
+          },
+        )
+      : Promise.resolve(null),
+  () =>
+    agent(
+      anchor(
+        `Check out a new git working branch for issue #${issueNumber} "${plan.outcome}". Pick a conventional branch name (type + short slug) and run git checkout -b with it. If already on a non-default branch, keep the current branch. Report the branch name as your final text.${guard}`,
+      ),
+      { label: "checkout", phase: "Branch", agentType: "general-purpose", model: "haiku" },
     ),
-    {
-      label: "revalidate",
-      phase: "Revalidate",
-      agentType: "general-purpose",
-      schema: REVALIDATE_SCHEMA,
-      model: "haiku",
-    },
-  );
+]);
+if (preconditions.length) {
   if (!reval || !Array.isArray(reval.results)) {
     return {
       stopped: "revalidate-failed",
       detail: reval,
+      branch,
       why: "The revalidate agent returned no results array.",
     };
   }
@@ -433,20 +450,17 @@ if (preconditions.length) {
     return {
       stopped: "plan-drift",
       drift,
+      branch,
       why: "Code the issue's plan presupposes is absent from the current codebase. Update the issue and relaunch.",
     };
   }
   log(`Revalidate: all ${preconditions.length} precondition(s) pass.`);
 }
 
-// ---- Branch: check out a working branch ----
+// The checkout agent already ran in parallel with Revalidate above; emit the phase
+// marker here, after the drift gate, so the observable trace stays
+// Load → Revalidate → Branch → Code (and plan-drift stops never reach Branch).
 phase("Branch");
-const branch = await agent(
-  anchor(
-    `Check out a new git working branch for issue #${issueNumber} "${plan.outcome}". Pick a conventional branch name (type + short slug) and run git checkout -b with it. If already on a non-default branch, keep the current branch. Report the branch name as your final text.${guard}`,
-  ),
-  { label: "checkout", phase: "Branch", agentType: "general-purpose" },
-);
 
 // ---- Code: delegated to workflow("code") (per-unit Red -> Green + independent verify) ----
 // preconditions / backlog_candidates are consumed on the build side, so code receives
@@ -500,7 +514,9 @@ let reaudited = true;
 for (let round = 1; round <= 3 && toFix.length; round++) {
   log(`Fix round ${round}: fixing ${toFix.length} finding(s).`);
   await agent(
-    anchor(`Fix these review findings and confirm tests pass:\n${JSON.stringify(toFix)}`),
+    anchor(
+      `Fix these review findings and confirm tests pass. The findings are as follows.\n${JSON.stringify(toFix)}`,
+    ),
     { agentType: "general-purpose", phase: "Audit", label: `fix:${round}` },
   );
   if (round === 3) {
@@ -586,13 +602,13 @@ const shipPayload = {
 };
 const ship = await agent(
   anchor(
-    `Turn all changes (planning artifacts + implementation) into a single Conventional Commits commit — you write the commit message (summarize the diff). ` +
-      `Push the branch, then open a draft pull request. Its body is a human-facing Summary you write, followed by deterministic fact sections rendered from data (do not hand-write the fact sections):\n` +
-      `(1) write a terse "## Summary" to a body file for the human reviewer — markdown bullets, not prose paragraphs: what this PR implements (outcome: ${JSON.stringify(plan.outcome)}), the approach in a line, and where to focus review. At most ~5 bullets; no filler, no invented facts.\n` +
-      `(2) write this exact JSON to a temp file:\n${JSON.stringify(shipPayload)}\n` +
-      `(3) append the fact tail and open the PR as ONE \`&&\` chain, so a renderer failure aborts before the PR is created — from the repository root run ` +
+    `Turn all changes (planning artifacts + implementation) into a single Conventional Commits commit; you write the commit message (summarize the diff). ` +
+      `Push the branch, then open a draft pull request. Its body is a human-facing Summary you write, followed by deterministic fact sections rendered from data (do not hand-write the fact sections). The steps are as follows.\n` +
+      `(1) write a terse "## Summary" to a body file for the human reviewer, in markdown bullets rather than prose paragraphs. Cover what this PR implements (the outcome is ${JSON.stringify(plan.outcome)}), the approach in a line, and where to focus review. At most ~5 bullets; no filler, no invented facts.\n` +
+      `(2) write this exact JSON to a temp file.\n${JSON.stringify(shipPayload)}\n` +
+      `(3) append the fact tail and open the PR as ONE \`&&\` chain, so a renderer failure aborts before the PR is created; from the repository root run ` +
       `\`python3 "$HOME/.claude/workflows/build/pr-body.py" < <tempfile> >> <bodyfile> && gh pr create --draft --title "<your commit subject>" --body-file <bodyfile>\`.\n` +
-      `pr-body.py exits non-zero (writing nothing) if the payload is malformed or missing a required field; if the chain fails, do NOT create the PR by other means — report committed with an empty pr_url and the error instead, so the missing fact tail surfaces rather than shipping a PR without it.\n` +
+      `pr-body.py exits non-zero (writing nothing) if the payload is malformed or missing a required field; if the chain fails, do NOT create the PR by other means. Report committed with an empty pr_url and the error instead, so the missing fact tail surfaces rather than shipping a PR without it.\n` +
       `Report the committed state and the PR url.${guard}`,
   ),
   {

--- a/workflows/code.js
+++ b/workflows/code.js
@@ -49,14 +49,12 @@ const RED_SCHEMA = {
   properties: {
     red_confirmed: {
       type: "boolean",
-      description:
-        "true when you ran the tests you wrote and confirmed they fail as expected",
+      description: "true when you ran the tests you wrote and confirmed they fail as expected",
     },
     test_files: { type: "array", items: { type: "string" } },
     notes: {
       type: "string",
-      description:
-        "when red_confirmed is false, the reason (e.g. the behavior already exists)",
+      description: "when red_confirmed is false, the reason (e.g. the behavior already exists)",
     },
   },
 };
@@ -123,12 +121,10 @@ const anomalies = [];
 phase("Implement");
 for (const unit of units) {
   const ctx =
-    `Unit ${unit.id}: ${unit.goal}\nTarget files: ${JSON.stringify(unit.files)}\n` +
-    `Contract: ${unit.contract}\nTest scenarios: ${JSON.stringify(unit.tests)}\n` +
-    `Test command: ${testCmd}\n` +
-    (completed.length
-      ? `Units already implemented: ${completed.join(", ")}\n`
-      : "");
+    `Unit ${unit.id}'s goal is "${unit.goal}". The target files are ${JSON.stringify(unit.files)}.\n` +
+    `The contract is ${unit.contract}. The test scenarios are ${JSON.stringify(unit.tests)}.\n` +
+    `The test command is ${testCmd}.\n` +
+    (completed.length ? `The units already implemented are ${completed.join(", ")}.\n` : "");
 
   // Red: write tests and confirm failure by running them. Write no implementation.
   let red = await agent(
@@ -152,7 +148,7 @@ for (const unit of units) {
     red = await agent(
       anchor(
         `TDD Red step retry. ${ctx}` +
-          `Last time the tests did not fail: ${red.notes}\n` +
+          `Last time the tests did not fail. The reason was ${red.notes}.\n` +
           `Scrutinize whether the tests really verify the target behavior (assertions are not empty, the target code is invoked). ` +
           `If the behavior is unimplemented they should fail. If after scrutiny the tests still pass, judge the behavior as already implemented and keep red_confirmed=false with the reason in notes.`,
       ),
@@ -165,13 +161,10 @@ for (const unit of units) {
       },
     );
   }
-  if (!red)
-    return { stopped: "red-failed", unit: unit.id, completed, anomalies };
+  if (!red) return { stopped: "red-failed", unit: unit.id, completed, anomalies };
   if (!red.red_confirmed) {
     anomalies.push({ unit: unit.id, kind: "no-red", notes: red.notes });
-    log(
-      `${unit.id}: Red unconfirmed (${red.notes}). Skipping the implement step.`,
-    );
+    log(`${unit.id}: Red unconfirmed (${red.notes}). Skipping the implement step.`);
     completed.push(unit.id);
     continue;
   }
@@ -181,7 +174,7 @@ for (const unit of units) {
     anchor(
       `TDD Green step. ${ctx}` +
         `Write the minimal implementation that makes the failing tests in ${JSON.stringify(red.test_files)} pass. ` +
-        `Weakening, skipping, or deleting test assertions is forbidden (if the test structure needs fixing, write it in notes and return green=false). ` +
+        `Changes that weaken / skip / delete test assertions are forbidden (if the test structure needs fixing, write it in notes and return green=false). ` +
         `After passing, refactor while keeping the tests green. Re-run the unit's tests and report.`,
     ),
     {
@@ -196,7 +189,7 @@ for (const unit of units) {
     green = await agent(
       anchor(
         `TDD Green step retry. ${ctx}` +
-          `Last time the tests did not pass: ${green.notes}\nIdentify the cause, fix the implementation, and make the unit's tests pass. Weakening tests is forbidden.`,
+          `Last time the tests did not pass. The reason was ${green.notes}.\nIdentify the cause, fix the implementation, and make the unit's tests pass. Weakening tests is forbidden.`,
       ),
       {
         label: `green2:${unit.id}`,

--- a/workflows/polish.js
+++ b/workflows/polish.js
@@ -4,12 +4,7 @@ export const meta = {
     'Deterministic Codex review + cleanup. Codex findings always pass through a critic-audit challenge, and the triage (confirmed / disputed / downgraded / needs_context) is decided by the script, so findings are never aggregated as facts and the challenge cannot be skipped. Callable standalone or nested from build via workflow("polish").',
   whenToUse:
     "Headless external-lens review of a diff plus AI-slop removal. args is a scope string, or {scope, repo, mode}. mode: full (default) runs review -> fix -> cleanup; review returns the challenged findings without fixing; cleanup runs only simplify + enhancer-code + test validation. For a deep internal-reviewer audit use the audit workflow.",
-  phases: [
-    { title: "Review" },
-    { title: "Challenge" },
-    { title: "Fix" },
-    { title: "Cleanup" },
-  ],
+  phases: [{ title: "Review" }, { title: "Challenge" }, { title: "Fix" }, { title: "Cleanup" }],
 };
 
 // Flatten of the /polish skill. The triage table lives in the script because
@@ -32,8 +27,7 @@ const opts = (() => {
 })();
 const scope = typeof opts.scope === "string" ? opts.scope : "";
 const repo = typeof opts.repo === "string" ? opts.repo : "";
-const mode =
-  opts.mode === "review" || opts.mode === "cleanup" ? opts.mode : "full";
+const mode = opts.mode === "review" || opts.mode === "cleanup" ? opts.mode : "full";
 
 const anchor = (p) =>
   repo
@@ -178,8 +172,8 @@ if (mode !== "cleanup") {
     const challenged = await agent(
       anchor(
         `critic-audit. Adversarially challenge this full set of external Codex review findings and return a verdict per finding.\n` +
-          `Verdict criteria: confirmed = real and the severity holds / disputed = false positive / downgraded = real but severity inflated (put the lowered severity in severity) / needs_context = undecidable from code alone, needs human context.\n` +
-          `Findings:\n${JSON.stringify(codex.findings)}`,
+          `The verdict criteria are as follows. confirmed = real and the severity holds / disputed = false positive / downgraded = real but severity inflated (put the lowered severity in severity) / needs_context = undecidable from code alone, needs human context.\n` +
+          `The findings are as follows.\n${JSON.stringify(codex.findings)}`,
       ),
       {
         agentType: "critic-audit",
@@ -210,10 +204,8 @@ if (mode !== "cleanup") {
         continue;
       }
       if (v.verdict === "disputed") continue;
-      const severity =
-        v.verdict === "downgraded" && v.severity ? v.severity : f.severity;
-      if (severity === "P1" || severity === "P2")
-        survivors.push({ ...f, severity });
+      const severity = v.verdict === "downgraded" && v.severity ? v.severity : f.severity;
+      if (severity === "P1" || severity === "P2") survivors.push({ ...f, severity });
     }
     log(
       `triage: ${survivors.length} survived / ${needsContext.length} needs_context / ${codex.findings.length - survivors.length - needsContext.length} dropped`,
@@ -236,7 +228,7 @@ if (mode !== "cleanup") {
       anchor(
         `Fix the findings that survived the challenge, highest severity first. ${scopeNote}\n` +
           `After fixing, detect and run the project's test command; roll back any fix that breaks tests via git stash. Do not commit.\n` +
-          `Findings:\n${JSON.stringify(survivors)}`,
+          `The findings are as follows.\n${JSON.stringify(survivors)}`,
       ),
       {
         label: "fix",

--- a/workflows/shake.js
+++ b/workflows/shake.js
@@ -57,8 +57,8 @@ const DIMENSIONS = [
 // norms embedded in both the fix and the invariant-check prompts.
 const INVARIANT_RULES =
   `A flaky fix changes how a test runs, never what it asserts.\n` +
-  `Allowed: clock injection / fake timers, pinning the seed, per-test state isolation, mocking the I/O boundary, unique temp dir / port per test.\n` +
-  `Forbidden: loosening an assertion or widening a tolerance, skipping / .only-ing / removing the test, replacing a real assertion with an always-pass stub, adding a blanket retry, tampering with the shake command or count. ` +
+  `What is allowed is clock injection / fake timers, pinning the seed, per-test state isolation, mocking the I/O boundary, unique temp dir / port per test.\n` +
+  `What is forbidden is loosening an assertion or widening a tolerance, skipping / .only-ing / removing the test, replacing a real assertion with an always-pass stub, adding a blanket retry, tampering with the shake command or count. ` +
   `The forbidden routes convert a flake into a silent gap, which is worse than the flake itself.`;
 
 // skill § Fix direction. Trigger to root-cause fix mapping.
@@ -140,13 +140,7 @@ const SMELL_SCHEMA = {
         properties: {
           smell: {
             type: "string",
-            enum: [
-              "wall-clock",
-              "unseeded-random",
-              "fixed-sleep",
-              "shared-state",
-              "fixed-path-io",
-            ],
+            enum: ["wall-clock", "unseeded-random", "fixed-sleep", "shared-state", "fixed-path-io"],
           },
           location: { type: "string", description: "file:line" },
           evidence: { type: "string" },
@@ -183,12 +177,7 @@ const INVARIANT_SCHEMA = {
 // (same rank as a stall). All pass = stable; all fail = broken (constant failure, not
 // flaky; reported as out of scope); mixed = flaky.
 const dimVerdict = (result) => {
-  if (
-    !result ||
-    !result.ran ||
-    !Array.isArray(result.runs) ||
-    result.runs.length < RUNS
-  ) {
+  if (!result || !result.ran || !Array.isArray(result.runs) || result.runs.length < RUNS) {
     return "unshaken";
   }
   const passes = result.runs.filter((r) => r.pass).length;
@@ -208,7 +197,7 @@ const route = (await agent(
       `1. ${scopeInstr}\n` +
       `2. Identify the test ecosystem (cargo test / nextest / jest / vitest etc.) from the project manifest.\n` +
       `3. Build the 4 dimension commands per target. Each command runs only that target once; the shake runner loops it ${RUNS} times. Including the string {RUN} substitutes the run number (1..${RUNS}) at execution time.\n` +
-      `   repeat: plain repeated normal run / order: randomize test order with a different seed each run (use {RUN} as the seed) / parallelism: alternate serial and max-worker (a one-liner branching on {RUN} parity) / seed: a different explicit seed each run if the suite accepts one, else an empty string.\n` +
+      `   repeat is a plain repeated normal run / order randomizes test order with a different seed each run (use {RUN} as the seed) / parallelism alternates serial and max-worker (a one-liner branching on {RUN} parity) / seed is a different explicit seed each run if the suite accepts one, else an empty string.\n` +
       `   For jest, for example, order is --shuffle with a seed, parallelism toggles --runInBand vs max workers. If a dimension cannot be constructed for the ecosystem, use an empty string.\n` +
       `Do not run or fix tests. This stage's job is deciding the commands only.`,
   ),
@@ -240,8 +229,8 @@ const results = await pipeline(
         agent(
           anchor(
             `You handle the static smell scan of shake. Scan the target test ${t.file} and its setup / fixtures / helpers with ugrep, and report signs of latent flakiness even where the test currently passes.\n` +
-              `Smells and grep patterns: wall-clock (Date.now, new Date(, Instant::now, SystemTime::, time.Now) / unseeded-random (Math.random, thread_rng, rand::random, faker) / fixed-sleep (setTimeout, thread::sleep, tokio::time::sleep, sleep() / shared-state (static mut, mutable module-level globals, singletons, missing per-test reset) / fixed-path-io (fixed /tmp paths, fixed ports, real network, env reads).\n` +
-              `Per hit, write file:line, the evidence, and the root-cause fix direction. Fix direction mapping:\n${FIX_DIRECTIONS}\n` +
+              `The smells and grep patterns are as follows. wall-clock (Date.now, new Date(, Instant::now, SystemTime::, time.Now) / unseeded-random (Math.random, thread_rng, rand::random, faker) / fixed-sleep (setTimeout, thread::sleep, tokio::time::sleep, sleep() / shared-state (static mut, mutable module-level globals, singletons, missing per-test reset) / fixed-path-io (fixed /tmp paths, fixed ports, real network, env reads).\n` +
+              `Per hit, write file:line, the evidence, and the root-cause fix direction. The fix-direction mapping is as follows.\n${FIX_DIRECTIONS}\n` +
               `Do not do a general review of the test logic itself.`,
           ),
           {
@@ -261,7 +250,7 @@ const results = await pipeline(
           });
         return agent(
           anchor(
-            `You handle the ${d.key} dimension of shake (exposes: ${d.exposes}). Run the command \`${d.command}\` ${RUNS} times. If it contains {RUN}, substitute the run number 1..${RUNS}.\n` +
+            `You handle the ${d.key} dimension of shake (it exposes ${d.exposes}). Run the command \`${d.command}\` ${RUNS} times. If it contains {RUN}, substitute the run number 1..${RUNS}.\n` +
               `Record each run's pass/fail as one element in runs (${RUNS} elements required; omitting runs or substituting an aggregate is not allowed). For failed runs, copy the gist of the error into note.\n` +
               `Do not change the test code or the command. Do not reduce the count. Even if you become convinced it is flaky midway, run all ${RUNS} times.`,
           ),
@@ -282,9 +271,7 @@ const results = await pipeline(
         dimension: d.key,
         verdict,
         fails:
-          verdict === "flaky" || verdict === "broken"
-            ? r.runs.filter((x) => !x.pass).length
-            : 0,
+          verdict === "flaky" || verdict === "broken" ? r.runs.filter((x) => !x.pass).length : 0,
         note: (r && r.notes) || "",
       };
     });
@@ -305,9 +292,7 @@ const results = await pipeline(
     else verdict = "stable";
     log(
       `${t.id}: ${verdict}` +
-        (triggers.length
-          ? ` (trigger: ${triggers.map((d) => d.dimension).join(", ")})`
-          : ""),
+        (triggers.length ? ` (trigger: ${triggers.map((d) => d.dimension).join(", ")})` : ""),
     );
 
     const fix = {
@@ -324,11 +309,11 @@ const results = await pipeline(
         const fixed = await agent(
           anchor(
             `You handle the fix stage of shake. Fix the root cause of the confirmed-flaky test ${t.file} (attempt ${attempt}/${MAX_FIX_ATTEMPTS}).\n` +
-              `Trigger dimensions: ${triggers.map((d) => `${d.dimension} (${d.fails}/${RUNS} fail)`).join(", ")}\n` +
-              `Static smells (root-cause candidates):\n${JSON.stringify(smells)}\n` +
-              `Fix direction mapping:\n${FIX_DIRECTIONS}\n\n${INVARIANT_RULES}\n` +
+              `The trigger dimensions are ${triggers.map((d) => `${d.dimension} (${d.fails}/${RUNS} fail)`).join(", ")}.\n` +
+              `The static smells (root-cause candidates) are as follows.\n${JSON.stringify(smells)}\n` +
+              `The fix-direction mapping is as follows.\n${FIX_DIRECTIONS}\n\n${INVARIANT_RULES}\n` +
               (history
-                ? `\nPrior attempts and failure reasons (if a prior attempt violated the invariant, roll it back first, then fix properly):\n${history}`
+                ? `\nThe prior attempts and failure reasons are as follows (if a prior attempt violated the invariant, roll it back first, then fix properly).\n${history}`
                 : ""),
           ),
           {
@@ -340,7 +325,7 @@ const results = await pipeline(
           },
         );
         if (!fixed || !fixed.applied) {
-          history += `attempt ${attempt}: no fix applied (${(fixed && fixed.summary) || "agent stall"})\n`;
+          history += `attempt ${attempt} applied no fix (${(fixed && fixed.summary) || "agent stall"})\n`;
           continue;
         }
         // independent invariant check ∥ re-shake of the trigger dimensions
@@ -376,9 +361,8 @@ const results = await pipeline(
         ]);
         // an invariant violation does not count as a fix (a stall is treated as a violation, fail-close)
         if (!inv || !inv.held) {
-          fix.invariant =
-            (inv && inv.reason) || "invariant check stall (fail-close)";
-          history += `attempt ${attempt}: invariant violation. ${fix.invariant}\n`;
+          fix.invariant = (inv && inv.reason) || "invariant check stall (fail-close)";
+          history += `attempt ${attempt} violated the invariant. ${fix.invariant}\n`;
           continue;
         }
         const reshakeVerdicts = triggers.map((trg, i) => ({
@@ -392,10 +376,8 @@ const results = await pipeline(
           fix.reshake = `all trigger dimensions ${RUNS}/${RUNS} stable`;
           break;
         }
-        fix.reshake = residual
-          .map((r) => `${r.dimension}=${r.verdict}`)
-          .join(", ");
-        history += `attempt ${attempt}: residual flake on re-shake (${fix.reshake})\n`;
+        fix.reshake = residual.map((r) => `${r.dimension}=${r.verdict}`).join(", ");
+        history += `attempt ${attempt} left residual flake on re-shake (${fix.reshake})\n`;
       }
       if (!fix.applied) {
         // skill § Stop point: a flake that survives 3 fix attempts is reported as a blocker, not weakened away


### PR DESCRIPTION
## 概要

- 全 workflow script (adrift / assert / audit / shake / code / build / polish) の agent prompt を MARKDOWN.md 記法規約に準拠させる。colon 導入 (`Steps:` `Findings:` `Label: value`) を散文 (「〜は次のとおり。」 / "The X is as follows.") に書き換え、prompt 内の em-dash を除去
- workflows/ と .ja/workflows/ (canonical) の両ツリーに同一の書き換えを反映
- polish workflow の cleanup pass を同梱。多行三項演算子等の単行化、build.js の Revalidate ∥ Branch 並列化で消えていた `phase("Branch")` シグナルの復元、checkout agent の haiku 固定
- .guardrails.json を追加 (sqliConcat ルールの false positive 抑止)

## 検証

- 全 14 script (両ツリー) の AsyncFunction parse pass
- `node --test workflows/tests/index.js` と `.ja/workflows/tests/index.js` とも 14/14 pass (U004_MANUAL_ACCEPTANCE=pass)
- oxlint clean

https://claude.ai/code/session_014zojevnNSiW5ff8oUSfbDS