### PR TITLE
chore(marketplace): build plugin を 4.0.2 に bump し gh sandbox escape 除去を配布する

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Autonomous development workflow toolkit distributed as one self-contained plugin. Installing build clones the whole repository once, so every skill, agent, and workflow loads under the build: namespace with no cross-plugin duplication.",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "architecture": "single-plugin",
     "adr": "docs/decisions/0083-collapse-marketplace-to-single-build-plugin.md"
   },
@@ -16,7 +16,7 @@
       "name": "build",
       "source": { "source": "github", "repo": "thkt/dotclaude" },
       "description": "End-to-end autonomous build. File an issue with /issue (optionally after /challenge, /research, and /think), hand the issue number to the build workflow, and get a draft PR after Load / Code / Audit / Polish / Ship. Bundles the full reviewer and critic agent set, the code / audit / polish / shake / assert / adrift workflows, and the planning and git skills (/think, /research, /commit, /pr).",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "author": {
         "name": "thkt",
         "url": "https://github.com/thkt"

--- a/.ja/README.md
+++ b/.ja/README.md
@@ -141,6 +141,8 @@ srt --version
 }
 ```
 
+build workflow は `gh` を sandbox 内で実行する。macOS で sandbox を有効にしている場合、`gh` の TLS 検証に `~/.claude/settings.json` の `sandbox.enableWeakerNetworkIsolation: true` が必要になる。未設定だと build が issue 取得段で失敗する。
+
 ### Hook ツール (推奨)
 
 Claude Code セッション中に自動実行される品質パイプラインフック。手動介入なしで lint エラー検出、コード整形、静的解析の注入、品質ゲートの強制を行う。

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Create `~/.srt-settings.json` for custom settings:
 }
 ```
 
+The build workflow runs `gh` inside the sandbox. On macOS with the sandbox enabled, `gh`'s TLS verification requires `sandbox.enableWeakerNetworkIsolation: true` in `~/.claude/settings.json`. Without it, the build fails at the issue-fetch step.
+
 ### Hook Tools (Recommended)
 
 Quality pipeline hooks that run automatically during Claude Code sessions. These


### PR DESCRIPTION
## 変更

#202 (build workflow の `ghUnsandboxed` 除去) を plugin 経由の consumer に届けるための version bump。

- `marketplace.json`: version 4.0.1 → 4.0.2 (metadata / build plugin の2箇所)
- `README.md` / `.ja/README.md`: consumer 前提を追記 (sandbox 有効な macOS では build の gh に `sandbox.enableWeakerNetworkIsolation: true` が必要)

## 背景

#202 は build.js の source を直したが、plugin cache で走る teammate には version bump しないと届かない (#200 と同じ配布 flow)。

https://claude.ai/code/session_01PETAEHNiT9EjoUXXw53bSR
