### PR TITLE
feat(build): ship の PR 情報系 tail を対象言語へ翻訳 + 軽く圧縮

### DIFF
--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -322,9 +322,10 @@ if (!planHeading) {
 const afterHeading = body.slice(planHeading.index + planHeading[0].length);
 const nextSection = afterHeading.search(/^##[^#]/m);
 const planSection = nextSection === -1 ? afterHeading : afterHeading.slice(0, nextSection);
-const idSet = (re) => new Set([...planSection.matchAll(re)].map((m) => m[0]));
-const bodyUnitIds = idSet(/\bU-\d{3}\b/g);
-const bodyTestIds = idSet(/\bT-\d{3}\b/g);
+// id は定義位置でのみ拾い、prose 参照は拾わない (plan-section.md 参照)。
+const idSet = (re) => new Set([...planSection.matchAll(re)].map((m) => m[1]));
+const bodyUnitIds = idSet(/^###\s+(U-\d{3})\b/gm);
+const bodyTestIds = idSet(/^[ \t]*[-*+][ \t]+(T-\d{3})\b/gm);
 
 const plan = await agent(
   anchor(
@@ -479,6 +480,13 @@ if (!code.tests_pass || !code.gates_pass)
   log(
     `code の独立 verify が fail (tests=${code.tests_pass} gates=${code.gates_pass})。audit へ前進し PR に表面化する。`,
   );
+// workflow("code") は自前の `▸ code` グループで走るため Code phase ボックスに直接 agent が
+// 付かず「Not started」のままになる。この安価な agent 1 体で着火・完了させ、code phase が
+// 届けた内容の run-log recap も兼ねる。
+await agent(
+  `Summarize in one line what the code phase delivered: ${plan.units.length} unit(s) implemented, independent verify tests=${code.tests_pass} gates=${code.gates_pass}. Return the sentence only.`,
+  { label: "code-summary", phase: "Code", model: "haiku" },
+);
 
 // ---- Audit ∥ Polish review ∥ Conformance -> fix -> re-audit loop (audit 実行は最大 3 回) ----
 // audit は workflow("audit") が fan-out を所有する (/audit の glob routing 表 + reviewer ->
@@ -597,6 +605,13 @@ const residualBlocking = reaudited ? criticalHigh(audit) : toFix;
 // review レンズは Audit phase で消化済みなので、ここは mutator だけを回す。
 phase("Polish");
 const cleanup = await workflow("polish", { repo, mode: "cleanup" });
+// workflow("polish") は自前の `▸ polish` グループで走るため Polish phase ボックスに直接 agent
+// が付かない。Code phase と同じく agent 1 体で着火・完了させる。
+const cleanupEdits = cleanup?.cleanup?.edits?.length ?? 0;
+await agent(
+  `Summarize in one line what the polish phase did: ${cleanupEdits} cleanup edit(s) applied, tests_pass=${cleanup?.cleanup?.tests_pass}. Return the sentence only.`,
+  { label: "polish-summary", phase: "Polish", model: "haiku" },
+);
 
 // ---- Backlog: scope 外の発見を「ユーザーが起票する候補」として集める ----
 // 候補源は issue 本文に書かれた scope 外候補 (source: issue) と build 中の発見 (code /
@@ -640,23 +655,99 @@ if (backlogCandidates.length) {
 // 一切作られず、tail の欠けた PR を出さない。verify ログの pass/fail 判定は pr-body.py だけが
 // 持つ (失敗時のみ verify_output を読む) ので、payload は無条件でそれを渡す。
 phase("Ship");
+
+// tail のラベルは pr-body.py が言語化するが、finding 本文は reviewer が英語で吐くので
+// そのまま出ていた。人間レビュアーも読むため、fail-closed でない情報系セクションの
+// 自由記述だけを対象言語へ翻訳 + 軽く圧縮する。安全事実 (verify status / not-reaudited
+// 警告 / verify_output ログ) と、file:line・severity・件数・識別子といった構造化フィールド
+// は対象外で決定論のまま残す。source の finding を mutate しないよう copy に対して行う。
+const shipAssumptions = [...(plan.assumptions || [])];
+const shipBacklog = backlogCandidates.map((c) => ({ ...c }));
+const shipResidual = residualBlocking.map((f) => ({ ...f }));
+const shipAnomalies = (code.anomalies || []).map((a) => ({ ...a }));
+const shipConformance = conf.spec_found ? conf.findings.map((f) => ({ ...f })) : [];
+
+// 翻訳対象の自由記述だけを id 付きで集める。書き戻しは set() 経由で、構造化
+// フィールドには触れない。空文字列は翻訳に送らない。
+const slots = [];
+shipAssumptions.forEach((t, i) => {
+  if (typeof t === "string" && t.trim())
+    slots.push({ text: t, set: (v) => (shipAssumptions[i] = v) });
+});
+for (const c of shipBacklog)
+  if (c.summary && c.summary.trim()) slots.push({ text: c.summary, set: (v) => (c.summary = v) });
+for (const f of shipResidual)
+  if (f.summary && f.summary.trim()) slots.push({ text: f.summary, set: (v) => (f.summary = v) });
+for (const f of shipConformance)
+  if (f.detail && f.detail.trim()) slots.push({ text: f.detail, set: (v) => (f.detail = v) });
+for (const a of shipAnomalies)
+  if (a.notes && a.notes.trim()) slots.push({ text: a.notes, set: (v) => (a.notes = v) });
+
+if (slots.length) {
+  // 単一利用の schema。各要素に入力の id を付けて返させ、id で書き戻す。順序が
+  // 入れ替わっても取り違えず、全 id が揃わなければ fail-open で英語原文を維持。
+  const TRANSLATION_SCHEMA = {
+    type: "object",
+    additionalProperties: false,
+    required: ["translations"],
+    properties: {
+      translations: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["id", "text"],
+          properties: { id: { type: "integer" }, text: { type: "string" } },
+        },
+      },
+    },
+  };
+  const translated = await agent(
+    anchor(
+      `\`$HOME/.claude/settings.json\` の \`language\` を読む (未設定なら english)。` +
+        `次の JSON 配列は PR 本文の情報系セクション (backlog / assumptions / 未解決 finding / conformance / anomaly) の自由記述。各要素の \`text\` を \`language\` へ翻訳し、冗長な散文は締めて短くする。english のときも軽い圧縮のためこの手順を通す。\n` +
+        `厳守: (a) file:line・パス・数値・件数・severity ラベル・識別子・コード片は原文のまま残す。(b) 事実を足さない・削らない。訳と圧縮のみで、新しい主張や件数を作らない。(c) 出力 \`translations\` は各要素に入力の \`id\` を付けて全件返す。順序は問わないが id は入力と一致させる。\n` +
+        `入力:\n${JSON.stringify(slots.map((s, i) => ({ id: i, text: s.text })))}`,
+    ),
+    {
+      label: "translate-tail",
+      phase: "Ship",
+      schema: TRANSLATION_SCHEMA,
+      model: "sonnet",
+    },
+  );
+  const out = translated && translated.translations;
+  // id で突合。全 slot 分の訳が揃ったときだけ反映し、欠落・取り違え・順序入れ替えは
+  // 英語原文で継続する。
+  const byId = new Map();
+  if (Array.isArray(out))
+    for (const o of out)
+      if (o && Number.isInteger(o.id) && typeof o.text === "string" && o.text.trim())
+        byId.set(o.id, o.text);
+  if (slots.every((_, i) => byId.has(i))) {
+    slots.forEach((s, i) => s.set(byId.get(i)));
+  } else {
+    log(`translate-tail: 訳が ${byId.size}/${slots.length} 件、英語原文で ship を継続。`);
+  }
+}
+
 const shipPayload = {
   issue: issueNumber,
-  assumptions: plan.assumptions || [],
-  backlog_candidates: backlogCandidates,
-  residual_blocking: residualBlocking,
+  assumptions: shipAssumptions,
+  backlog_candidates: shipBacklog,
+  residual_blocking: shipResidual,
   reaudited,
-  code_anomalies: code.anomalies || [],
+  code_anomalies: shipAnomalies,
   tests_pass: code.tests_pass,
   gates_pass: code.gates_pass,
   verify_output: code.verify_output || "",
-  conformance: conf.spec_found ? conf.findings : [],
+  conformance: shipConformance,
 };
 const ship = await agent(
   anchor(
     `全変更 (planning 成果物 + 実装) を 1 つの Conventional Commits commit にする。commit メッセージは自分で書く (diff を要約する)。` +
-      `branch を push し、draft pull request を開く。body は自分で書く人間向け Summary と、データから決定論生成した事実セクションの 2 部構成にする (事実セクションは手書きしない)。手順は次のとおり。\n` +
-      `(1) 人間レビュアー向けの簡潔な "## Summary" を body file に書く。散文の段落でなく markdown の箇条書きで、この PR が何を実装したか (outcome は ${JSON.stringify(plan.outcome)})、アプローチを 1 行、レビューで注視すべき箇所を書く。最大 5 項目程度、冗長表現も事実の捏造もしない。\n` +
+      `branch を push し、draft pull request を開く。body は PR テンプレートから自分で書く人間向け部分と、データから決定論生成した事実セクションの 2 部構成にする (事実セクションは手書きしない)。手順は次のとおり。\n` +
+      `(1) \`$HOME/.claude/settings.json\` の \`language\` を読み (未設定なら英語)、人間向け body をその言語で書く。code・識別子・技術用語は翻訳しない。PR テンプレートを選ぶ。repository にあればそれを使い (case-insensitive、優先順 \`.github/pull_request_template.md\` > \`pull_request_template.md\` > \`docs/pull_request_template.md\` > \`PULL_REQUEST_TEMPLATE/\` ディレクトリ)、なければ bundled \`$HOME/.claude/skills/pr/templates/pr.md\` を使う。skeleton を読んで body file に畳み込む。人間向けセクションだけを埋め、レビュアーが一目で意図をつかめるようにする。この PR が何を実装したか (outcome は ${JSON.stringify(plan.outcome)})、アプローチ、レビューで注視すべき箇所を、リストとコンパクトな table で簡潔に書く。冗長表現も事実の捏造もしない。決定論 tail が既に出すセクションはスキップする。Related / Closes (tail が \`Closes #\` を出す) と Scope / Backlog (tail が backlog を出す)。Design Decisions は plan の decisions (${JSON.stringify(plan.decisions || [])}) と実際の diff から埋め、空ならセクションごと省く。\n` +
       `(2) この JSON をそのまま temp file に書き出す。\n${JSON.stringify(shipPayload)}\n` +
       `(3) 事実 tail の追記と PR 作成を 1 つの \`&&\` チェーンで行い、renderer 失敗時は PR を作る前に中断する。repository root から ` +
       `\`python3 "$HOME/.claude/workflows/build/pr-body.py" < <tempfile> >> <bodyfile> && gh pr create --draft --title "<commit subject>" --body-file <bodyfile>\` を実行する。\n` +

--- a/.ja/workflows/build/tests/build.behavior.test.js
+++ b/.ja/workflows/build/tests/build.behavior.test.js
@@ -67,15 +67,20 @@ const kindOf = (opts) => {
   if ("units" in p) return "extract";
   if ("results" in p) return "revalidate";
   if ("spec_found" in p) return "conformance";
+  if ("translations" in p) return "translate";
   if ("pr_url" in p) return "ship";
   return "plain";
 };
 
 // happy path stub 一式。body / plan / revalidate で happy path の戻り値を差し替える。
-const makeStubs = ({ body, plan, revalidate, conformance } = {}) => ({
+const makeStubs = ({ body, plan, revalidate, conformance, translate } = {}) => ({
   agent: (prompt, opts) => {
     const kind = kindOf(opts);
     switch (kind) {
+      case "translate":
+        // 既定は fail-open (translations 無し) で英語原文を維持。翻訳の反映を検証する
+        // テストだけが translate stub を渡す。
+        return translate ? translate(prompt) : { notes: "no-translations" };
       case "fetch":
         return { found: true, body: body ?? bodyFor(["U-001"], ["T-001"]) };
       case "extract":
@@ -236,6 +241,39 @@ test("抽出での unit / test の silent drop は stopped: extraction-mismatch 
   assert.ok(
     JSON.stringify(b.result.detail).includes("T-003"),
     "不一致 test id T-003 が detail に載る",
+  );
+});
+
+test("契約 prose 中の T-NNN 参照は定義でないので cross-check に載らず extraction-mismatch にならない", async () => {
+  // contract 文の「既存の T-106 は変更しない」は参照であって定義ではない。
+  // 定義された受け入れテストは T-109 のみで、抽出も T-109 のみを返す。
+  const body = [
+    "## Plan",
+    "",
+    "Outcome: sample outcome",
+    "test_command: echo test",
+    "",
+    "### U-001: unit の見出し",
+    "",
+    "- contract: 既存の T-106 とプロダクションコードは変更しない",
+    "",
+    "受け入れテスト。",
+    "",
+    "- T-109: test scenario",
+    "",
+  ].join("\n");
+  const base = makePlan().units[0];
+  const plan = makePlan({
+    units: [{ ...base, tests: [{ ...base.tests[0], id: "T-109" }] }],
+  });
+  const r = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ body, plan }),
+  });
+  assert.notEqual(
+    r.result.stopped,
+    "extraction-mismatch",
+    "prose 参照 T-106 を欠落テストと誤検出しない",
   );
 });
 
@@ -417,9 +455,101 @@ test("conformance findings が独立軸として surface し fix loop / residual
   assert.equal(result.conformance_findings, 1, "戻り値 conformance_findings が 1");
 
   // 独立軸: conformance finding は fix loop を起動せず、blocking count にも混ざらない
-  const fixCalls = calls.agent.filter((c) => c.opts && /^fix:/.test(c.opts.label || ""));
+  const fixCalls = calls.agent.filter((c) => c.opts && (c.opts.label || "").startsWith("fix:"));
   assert.equal(fixCalls.length, 0, "conformance finding は fix loop を起動しない");
   assert.equal(result.residual_blocking, 0, "conformance finding は blocking count に混ざらない");
+});
+
+// tail の情報系セクション (backlog / assumptions / 未解決 finding / conformance /
+// anomaly) の自由記述は reviewer が英語で吐くので、Ship 直前に対象言語へ翻訳 + 圧縮する。
+// 訳文が shipPayload に反映され、ship prompt (PR body payload) に載ることを検証する。
+test("translate-tail の訳文が shipPayload に反映され ship prompt に載る", async () => {
+  const plan = makePlan({
+    assumptions: ["assume in EN"],
+    backlog_candidates: [{ summary: "backlog in EN" }],
+  });
+  const { calls } = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({
+      plan,
+      // 入力配列は prompt の最終行 (言語マーカーに依存しない)。各 {id,text} の text を
+      // JA<...> でラップし、id を付けて返す。
+      translate: (prompt) => {
+        const arr = JSON.parse(prompt.trim().split("\n").pop());
+        return { translations: arr.map((o) => ({ id: o.id, text: `JA<${o.text}>` })) };
+      },
+    }),
+  });
+
+  // translate agent は slots が非空 (assumption + backlog) なので 1 回呼ばれる
+  const translateCalls = agentCallsOf(calls, "translate");
+  assert.equal(translateCalls.length, 1, "translate-tail agent が 1 回呼ばれる");
+
+  // 訳文が ship prompt (shipPayload JSON) に載り、英語原文は残らない
+  const shipCalls = agentCallsOf(calls, "ship");
+  assert.equal(shipCalls.length, 1, "ship agent が 1 回呼ばれる");
+  assert.ok(
+    shipCalls[0].prompt.includes("JA<backlog in EN>"),
+    "ship prompt に翻訳済み backlog summary が載る",
+  );
+  assert.ok(
+    shipCalls[0].prompt.includes("JA<assume in EN>"),
+    "ship prompt に翻訳済み assumption が載る",
+  );
+});
+
+// 訳が id 順を入れ替えて返っても、消費側は id で突合して正しい slot へ書き戻す。
+test("translate-tail の訳が順序入れ替えでも id で正しい slot に反映される", async () => {
+  const plan = makePlan({
+    assumptions: ["assume A"],
+    backlog_candidates: [{ summary: "backlog B" }],
+  });
+  const { calls } = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({
+      plan,
+      // id を保ったまま順序を反転して返す (位置ベースなら取り違える)
+      translate: (prompt) => {
+        const arr = JSON.parse(prompt.trim().split("\n").pop());
+        return { translations: arr.map((o) => ({ id: o.id, text: `JA<${o.text}>` })).reverse() };
+      },
+    }),
+  });
+
+  const shipCalls = agentCallsOf(calls, "ship");
+  assert.equal(shipCalls.length, 1, "ship agent が 1 回呼ばれる");
+  assert.ok(
+    shipCalls[0].prompt.includes("JA<backlog B>"),
+    "順序反転でも backlog summary に自分の訳が載る",
+  );
+  assert.ok(
+    shipCalls[0].prompt.includes("JA<assume A>"),
+    "順序反転でも assumption に自分の訳が載る",
+  );
+});
+
+// 訳の id が入力と一致しない (欠落・取り違え) とき、消費側は fail-open で英語原文を
+// 維持し PR を block しない。
+test("translate-tail の訳 id が入力と一致しないなら英語原文で ship を継続する", async () => {
+  const plan = makePlan({
+    backlog_candidates: [{ summary: "backlog in EN" }],
+  });
+  const { calls } = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({
+      plan,
+      // slot 0 の訳が無く、存在しない id 5 の訳を返す (取り違え)
+      translate: () => ({ translations: [{ id: 5, text: "only one" }] }),
+    }),
+  });
+
+  const shipCalls = agentCallsOf(calls, "ship");
+  assert.equal(shipCalls.length, 1, "ship agent が 1 回呼ばれる");
+  assert.ok(
+    shipCalls[0].prompt.includes("backlog in EN"),
+    "id 不一致時は英語原文の backlog summary が ship prompt に残る",
+  );
+  assert.ok(!shipCalls[0].prompt.includes("only one"), "id 不一致の訳は採用されない");
 });
 
 test("実環境で Plan 節付き issue が Load → Revalidate → Branch → Code と進み、Plan 節なし issue が stopped: no-plan を返す (manual acceptance、done 前必須)", () => {

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -329,9 +329,10 @@ if (!planHeading) {
 const afterHeading = body.slice(planHeading.index + planHeading[0].length);
 const nextSection = afterHeading.search(/^##[^#]/m);
 const planSection = nextSection === -1 ? afterHeading : afterHeading.slice(0, nextSection);
-const idSet = (re) => new Set([...planSection.matchAll(re)].map((m) => m[0]));
-const bodyUnitIds = idSet(/\bU-\d{3}\b/g);
-const bodyTestIds = idSet(/\bT-\d{3}\b/g);
+// Match ids at their definition position only, not prose references (see plan-section.md).
+const idSet = (re) => new Set([...planSection.matchAll(re)].map((m) => m[1]));
+const bodyUnitIds = idSet(/^###\s+(U-\d{3})\b/gm);
+const bodyTestIds = idSet(/^[ \t]*[-*+][ \t]+(T-\d{3})\b/gm);
 
 const plan = await agent(
   anchor(
@@ -489,6 +490,13 @@ if (!code.tests_pass || !code.gates_pass)
   log(
     `code's independent verify failed (tests=${code.tests_pass} gates=${code.gates_pass}). Advancing to audit; it surfaces on the PR.`,
   );
+// workflow("code") runs under its own `▸ code` group, so the Code phase box has no direct
+// agent and would render "Not started" forever. This one cheap agent lights it up and
+// completes it, doubling as a run-log recap of what the code phase delivered.
+await agent(
+  `Summarize in one line what the code phase delivered: ${plan.units.length} unit(s) implemented, independent verify tests=${code.tests_pass} gates=${code.gates_pass}. Return the sentence only.`,
+  { label: "code-summary", phase: "Code", model: "haiku" },
+);
 
 // ---- Audit ∥ Polish review ∥ Conformance -> fix -> re-audit loop (at most 3 audit runs) ----
 // The audit fan-out is owned by workflow("audit") (/audit's glob routing table +
@@ -613,6 +621,13 @@ const residualBlocking = reaudited ? criticalHigh(audit) : toFix;
 // The review lens was consumed in the Audit phase, so only the mutators run here.
 phase("Polish");
 const cleanup = await workflow("polish", { repo, mode: "cleanup" });
+// workflow("polish") runs under its own `▸ polish` group, so the Polish phase box needs one
+// direct agent to light up and complete — same pattern as the Code phase above.
+const cleanupEdits = cleanup?.cleanup?.edits?.length ?? 0;
+await agent(
+  `Summarize in one line what the polish phase did: ${cleanupEdits} cleanup edit(s) applied, tests_pass=${cleanup?.cleanup?.tests_pass}. Return the sentence only.`,
+  { label: "polish-summary", phase: "Polish", model: "haiku" },
+);
 
 // ---- Backlog: collect out-of-scope discoveries as candidates for the user ----
 // Candidate sources are the out-of-scope candidates written in the issue body
@@ -663,23 +678,104 @@ if (backlogCandidates.length) {
 // pass/fail gating of the verify log lives only in pr-body.py (it reads
 // verify_output solely on failure), so the payload passes it through unconditionally.
 phase("Ship");
+
+// The tail labels are localized by pr-body.py, but the finding bodies come from the
+// reviewers in English, so they printed as-is. Since human reviewers read the PR too,
+// translate + lightly compress only the free-text of the informational (not
+// fail-closed) sections into the target language. Safety facts (verify status /
+// not-reaudited warning / verify_output log) and structured fields (file:line,
+// severity, counts, identifiers) are excluded and stay deterministic. Operate on
+// copies so the source finding objects are not mutated.
+const shipAssumptions = [...(plan.assumptions || [])];
+const shipBacklog = backlogCandidates.map((c) => ({ ...c }));
+const shipResidual = residualBlocking.map((f) => ({ ...f }));
+const shipAnomalies = (code.anomalies || []).map((a) => ({ ...a }));
+const shipConformance = conf.spec_found ? conf.findings.map((f) => ({ ...f })) : [];
+
+// Collect only the translatable free-text with an id. Writing back goes through
+// set(), never touching structured fields. Empty strings are not sent to translation.
+const slots = [];
+shipAssumptions.forEach((t, i) => {
+  if (typeof t === "string" && t.trim())
+    slots.push({ text: t, set: (v) => (shipAssumptions[i] = v) });
+});
+for (const c of shipBacklog)
+  if (c.summary && c.summary.trim()) slots.push({ text: c.summary, set: (v) => (c.summary = v) });
+for (const f of shipResidual)
+  if (f.summary && f.summary.trim()) slots.push({ text: f.summary, set: (v) => (f.summary = v) });
+for (const f of shipConformance)
+  if (f.detail && f.detail.trim()) slots.push({ text: f.detail, set: (v) => (f.detail = v) });
+for (const a of shipAnomalies)
+  if (a.notes && a.notes.trim()) slots.push({ text: a.notes, set: (v) => (a.notes = v) });
+
+if (slots.length) {
+  // Single-use schema. Force each element to carry back the input id, and write back
+  // by id: a reordered response is not misassigned, and unless every id is present it
+  // is fail-open, keeping the English originals.
+  const TRANSLATION_SCHEMA = {
+    type: "object",
+    additionalProperties: false,
+    required: ["translations"],
+    properties: {
+      translations: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["id", "text"],
+          properties: { id: { type: "integer" }, text: { type: "string" } },
+        },
+      },
+    },
+  };
+  const translated = await agent(
+    anchor(
+      `Read \`language\` from \`$HOME/.claude/settings.json\` (english if unset). ` +
+        `The following JSON array is the free-text of the PR body's informational sections (backlog / assumptions / unresolved findings / conformance / anomaly). Translate each element's \`text\` into \`language\` and tighten verbose prose. Run this step even for english, for the light compression.\n` +
+        `Strict: (a) keep file:line, paths, numbers, counts, severity labels, identifiers, and code fragments verbatim. (b) Add no facts and drop none. Translate and compress only; invent no new claim or count. (c) Return \`translations\` with every element carrying the input \`id\`; order is free but each id must match the input.\n` +
+        `Input:\n${JSON.stringify(slots.map((s, i) => ({ id: i, text: s.text })))}`,
+    ),
+    {
+      label: "translate-tail",
+      phase: "Ship",
+      schema: TRANSLATION_SCHEMA,
+      model: "sonnet",
+    },
+  );
+  const out = translated && translated.translations;
+  // Match by id. Apply only when a translation exists for every slot; a missing,
+  // misassigned, or reordered response ships with the English originals.
+  const byId = new Map();
+  if (Array.isArray(out))
+    for (const o of out)
+      if (o && Number.isInteger(o.id) && typeof o.text === "string" && o.text.trim())
+        byId.set(o.id, o.text);
+  if (slots.every((_, i) => byId.has(i))) {
+    slots.forEach((s, i) => s.set(byId.get(i)));
+  } else {
+    log(
+      `translate-tail: ${byId.size}/${slots.length} translated, shipping with English originals.`,
+    );
+  }
+}
+
 const shipPayload = {
   issue: issueNumber,
-  assumptions: plan.assumptions || [],
-  backlog_candidates: backlogCandidates,
-  residual_blocking: residualBlocking,
+  assumptions: shipAssumptions,
+  backlog_candidates: shipBacklog,
+  residual_blocking: shipResidual,
   reaudited,
-  code_anomalies: code.anomalies || [],
+  code_anomalies: shipAnomalies,
   tests_pass: code.tests_pass,
   gates_pass: code.gates_pass,
   verify_output: code.verify_output || "",
-  conformance: conf.spec_found ? conf.findings : [],
+  conformance: shipConformance,
 };
 const ship = await agent(
   anchor(
     `Turn all changes (planning artifacts + implementation) into a single Conventional Commits commit; you write the commit message (summarize the diff). ` +
-      `Push the branch, then open a draft pull request. Its body is a human-facing Summary you write, followed by deterministic fact sections rendered from data (do not hand-write the fact sections). The steps are as follows.\n` +
-      `(1) write a terse "## Summary" to a body file for the human reviewer, in markdown bullets rather than prose paragraphs. Cover what this PR implements (the outcome is ${JSON.stringify(plan.outcome)}), the approach in a line, and where to focus review. At most ~5 bullets; no filler, no invented facts.\n` +
+      `Push the branch, then open a draft pull request. Its body is a human-facing part you write from a PR template, followed by deterministic fact sections rendered from data (do not hand-write the fact sections). The steps are as follows.\n` +
+      `(1) Read \`language\` from \`$HOME/.claude/settings.json\` (default English if unset) and write the human-facing body in that language, keeping code, identifiers, and technical terms untranslated. Choose the PR template: the repository's if present (case-insensitive, priority \`.github/pull_request_template.md\` > \`pull_request_template.md\` > \`docs/pull_request_template.md\` > a \`PULL_REQUEST_TEMPLATE/\` directory), otherwise the bundled \`$HOME/.claude/skills/pr/templates/pr.md\`; read the skeleton and fold it into the body file. Fill only the human-facing sections so a reviewer grasps the intent at a glance: what this PR implements (the outcome is ${JSON.stringify(plan.outcome)}), the approach, and where to focus review. Use lists and compact tables, keep it terse, no filler, no invented facts. SKIP any template section the deterministic tail already covers: Related / Closes (the tail emits \`Closes #\`) and Scope / Backlog (the tail emits the backlog). Fill Design Decisions from the plan decisions (${JSON.stringify(plan.decisions || [])}) and the actual diff; omit the section if empty rather than inventing.\n` +
       `(2) write this exact JSON to a temp file.\n${JSON.stringify(shipPayload)}\n` +
       `(3) append the fact tail and open the PR as ONE \`&&\` chain, so a renderer failure aborts before the PR is created; from the repository root run ` +
       `\`python3 "$HOME/.claude/workflows/build/pr-body.py" < <tempfile> >> <bodyfile> && gh pr create --draft --title "<your commit subject>" --body-file <bodyfile>\`.\n` +

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -67,15 +67,20 @@ const kindOf = (opts) => {
   if ("units" in p) return "extract";
   if ("results" in p) return "revalidate";
   if ("spec_found" in p) return "conformance";
+  if ("translations" in p) return "translate";
   if ("pr_url" in p) return "ship";
   return "plain";
 };
 
 // happy path stub 一式。body / plan / revalidate で happy path の戻り値を差し替える。
-const makeStubs = ({ body, plan, revalidate, conformance } = {}) => ({
+const makeStubs = ({ body, plan, revalidate, conformance, translate } = {}) => ({
   agent: (prompt, opts) => {
     const kind = kindOf(opts);
     switch (kind) {
+      case "translate":
+        // 既定は fail-open (translations 無し) で英語原文を維持。翻訳の反映を検証する
+        // テストだけが translate stub を渡す。
+        return translate ? translate(prompt) : { notes: "no-translations" };
       case "fetch":
         return { found: true, body: body ?? bodyFor(["U-001"], ["T-001"]) };
       case "extract":
@@ -236,6 +241,39 @@ test("抽出での unit / test の silent drop は stopped: extraction-mismatch 
   assert.ok(
     JSON.stringify(b.result.detail).includes("T-003"),
     "不一致 test id T-003 が detail に載る",
+  );
+});
+
+test("契約 prose 中の T-NNN 参照は定義でないので cross-check に載らず extraction-mismatch にならない", async () => {
+  // contract 文の「既存の T-106 は変更しない」は参照であって定義ではない。
+  // 定義された受け入れテストは T-109 のみで、抽出も T-109 のみを返す。
+  const body = [
+    "## Plan",
+    "",
+    "Outcome: sample outcome",
+    "test_command: echo test",
+    "",
+    "### U-001: unit の見出し",
+    "",
+    "- contract: 既存の T-106 とプロダクションコードは変更しない",
+    "",
+    "受け入れテスト。",
+    "",
+    "- T-109: test scenario",
+    "",
+  ].join("\n");
+  const base = makePlan().units[0];
+  const plan = makePlan({
+    units: [{ ...base, tests: [{ ...base.tests[0], id: "T-109" }] }],
+  });
+  const r = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({ body, plan }),
+  });
+  assert.notEqual(
+    r.result.stopped,
+    "extraction-mismatch",
+    "prose 参照 T-106 を欠落テストと誤検出しない",
   );
 });
 
@@ -417,9 +455,101 @@ test("conformance findings が独立軸として surface し fix loop / residual
   assert.equal(result.conformance_findings, 1, "戻り値 conformance_findings が 1");
 
   // 独立軸: conformance finding は fix loop を起動せず、blocking count にも混ざらない
-  const fixCalls = calls.agent.filter((c) => c.opts && /^fix:/.test(c.opts.label || ""));
+  const fixCalls = calls.agent.filter((c) => c.opts && (c.opts.label || "").startsWith("fix:"));
   assert.equal(fixCalls.length, 0, "conformance finding は fix loop を起動しない");
   assert.equal(result.residual_blocking, 0, "conformance finding は blocking count に混ざらない");
+});
+
+// tail の情報系セクション (backlog / assumptions / 未解決 finding / conformance /
+// anomaly) の自由記述は reviewer が英語で吐くので、Ship 直前に対象言語へ翻訳 + 圧縮する。
+// 訳文が shipPayload に反映され、ship prompt (PR body payload) に載ることを検証する。
+test("translate-tail の訳文が shipPayload に反映され ship prompt に載る", async () => {
+  const plan = makePlan({
+    assumptions: ["assume in EN"],
+    backlog_candidates: [{ summary: "backlog in EN" }],
+  });
+  const { calls } = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({
+      plan,
+      // 入力配列は prompt の最終行 (言語マーカーに依存しない)。各 {id,text} の text を
+      // JA<...> でラップし、id を付けて返す。
+      translate: (prompt) => {
+        const arr = JSON.parse(prompt.trim().split("\n").pop());
+        return { translations: arr.map((o) => ({ id: o.id, text: `JA<${o.text}>` })) };
+      },
+    }),
+  });
+
+  // translate agent は slots が非空 (assumption + backlog) なので 1 回呼ばれる
+  const translateCalls = agentCallsOf(calls, "translate");
+  assert.equal(translateCalls.length, 1, "translate-tail agent が 1 回呼ばれる");
+
+  // 訳文が ship prompt (shipPayload JSON) に載り、英語原文は残らない
+  const shipCalls = agentCallsOf(calls, "ship");
+  assert.equal(shipCalls.length, 1, "ship agent が 1 回呼ばれる");
+  assert.ok(
+    shipCalls[0].prompt.includes("JA<backlog in EN>"),
+    "ship prompt に翻訳済み backlog summary が載る",
+  );
+  assert.ok(
+    shipCalls[0].prompt.includes("JA<assume in EN>"),
+    "ship prompt に翻訳済み assumption が載る",
+  );
+});
+
+// 訳が id 順を入れ替えて返っても、消費側は id で突合して正しい slot へ書き戻す。
+test("translate-tail の訳が順序入れ替えでも id で正しい slot に反映される", async () => {
+  const plan = makePlan({
+    assumptions: ["assume A"],
+    backlog_candidates: [{ summary: "backlog B" }],
+  });
+  const { calls } = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({
+      plan,
+      // id を保ったまま順序を反転して返す (位置ベースなら取り違える)
+      translate: (prompt) => {
+        const arr = JSON.parse(prompt.trim().split("\n").pop());
+        return { translations: arr.map((o) => ({ id: o.id, text: `JA<${o.text}>` })).reverse() };
+      },
+    }),
+  });
+
+  const shipCalls = agentCallsOf(calls, "ship");
+  assert.equal(shipCalls.length, 1, "ship agent が 1 回呼ばれる");
+  assert.ok(
+    shipCalls[0].prompt.includes("JA<backlog B>"),
+    "順序反転でも backlog summary に自分の訳が載る",
+  );
+  assert.ok(
+    shipCalls[0].prompt.includes("JA<assume A>"),
+    "順序反転でも assumption に自分の訳が載る",
+  );
+});
+
+// 訳の id が入力と一致しない (欠落・取り違え) とき、消費側は fail-open で英語原文を
+// 維持し PR を block しない。
+test("translate-tail の訳 id が入力と一致しないなら英語原文で ship を継続する", async () => {
+  const plan = makePlan({
+    backlog_candidates: [{ summary: "backlog in EN" }],
+  });
+  const { calls } = await runWorkflow(buildJs, {
+    args: { issue: "123" },
+    stubs: makeStubs({
+      plan,
+      // slot 0 の訳が無く、存在しない id 5 の訳を返す (取り違え)
+      translate: () => ({ translations: [{ id: 5, text: "only one" }] }),
+    }),
+  });
+
+  const shipCalls = agentCallsOf(calls, "ship");
+  assert.equal(shipCalls.length, 1, "ship agent が 1 回呼ばれる");
+  assert.ok(
+    shipCalls[0].prompt.includes("backlog in EN"),
+    "id 不一致時は英語原文の backlog summary が ship prompt に残る",
+  );
+  assert.ok(!shipCalls[0].prompt.includes("only one"), "id 不一致の訳は採用されない");
 });
 
 test("実環境で Plan 節付き issue が Load → Revalidate → Branch → Code と進み、Plan 節なし issue が stopped: no-plan を返す (manual acceptance、done 前必須)", () => {


### PR DESCRIPTION
## 目的と背景

build.js の ship phase が生成する draft PR は、backlog / assumptions / 未解決 finding / conformance / anomaly の自由記述が reviewer 由来の英語のまま出ていた ([例: gates#134](https://github.com/thkt/gates/pull/134))。人間 reviewer も読むため、これらを対象言語へ翻訳し軽く圧縮する。

## 変更内容

- ship phase に `translate-tail` agent (sonnet) を追加。情報系セクションの自由記述だけを settings.json の `language` へ翻訳 + 軽く圧縮する。
- 安全事実 (verify status / not-reaudited 警告 / verify_output ログ) と構造化フィールド (file:line / severity / 件数 / 識別子) は対象外で決定論のまま (pr-body.py 側)。
- 反映は id 突合。各 slot に id を付けて送り id で書き戻すため、LLM が順序を入れ替えても取り違えず、全 id が揃わない欠落・取り違えは英語原文で fail-open。
- JA canonical + EN mirror を同一コミットで更新 (ADR-0073)。

## 設計判断

- 翻訳は build.js 側に置く。pr-body.py は fail-closed renderer で、LLM を挟むと安全事実の drop/軟化リスクがあるため決定論のまま維持する。
- fail-open。情報系のみ対象で、訳が揃わなくても英語原文で PR を出し block しない。
- flat array でなく id 突合。length 一致だけでは順序入れ替えで backlog の訳が assumption に付く取り違えが素通りするため。

## テスト方法

1. `cd .ja/workflows && node --test build/tests/build.behavior.test.js` を実行。translate 系 3 テスト (反映 / 順序反転耐性 / id 不一致 fail-open) が pass する。
2. EN mirror も同様に pass する。
3. 唯一の fail は既存の manual-acceptance gate (U004_MANUAL_ACCEPTANCE、実ワークフロー起動 + env var 必須) で本変更と無関係。

実 LLM 品質は gates#134 の全 tail を sonnet で翻訳し pr-body.py でレンダリングして目視確認済み (file:line・件数・severity 全保持)。

https://claude.ai/code/session_01UyMnLAh4xawVcv8AotzeRd