### PR TITLE
fix(marketplace): plugin source を github 化し stale command 参照を除去

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
   "plugins": [
     {
       "name": "plan",
-      "source": "./",
+      "source": { "source": "github", "repo": "thkt/dotclaude" },
       "description": "Planning and design: /outcome for outcome definition, /think for design exploration and SOW/Spec generation, /research for technical investigation, /slice for breaking plans into vertical-slice issues, plus architecture agents",
       "version": "3.0.0",
       "author": {
@@ -34,7 +34,7 @@
     },
     {
       "name": "build",
-      "source": "./",
+      "source": { "source": "github", "repo": "thkt/dotclaude" },
       "description": "Implementation and testing: /build for end-to-end orchestration, /code, /fix with TDD/RGRC cycle and quality gates, /shake for flaky-test detection",
       "version": "3.0.0",
       "author": {
@@ -44,12 +44,7 @@
       "license": "MIT",
       "keywords": ["tdd", "rgrc", "implementation", "testing", "flaky", "fix"],
       "category": "Implementation",
-      "commands": [
-        "./skills/build/SKILL.md",
-        "./skills/code/SKILL.md",
-        "./skills/fix/SKILL.md",
-        "./skills/shake/SKILL.md"
-      ],
+      "commands": ["./skills/fix/SKILL.md"],
       "agents": [
         "./agents/resolvers/resolver-build.md",
         "./agents/enhancers/enhancer-code.md",
@@ -59,7 +54,7 @@
     },
     {
       "name": "review",
-      "source": "./",
+      "source": { "source": "github", "repo": "thkt/dotclaude" },
       "description": "Quality and review: /audit, /polish, /preview, /challenge, /assert with 21 specialized reviewer agents",
       "version": "3.0.0",
       "author": {
@@ -69,13 +64,7 @@
       "license": "MIT",
       "keywords": ["audit", "review", "quality", "polish", "challenge", "security", "readability"],
       "category": "Quality",
-      "commands": [
-        "./skills/audit/SKILL.md",
-        "./skills/polish/SKILL.md",
-        "./skills/preview/SKILL.md",
-        "./skills/challenge/SKILL.md",
-        "./skills/assert/SKILL.md"
-      ],
+      "commands": ["./skills/preview/SKILL.md", "./skills/challenge/SKILL.md"],
       "agents": [
         "./agents/critics/critic-audit.md",
         "./agents/critics/critic-evidence.md",
@@ -106,7 +95,7 @@
     },
     {
       "name": "ship",
-      "source": "./",
+      "source": { "source": "github", "repo": "thkt/dotclaude" },
       "description": "Git and release: /commit, /checkout, /pr, /issue with conventional commits and PR generation. Requires the plan and review plugins: /issue invokes /challenge (review) and /research, /think, /slice (plan)",
       "version": "3.0.0",
       "author": {
@@ -126,22 +115,17 @@
     },
     {
       "name": "toolkit",
-      "source": "./",
-      "description": "Utilities and patterns: /adr for decision records, /adrift for ADR-vs-code drift, /census for undocumented-decision discovery, /reflect for session reflection, plus frontend pattern references",
+      "source": { "source": "github", "repo": "thkt/dotclaude" },
+      "description": "Utilities and patterns: /adr for decision records, /adrift for ADR-vs-code drift, /census for undocumented-decision discovery, plus frontend pattern references",
       "version": "3.0.0",
       "author": {
         "name": "thkt",
         "url": "https://github.com/thkt"
       },
       "license": "MIT",
-      "keywords": ["adr", "adrift", "census", "reflect", "patterns", "frontend", "productivity"],
+      "keywords": ["adr", "adrift", "census", "patterns", "frontend", "productivity"],
       "category": "Utilities",
-      "commands": [
-        "./skills/adr/SKILL.md",
-        "./skills/adrift/SKILL.md",
-        "./skills/census/SKILL.md",
-        "./skills/reflect/SKILL.md"
-      ],
+      "commands": ["./skills/adr/SKILL.md", "./skills/census/SKILL.md"],
       "skills": [
         "./skills/use-cli-gcloud/SKILL.md",
         "./skills/use-cli-recall/SKILL.md",


### PR DESCRIPTION
## 背景

`/plugin` で build プラグインをインストールした際の検証で、marketplace.json に2つの packaging 欠陥を発見した。

## 問題1: 配布物が 23GB に膨張

全 plugin が `source: "./"` (ローカルパス = リポジトリルート = `~/.claude`)。ローカルパス source は git clone でなくファイルシステムコピーで **gitignore を無視**するため、install 毎に working tree 全体を cache へ複製していた。

| 混入 (全て gitignore 済み) | サイズ |
| --- | --- |
| projects/ (個人 memory + 全セッション transcript) | 4.0GB |
| logs/ | 439MB |
| telemetry/ | 125MB |
| node_modules/ | 31MB |

plan/build/review/ship の4 plugin で **各 5.7GB × 4 = cache 23GB**。個人 memory・全 transcript が重複格納されていた。

除外機構 (`.claudeignore` / manifest の files allowlist 等) は公式非対応 (claude-code-guide で裏取り済み)。

## 問題2: stale command 参照 8件

workflow 化済みで SKILL.md 実体を失った command 参照が残存 (build/code/shake, audit/polish/assert, adrift) + 未実装の reflect。

## 修正

- 全 5 plugin の source を `{ github, thkt/dotclaude }` に変更。git clone は tracked のみ取得 → **2.2MB (524 files)** に縮小
- stale command 参照 8件を除去。`workflows/*.js` は auto-discovery されるため manifest 宣言は不要

ローカル harness は `~/.claude` 直参照で動作するため、本変更はプラグイン配布経路のみに影響する。

## 検証

- workflow 本体 7本すべて `node --check` pass、meta 妥当
- marketplace.json は JSON 妥当、参照欠落0
- マージ後に旧 cache (23GB) を削除し github source で clean 再インストールして 2.2MB を実測確認する

https://claude.ai/code/session_01MhmxU4dEJYZztPmSb8pkVo