### PR TITLE
fix(build): sibling を dev-tree 優先に反転し stale plugin の shadow を防ぐ

### DIFF
--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -49,9 +49,9 @@ const guard = repo
 // どちらも素の dev tree 形を先に試すので、dev tree はそのまま動く。
 const sibling = async (name, a) => {
   try {
-    return await workflow(`build:${name}`, a);
-  } catch {
     return await workflow(name, a);
+  } catch {
+    return await workflow(`build:${name}`, a);
   }
 };
 const bundled = (rel) =>

--- a/.ja/workflows/build/tests/build.behavior.test.js
+++ b/.ja/workflows/build/tests/build.behavior.test.js
@@ -70,7 +70,16 @@ const kindOf = (opts) => {
 
 // happy path stub 一式。body / plan / revalidate / diff / presence / conformance で
 // happy path の戻り値を差し替える。diff / presence は値でも関数 (prompt を受ける) でもよい。
-const makeStubs = ({ body, plan, revalidate, conformance, translate, diff, presence, critique } = {}) => ({
+const makeStubs = ({
+  body,
+  plan,
+  revalidate,
+  conformance,
+  translate,
+  diff,
+  presence,
+  critique,
+} = {}) => ({
   agent: (prompt, opts) => {
     const kind = kindOf(opts);
     switch (kind) {
@@ -131,9 +140,9 @@ const makeStubs = ({ body, plan, revalidate, conformance, translate, diff, prese
         tests_pass: true,
         gates_pass: true,
       };
-    // 実 runtime の意味論: 未知の workflow 名は throw する。plugin 名前空間の build:* は
-    // dev tree では未知なので、sibling() の fallback がここで発火する。audit は ADR-0085 で
-    // build から外れたので、呼ばれたらこの throw が (fallback ではなく) テストを落とす。
+    // 実 runtime の意味論: 未知の workflow 名は throw する。sibling() は code を先に試して
+    // ここで解決するので build:code へ fallback しない。audit は ADR-0085 で build から
+    // 外れたので、呼ばれたらこの throw が (fallback ではなく) テストを落とす。
     throw new Error(`unknown workflow: ${name}`);
   },
 });
@@ -442,13 +451,13 @@ test("happy path の phase 順が Load → Revalidate → Branch → Code → Cl
   );
   assert.equal(cleanupCalls[0].opts.model, "sonnet", "cleanup agent は sonnet 固定");
 
-  // sibling() が build:X を先に試して dev tree では throw → X に fallback するので、
-  // capture には plugin 名と bare 名の両方が現れる。audit は集合に現れない (ADR-0085)。
+  // sibling() は素の dev tree 形 (code) を先に試し、解決すれば build:code に fallback しない。
+  // dev tree では code が返るので capture には code のみが現れる。audit は集合に現れない (ADR-0085)。
   const names = new Set(calls.workflow.map((c) => c.name));
   assert.deepEqual(
     [...names].sort(),
-    ["build:code", "code"],
-    "workflow capture に code (+ build: 名前空間の試行) のみが現れる",
+    ["code"],
+    "workflow capture に dev-tree の code のみが現れる (build:code に fallback しない)",
   );
   for (const banned of ["audit", "polish", "challenge", "think", "research"]) {
     assert.ok(!names.has(banned), `workflow('${banned}') が呼ばれない`);

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -50,9 +50,9 @@ const guard = repo
 // ~/.claude/plugins. Both try the bare dev-tree form first, so the dev tree keeps working.
 const sibling = async (name, a) => {
   try {
-    return await workflow(`build:${name}`, a);
-  } catch {
     return await workflow(name, a);
+  } catch {
+    return await workflow(`build:${name}`, a);
   }
 };
 const bundled = (rel) =>
@@ -323,7 +323,11 @@ if (planHeading) {
 
   const blockers = validate(plan);
   if (blockers.length) {
-    return { stopped: "invalid-plan", blockers, why: "The extracted plan fails structural validation." };
+    return {
+      stopped: "invalid-plan",
+      blockers,
+      why: "The extracted plan fails structural validation.",
+    };
   }
 
   // Reject silent drops / fabrications in extraction via exact id-set comparison.
@@ -354,7 +358,11 @@ if (planHeading) {
   plan = drafted.plan;
   const blockers = validate(plan);
   if (blockers.length) {
-    return { stopped: "invalid-plan", blockers, why: "The generated plan fails structural validation." };
+    return {
+      stopped: "invalid-plan",
+      blockers,
+      why: "The generated plan fails structural validation.",
+    };
   }
 }
 

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -70,7 +70,16 @@ const kindOf = (opts) => {
 
 // happy path stub 一式。body / plan / revalidate / diff / presence / conformance で
 // happy path の戻り値を差し替える。diff / presence は値でも関数 (prompt を受ける) でもよい。
-const makeStubs = ({ body, plan, revalidate, conformance, translate, diff, presence, critique } = {}) => ({
+const makeStubs = ({
+  body,
+  plan,
+  revalidate,
+  conformance,
+  translate,
+  diff,
+  presence,
+  critique,
+} = {}) => ({
   agent: (prompt, opts) => {
     const kind = kindOf(opts);
     switch (kind) {
@@ -131,9 +140,9 @@ const makeStubs = ({ body, plan, revalidate, conformance, translate, diff, prese
         tests_pass: true,
         gates_pass: true,
       };
-    // 実 runtime の意味論: 未知の workflow 名は throw する。plugin 名前空間の build:* は
-    // dev tree では未知なので、sibling() の fallback がここで発火する。audit は ADR-0085 で
-    // build から外れたので、呼ばれたらこの throw が (fallback ではなく) テストを落とす。
+    // 実 runtime の意味論: 未知の workflow 名は throw する。sibling() は code を先に試して
+    // ここで解決するので build:code へ fallback しない。audit は ADR-0085 で build から
+    // 外れたので、呼ばれたらこの throw が (fallback ではなく) テストを落とす。
     throw new Error(`unknown workflow: ${name}`);
   },
 });
@@ -442,13 +451,13 @@ test("happy path の phase 順が Load → Revalidate → Branch → Code → Cl
   );
   assert.equal(cleanupCalls[0].opts.model, "sonnet", "cleanup agent は sonnet 固定");
 
-  // sibling() が build:X を先に試して dev tree では throw → X に fallback するので、
-  // capture には plugin 名と bare 名の両方が現れる。audit は集合に現れない (ADR-0085)。
+  // sibling() は素の dev tree 形 (code) を先に試し、解決すれば build:code に fallback しない。
+  // dev tree では code が返るので capture には code のみが現れる。audit は集合に現れない (ADR-0085)。
   const names = new Set(calls.workflow.map((c) => c.name));
   assert.deepEqual(
     [...names].sort(),
-    ["build:code", "code"],
-    "workflow capture に code (+ build: 名前空間の試行) のみが現れる",
+    ["code"],
+    "workflow capture に dev-tree の code のみが現れる (build:code に fallback しない)",
   );
   for (const banned of ["audit", "polish", "challenge", "think", "research"]) {
     assert.ok(!names.has(banned), `workflow('${banned}') が呼ばれない`);


### PR DESCRIPTION
## 問題

build workflow が tests 空の docs-only unit を実装せず素通りした。

原因: `sibling()` が `build:code` (plugin 名前空間) を先に解決するため、plugin がインストール済みの環境では dev-tree より古い plugin コピーの `code.js` が走る。その古い版は direct-implementation 分岐 (tests 空 unit を直接実装) を欠き、Red 未確認 → no-red anomaly として completed 扱いにして実装を飛ばしていた。

コメントは「Both try the bare dev-tree form first」と書かれていたが、実コードは plugin 優先で矛盾していた。姉妹ヘルパー `bundled` は dev-tree 優先で正しい。

## 変更

- `sibling()` の try/catch 順を反転し、素の dev-tree 形を先に試す。plugin 名前空間へは未解決時のみ fallback。`bundled` とコメントの意図に一致させる。
- happy-path テストの workflow capture 期待値を `["build:code","code"]` から `["code"]` に更新。順序反転を検出するガードを兼ねる。

## 確認

- build.behavior / code.model / audit.effort / polish.effort すべて green。manual-acceptance gate は ADR-0085 用の pre-existing failure で本変更と無関係。

## 影響

dev-tree が常に source of truth になる。plugin 利用者は次リリースまで古い `code.js` のままだが、これはリリース運用側の話。

https://claude.ai/code/session_01SbtD7xi6s6KeyDxn7q9gHQ