### PR TITLE
chore(marketplace): build plugin を 4.0.1 に bump し sibling fix を配布する

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Autonomous development workflow toolkit distributed as one self-contained plugin. Installing build clones the whole repository once, so every skill, agent, and workflow loads under the build: namespace with no cross-plugin duplication.",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "architecture": "single-plugin",
     "adr": "docs/decisions/0083-collapse-marketplace-to-single-build-plugin.md"
   },
@@ -16,7 +16,7 @@
       "name": "build",
       "source": { "source": "github", "repo": "thkt/dotclaude" },
       "description": "End-to-end autonomous build. File an issue with /issue (optionally after /challenge, /research, and /think), hand the issue number to the build workflow, and get a draft PR after Load / Code / Audit / Polish / Ship. Bundles the full reviewer and critic agent set, the code / audit / polish / shake / assert / adrift workflows, and the planning and git skills (/think, /research, /commit, /pr).",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "author": {
         "name": "thkt",
         "url": "https://github.com/thkt"


### PR DESCRIPTION
#199 (sibling を dev-tree 優先に反転し stale plugin の shadow を防ぐ) を plugin 利用者へ届けるための release bump。

## 変更

`marketplace.json` の version を 4.0.0 → 4.0.1 (metadata / plugin 両方)。

## 背景

plugin source は `github: thkt/dotclaude` で main を再 clone する方式 (ADR-0083)。installed version と marketplace version が同一だと /plugin update が「最新」と判断して再 clone しない可能性が高いため、version 差分で update を発火させ fix 済み main を取得させる。

## マージ後

`/plugin` で build@dotclaude を update すると main (fix 済み) を再 clone する。project スコープ install (例: kai) も同様に update が必要。

https://claude.ai/code/session_01SbtD7xi6s6KeyDxn7q9gHQ