### PR TITLE
fix(build): auto mode で分類器が殺す gh sandbox escape 指示を除去

### DIFF
--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -65,12 +65,6 @@ const obj = (required, properties) => ({
   properties,
 });
 
-// gh の TLS 検証 (trustd) を Bash sandbox が塞ぐ。git (OpenSSL) は影響を受けないため、
-// sandbox を抜けるのは gh だけにする。settings.json の恒久対応は plugin に同梱されず、
-// 配布先はこの prompt fallback に頼る。
-const ghUnsandboxed =
-  " `gh` コマンドは Bash sandbox 内で TLS 検証に失敗するため、`gh` を呼ぶ Bash は dangerouslyDisableSandbox: true で実行する。git ほか他のコマンドは sandbox 内のままにする。";
-
 const FETCH_SCHEMA = obj(["found", "body"], {
   found: { type: "boolean" },
   body: {
@@ -84,8 +78,7 @@ const fetched = await agent(
   anchor(
     `GitHub issue ${issueRef} の本文を固定コマンドで取得する。要約や整形をしない。` +
       `\`gh issue view ${issueRef} --json body --jq .body\` を正確に実行し、その stdout を body として逐語で返す。` +
-      `コマンドが非ゼロで終了した場合 (issue が無い / 取得失敗) は found: false を返す。` +
-      ghUnsandboxed,
+      `コマンドが非ゼロで終了した場合 (issue が無い / 取得失敗) は found: false を返す。`,
   ),
   {
     label: "fetch",
@@ -605,8 +598,7 @@ const [diff, testPresence, conformance] = await parallel([
           `(この build はまだ commit していない) なので、\`git diff HEAD\` と \`git status --porcelain\` が示す ` +
           `未追跡ファイル (新規の test / 実装ファイル) を使う。main...HEAD は使わない (HEAD はまだ分岐点にある)。` +
           `3 分類 (missing/partial、scope creep、implemented-but-wrong) を spec 行の引用付きで報告する。` +
-          `spec が無ければ spec_found=false と空の findings を返す。` +
-          ghUnsandboxed,
+          `spec が無ければ spec_found=false と空の findings を返す。`,
       ),
       {
         label: "conformance",
@@ -742,7 +734,7 @@ const ship = await agent(
       `(3) fact tail の追記と PR 作成を 1 つの \`&&\` チェーンで行い、レンダラー失敗時は PR 作成前に中断させる。リポジトリルートから ` +
       `\`python3 ${bundled("workflows/build/pr-body.py")} < <tempfile> >> <bodyfile> && gh pr create --draft --title "<commit の subject>" --body-file <bodyfile>\` を実行する。\n` +
       `pr-body.py は payload が壊れているか必須フィールドを欠くと非ゼロで終了する (何も出力しない)。チェーンが失敗したら他の手段で PR を作らない。committed と空の pr_url とエラーを報告する。\n` +
-      `committed の状態と PR url を報告する。${guard}${ghUnsandboxed}`,
+      `committed の状態と PR url を報告する。${guard}`,
   ),
   {
     label: "ship",

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -66,12 +66,6 @@ const obj = (required, properties) => ({
   properties,
 });
 
-// The Bash sandbox blocks gh's TLS validation (trustd); git (OpenSSL) is unaffected,
-// so only gh escapes the sandbox. The settings.json fix is not shipped with the
-// plugin, so consumers rely on this prompt fallback.
-const ghUnsandboxed =
-  " The `gh` command fails TLS verification inside the Bash sandbox, so run the Bash call that invokes `gh` with dangerouslyDisableSandbox: true; keep git and every other command sandboxed.";
-
 const FETCH_SCHEMA = obj(["found", "body"], {
   found: { type: "boolean" },
   body: {
@@ -85,8 +79,7 @@ const fetched = await agent(
   anchor(
     `Fetch the body of GitHub issue ${issueRef} with a fixed command; do not summarize or reformat. ` +
       `Run exactly \`gh issue view ${issueRef} --json body --jq .body\` and return its stdout verbatim as body. ` +
-      `If the command exits non-zero (issue not found / fetch failed), return found: false.` +
-      ghUnsandboxed,
+      `If the command exits non-zero (issue not found / fetch failed), return found: false.`,
   ),
   {
     label: "fetch",
@@ -628,8 +621,7 @@ const [diff, testPresence, conformance] = await parallel([
           `files (new test/impl files) shown by \`git status --porcelain\`. ` +
           `Do not use main...HEAD (HEAD is still the branch point). Report the 3 categories ` +
           `(missing/partial, scope creep, implemented-but-wrong) with the spec line quoted. ` +
-          `If no spec is available, return spec_found=false with an empty findings array.` +
-          ghUnsandboxed,
+          `If no spec is available, return spec_found=false with an empty findings array.`,
       ),
       {
         label: "conformance",
@@ -770,7 +762,7 @@ const ship = await agent(
       `(3) append the fact tail and open the PR as one \`&&\` chain, so a renderer failure aborts before the PR is created; from the repository root run ` +
       `\`python3 ${bundled("workflows/build/pr-body.py")} < <tempfile> >> <bodyfile> && gh pr create --draft --title "<your commit subject>" --body-file <bodyfile>\`.\n` +
       `pr-body.py exits non-zero (writing nothing) if the payload is malformed or missing a required field; if the chain fails, do not create the PR by other means. Report committed with an empty pr_url and the error instead.\n` +
-      `Report the committed state and the PR url.${guard}${ghUnsandboxed}`,
+      `Report the committed state and the PR url.${guard}`,
   ),
   {
     label: "ship",


### PR DESCRIPTION
## 背景

build workflow の fetch / conformance / ship agent prompt に、gh を `dangerouslyDisableSandbox: true` で sandbox 外実行させる `ghUnsandboxed` 指示があった。auto mode ではこの sandbox escape 行為そのものが分類器ゲートに掛かり deny され、build が Load(fetch) 段で停止する。

`autoMode.classifyAllShell` が Bash allow ルールを全 suspend するため `permissions.allow` では回避できず、escape の許可は `autoMode.allow` でも上書きできない。project settings をいじっても解消しない構造的な非互換 (既知 issue anthropics/claude-code#58222 と同根)。

## 変更

fetch / conformance / ship の3 agent prompt から `ghUnsandboxed` (const + コメント + 3参照) を除去。gh を sandbox 内実行に統一し、escape の必要性を消すことで分類器ゲートを構造的に回避する。JA canonical + EN の両方を更新。

## 影響

| 環境 | 影響 |
| --- | --- |
| sandbox 無効 | gh は素で動くため影響なし |
| sandbox 有効 (macOS) | gh の TLS 検証に `sandbox.enableWeakerNetworkIsolation: true` が前提になる |

従来の escape fallback は auto mode では既に分類器に殺されて機能しておらず、interactive かつ未設定の macOS でだけ効いていた層のみが前提設定を要する。

## follow-up

- consumer 向けに `enableWeakerNetworkIsolation` 前提を doc 化 (別 PR)
- plugin version bump で配布 (#200 と同様の flow)
- Linux sandbox での gh 動作は未検証

https://claude.ai/code/session_01PETAEHNiT9EjoUXXw53bSR
