### PR TITLE
fix(build): resume で args 再指定が必須と guard why に明記

### DIFF
--- a/workflows/build.js
+++ b/workflows/build.js
@@ -35,7 +35,7 @@ const issueNumber = (issueRef.match(/(\d+)\D*$/) || [])[1] || "";
 if (!issueRef || !issueNumber) {
   return {
     stopped: "no-issue",
-    why: 'Pass the issue as args ("123" / "#123" / URL / {issue, repo}).',
+    why: 'Pass the issue as args ("123" / "#123" / URL / {issue, repo}). On resume the runtime does not carry args, so re-pass it: Workflow({scriptPath, resumeFromRunId, args}).',
   };
 }
 


### PR DESCRIPTION
## 概要

build.js を `resumeFromRunId` で再開すると runtime が global `args` を運ばず、Load 冒頭 guard が `no-issue` で即停止する。root fix は Claude Code Workflow runtime 側 (journal への args 永続化) で本 repo 対応不能。repo 側 workaround として、guard の `why` に resume での args 再指定手順を追記する。

## 変更

`workflows/build.js:38` の guard `why` メッセージ 1 行。resume 時は `Workflow({scriptPath, resumeFromRunId, args})` で args を再指定する旨を追記。

## スコープ外

root fix (runtime 側の args 永続化) は Claude Code 本体への別途起票が必要。

Closes #132

https://claude.ai/code/session_01GhcG2aEF4Bcr4K7nuF2Tyy