### PR TITLE
chore(workflows): build → code の実装 agent model を opus に統一

### DIFF
--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -563,10 +563,10 @@ const code =
   (await sibling("code", {
     plan: stripPreconditions(plan),
     repo,
-    // 機械的な per-unit TDD ループは sonnet に固定する。plan が contract と test
-    // シナリオを持つので実装は機械的で、これが意図した cost floor。ここで明示し、build
-    // ごとに code.js の opus 既定を暗黙継承させない。
-    model: "sonnet",
+    // per-unit TDD ループは opus に固定する (2026-07-13 ユーザー決定、コストは制約にしない)。
+    // ephemeral plan 経路など contract が弱いケースでも実装品質の余裕を持たせ、
+    // code.js の standalone 既定 (opus) とも揃える。code.js の既定変更に左右されないようここで明示する。
+    model: "opus",
   })) || null;
 if (!code || code.stopped) {
   return { stopped: "code-failed", detail: code, planning: plan.dir };

--- a/.ja/workflows/build/tests/build.behavior.test.js
+++ b/.ja/workflows/build/tests/build.behavior.test.js
@@ -1,5 +1,5 @@
 // U-004: build.js が Load (fetch -> 決定論 id 収集 -> extract -> validate + id cross-check) /
-// Revalidate / Branch / Code (sonnet) / Audit / Polish / Backlog (source: issue) / Ship の
+// Revalidate / Branch / Code (opus) / Audit / Polish / Backlog (source: issue) / Ship の
 // 実行ループになることの行動検証。fail-close 分岐・phase 順・stopped 値 snapshot を自動検証する。
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -456,7 +456,7 @@ test("Revalidate は 1 miss で stopped: plan-drift、全 pass で Branch へ進
   assert.ok(empty.calls.phase.includes("Branch"), "preconditions 空でも Branch phase に到達する");
 });
 
-test("happy path の phase 順が Load → Revalidate → Branch → Code → Audit → Polish → Backlog → Ship で、code に model: sonnet が渡り challenge / think / research が呼ばれない", async () => {
+test("happy path の phase 順が Load → Revalidate → Branch → Code → Audit → Polish → Backlog → Ship で、code に model: opus が渡り challenge / think / research が呼ばれない", async () => {
   const { calls } = await runWorkflow(buildJs, {
     args: { issue: "123" },
     stubs: makeStubs(),
@@ -470,7 +470,7 @@ test("happy path の phase 順が Load → Revalidate → Branch → Code → Au
 
   const codeCalls = calls.workflow.filter((c) => c.name === "code");
   assert.equal(codeCalls.length, 1, "workflow('code') が 1 回呼ばれる");
-  assert.equal(codeCalls[0].args.model, "sonnet", "code に model: sonnet が渡る");
+  assert.equal(codeCalls[0].args.model, "opus", "code に model: opus が渡る");
   assert.ok(
     !("preconditions" in codeCalls[0].args.plan),
     "code へ渡す plan から preconditions が strip される",

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -575,10 +575,11 @@ const code =
   (await sibling("code", {
     plan: stripPreconditions(plan),
     repo,
-    // Pin the mechanical per-unit TDD loop to sonnet. The plan carries contracts and
-    // test scenarios, so implementation is mechanical; this is the intended cost floor,
-    // kept explicit here rather than silently inheriting code.js's opus default on every build.
-    model: "sonnet",
+    // Pin the per-unit TDD loop to opus (user decision 2026-07-13; cost is not a constraint).
+    // Keeps implementation headroom for weak-contract cases like the ephemeral-plan path,
+    // and matches code.js's standalone default. Kept explicit here so build does not
+    // silently track a future change of code.js's default.
+    model: "opus",
   })) || null;
 if (!code || code.stopped) {
   return { stopped: "code-failed", detail: code, planning: plan.dir };

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -1,5 +1,5 @@
 // U-004: build.js が Load (fetch -> 決定論 id 収集 -> extract -> validate + id cross-check) /
-// Revalidate / Branch / Code (sonnet) / Audit / Polish / Backlog (source: issue) / Ship の
+// Revalidate / Branch / Code (opus) / Audit / Polish / Backlog (source: issue) / Ship の
 // 実行ループになることの行動検証。fail-close 分岐・phase 順・stopped 値 snapshot を自動検証する。
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -456,7 +456,7 @@ test("Revalidate は 1 miss で stopped: plan-drift、全 pass で Branch へ進
   assert.ok(empty.calls.phase.includes("Branch"), "preconditions 空でも Branch phase に到達する");
 });
 
-test("happy path の phase 順が Load → Revalidate → Branch → Code → Audit → Polish → Backlog → Ship で、code に model: sonnet が渡り challenge / think / research が呼ばれない", async () => {
+test("happy path の phase 順が Load → Revalidate → Branch → Code → Audit → Polish → Backlog → Ship で、code に model: opus が渡り challenge / think / research が呼ばれない", async () => {
   const { calls } = await runWorkflow(buildJs, {
     args: { issue: "123" },
     stubs: makeStubs(),
@@ -470,7 +470,7 @@ test("happy path の phase 順が Load → Revalidate → Branch → Code → Au
 
   const codeCalls = calls.workflow.filter((c) => c.name === "code");
   assert.equal(codeCalls.length, 1, "workflow('code') が 1 回呼ばれる");
-  assert.equal(codeCalls[0].args.model, "sonnet", "code に model: sonnet が渡る");
+  assert.equal(codeCalls[0].args.model, "opus", "code に model: opus が渡る");
   assert.ok(
     !("preconditions" in codeCalls[0].args.plan),
     "code へ渡す plan から preconditions が strip される",


### PR DESCRIPTION
## 変更の目的

build → code が sibling 呼び出しで渡す実装 agent (per-unit TDD red/green) の model pin を sonnet から opus に変更する。

- コストを制約にしない方針のユーザー決定 (2026-07-13)
- ephemeral plan 経路 (Plan 節なし issue) では contract の質が /issue 精製版より低く、「実装は機械的だから sonnet で足りる」という従来前提が崩れるため、実装品質の余裕を確保する
- standalone /code の既定 (opus) と揃い、経路によるモデル差が消える

## 変更点

- `workflows/build.js` / `.ja/workflows/build.js`: sibling("code") の `model: "sonnet"` → `"opus"`、コメントの根拠を更新
- `workflows/build/tests/build.behavior.test.js` / `.ja` mirror: happy path テストの期待値とテスト名を opus に更新

## 対象外

- effort 軸 (issue #191 / PR #192 で per-stage policy として確定済み)
- extract / translate-tail / ship の sonnet pin (実装段ではない)

## テスト

`node --test workflows/tests/`: 24 tests, 23 pass。唯一の fail は PR #189 由来の manual acceptance gate (`U004_MANUAL_ACCEPTANCE` 未設定時は設計上 fail) で本変更と無関係。

https://claude.ai/code/session_01Phy7fi3nxrYw7VNSeE1zZ4