### PR TITLE
feat(skills): scribe-setup を .ja canonical + EN ミラーペアに追加する

### DIFF
--- a/.ja/skills/scribe-setup/SKILL.md
+++ b/.ja/skills/scribe-setup/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: scribe-setup
+description: 対象リポを scribe（コード構造の docs/wiki 蓄積機構）の巡回対象に整える。wiki 規約 README の配置と scribe ラベル作成を行う。
+when_to_use: このリポを scribe に追加, wiki 蓄積を始めたい, scribe setup, wiki 蓄積の準備
+allowed-tools: Bash Read Write Edit Glob Grep
+---
+
+# scribe セットアップ
+
+対象リポを `~/.claude/scribe` の巡回対象に整える。機構本体は触らず、対象リポ側に `docs/wiki/README.md` と GitHub の scribe ラベルを揃える。`docs/wiki/README.md` の存在自体が巡回対象の印になる（登録簿は無い）。
+
+対象リポは引数のパス、無ければ cwd。以降 `<repo>` はその絶対パス。
+
+## Phase 1. 対象リポの把握
+
+1. `<repo>` を絶対パスに解決し `cd <repo>`。git リポでなければ中止して理由を伝える。
+2. 既存状態を確認する。`docs/wiki/README.md` があれば「セットアップ済み。再実行は既存を上書きするか」をユーザーに確認してから進む。
+3. `gh repo view --json nameWithOwner -q .nameWithOwner` で slug を取る。取れないリポ（GitHub リモート無し）は scribe 対象にできない旨を伝えて中止する。
+4. `<repo>` が run.sh の SCAN_ROOTS（`~/Personal`, `~/GitHub/*/*`）の外なら、定期巡回に乗らず手動実行のみになる旨をユーザーに伝える。
+
+## Phase 2. wiki 規約 README の配置
+
+```bash
+mkdir -p <repo>/docs/wiki
+cp ~/.claude/scribe/wiki-readme.template.md <repo>/docs/wiki/README.md
+```
+
+雛形は汎用なので基本そのまま。リポ固有の書式追加があればここで足す。既存 README があれば上書き前に差分をユーザーに確認する。
+
+## Phase 3. scribe ラベル作成
+
+PR に付けるラベルを対象リポに一度だけ作る。scribe の差分基準（最後にマージされた scribe PR の検索）もこのラベルに依存する。
+
+```bash
+gh label create scribe -R <owner/repo> -c '#0E8A16' -d 'scribe が提案する wiki 更新' 2>/dev/null || true
+```
+
+## Phase 4. 初回実行の確認
+
+「初回巡回（コードベース全体を読んで wiki を基礎化し PR を作る）を今流すか」をユーザーに確認する。流す場合:
+
+```bash
+~/.claude/scribe/run.sh <repo の絶対パス>
+```
+
+codex が動くため 1 リポあたり約 2 分・十数万トークンかかる。完了後 PR URL を伝える。承認はユーザーがその PR をマージすること。scribe は直接デフォルトブランチに触れない。

--- a/scribe/tests/test-setup-doc-accuracy.sh
+++ b/scribe/tests/test-setup-doc-accuracy.sh
@@ -12,6 +12,16 @@ SETUP="scribe/SETUP.md"
 PASS=0
 FAIL=0
 
+# --- shared helpers (U-001) ---
+# frontmatter: 先頭 --- から次の --- までの本体行を出力する
+frontmatter() {
+  awk 'NR==1 && /^---[[:space:]]*$/ {f=1; next} f && /^---[[:space:]]*$/ {exit} f' "$1"
+}
+# code_blocks: fenced code block をフェンス行込みで出力する
+code_blocks() {
+  awk '/^```/{f=!f; print; next} f{print}' "$1"
+}
+
 # T-002
 test_t002() {
   local name="重複が消え、構成説明が実体と一致する"
@@ -76,7 +86,137 @@ test_t002() {
   fi
 }
 
+# =====================================================================
+# U-001: scribe-setup skill の JA/EN ミラー化と frontmatter 正規化の検証
+# 既存 U-002 テストを拡張。SETUP.md の /scribe-setup 参照解決 (T-001) を
+# guard として常時アサートし、.ja canonical の byte 一致 (T-002) と
+# frontmatter 正規化 (T-003) を mirror contract に照らして検証する。
+# =====================================================================
+
+# T-001 (U-001)
+test_u001_t001() {
+  local name="SETUP.md の scribe-setup 参照が実在 skill に解決する"
+  local errors=()
+  local en="skills/scribe-setup/SKILL.md"
+
+  # given: SETUP.md が per-repo オンボーディングとして /scribe-setup を参照している
+  if ! ugrep -q scribe-setup "$SETUP"; then
+    errors+=("SETUP.md が scribe-setup スキルを参照していない")
+  fi
+
+  # when/then: 参照先 skill が実在し、frontmatter name が scribe-setup と一致する
+  if [[ ! -f "$en" ]]; then
+    errors+=("参照先 $en が実在しない")
+  else
+    local nm
+    nm="$(frontmatter "$en" | awk '/^name:/{print $2; exit}')"
+    if [[ "$nm" != "scribe-setup" ]]; then
+      errors+=("frontmatter の name が scribe-setup と一致しない (name='$nm')")
+    fi
+  fi
+
+  if [[ ${#errors[@]} -eq 0 ]]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name"
+    printf '    %s\n' "${errors[@]}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# T-002 (U-001)
+test_u001_t002() {
+  local name=".ja canonical と EN ミラーの構造リテラルが byte 一致する"
+  local errors=()
+  local en="skills/scribe-setup/SKILL.md"
+  local ja=".ja/skills/scribe-setup/SKILL.md"
+
+  # given: .ja canonical と EN ミラーのペアが存在する前提。不在なら byte 比較不能
+  if [[ ! -f "$ja" ]]; then
+    errors+=(".ja canonical ($ja) が存在しない")
+  elif [[ ! -f "$en" ]]; then
+    errors+=("EN ミラー ($en) が存在しない")
+  else
+    # when/then: name / when_to_use / fenced code block を byte 比較する
+    local ja_fm en_fm ja_name en_name ja_wtu en_wtu ja_code en_code
+    ja_fm="$(frontmatter "$ja")"
+    en_fm="$(frontmatter "$en")"
+
+    ja_name="$(printf '%s\n' "$ja_fm" | ugrep '^name:' || true)"
+    en_name="$(printf '%s\n' "$en_fm" | ugrep '^name:' || true)"
+    if [[ "$ja_name" != "$en_name" ]]; then
+      errors+=("name 行が byte 一致しない (ja='$ja_name' en='$en_name')")
+    fi
+
+    ja_wtu="$(printf '%s\n' "$ja_fm" | ugrep '^when_to_use:' || true)"
+    en_wtu="$(printf '%s\n' "$en_fm" | ugrep '^when_to_use:' || true)"
+    if [[ "$ja_wtu" != "$en_wtu" ]]; then
+      errors+=("when_to_use 行が byte 一致しない (ja='$ja_wtu' en='$en_wtu')")
+    fi
+
+    ja_code="$(code_blocks "$ja")"
+    en_code="$(code_blocks "$en")"
+    if [[ "$ja_code" != "$en_code" ]]; then
+      errors+=("fenced code block が byte 一致しない")
+    fi
+  fi
+
+  if [[ ${#errors[@]} -eq 0 ]]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name"
+    printf '    %s\n' "${errors[@]}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# T-003 (U-001)
+test_u001_t003() {
+  local name="frontmatter が mirror contract の形に正規化されている"
+  local errors=()
+  local en="skills/scribe-setup/SKILL.md"
+
+  if [[ ! -f "$en" ]]; then
+    errors+=("$en が存在しない")
+  else
+    # when/then: when_to_use キーの存在、user-invocable キーの不在、
+    #            allowed-tools の space 区切り単一行を検査する
+    local fm
+    fm="$(frontmatter "$en")"
+
+    if ! printf '%s\n' "$fm" | ugrep -q '^when_to_use:'; then
+      errors+=("when_to_use キーが存在しない")
+    fi
+
+    if printf '%s\n' "$fm" | ugrep -q '^user-invocable:'; then
+      errors+=("user-invocable キーが存在する (mirror contract では不在)")
+    fi
+
+    if ! printf '%s\n' "$fm" | ugrep -qE '^allowed-tools:[[:space:]]+[^[:space:]]'; then
+      errors+=("allowed-tools が space 区切り単一行でない (値が同一行に無い)")
+    fi
+
+    if printf '%s\n' "$fm" | ugrep -qE '^[[:space:]]+-[[:space:]]'; then
+      errors+=("frontmatter に YAML list 項目が残っている (allowed-tools 未単一行化)")
+    fi
+  fi
+
+  if [[ ${#errors[@]} -eq 0 ]]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name"
+    printf '    %s\n' "${errors[@]}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 test_t002
+test_u001_t001
+test_u001_t002
+test_u001_t003
 
 echo "---"
 echo "PASS=$PASS FAIL=$FAIL"

--- a/skills/scribe-setup/SKILL.md
+++ b/skills/scribe-setup/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: scribe-setup
+description: Prepare a target repo to be picked up by scribe (the mechanism that accumulates code-structure docs/wiki). Places the wiki-convention README and creates the scribe label.
+when_to_use: このリポを scribe に追加, wiki 蓄積を始めたい, scribe setup, wiki 蓄積の準備
+allowed-tools: Bash Read Write Edit Glob Grep
+---
+
+# scribe setup
+
+Prepare a target repo to be picked up by `~/.claude/scribe`. Leave the mechanism itself untouched and, on the target repo side, put `docs/wiki/README.md` and the GitHub scribe label in place. The presence of `docs/wiki/README.md` itself is the mark of a scan target (there is no registry).
+
+The target repo is the path argument, or cwd when absent. Hereafter `<repo>` is its absolute path.
+
+## Phase 1. Understand the target repo
+
+1. Resolve `<repo>` to an absolute path and `cd <repo>`. If it is not a git repo, stop and explain why.
+2. Check the existing state. If `docs/wiki/README.md` exists, confirm with the user "already set up; does re-running overwrite the existing one?" before proceeding.
+3. Get the slug with `gh repo view --json nameWithOwner -q .nameWithOwner`. For a repo where this fails (no GitHub remote), explain that it cannot be a scribe target and stop.
+4. If `<repo>` is outside run.sh's SCAN_ROOTS (`~/Personal`, `~/GitHub/*/*`), tell the user it will not ride the periodic scan and runs only manually.
+
+## Phase 2. Place the wiki-convention README
+
+```bash
+mkdir -p <repo>/docs/wiki
+cp ~/.claude/scribe/wiki-readme.template.md <repo>/docs/wiki/README.md
+```
+
+The template is generic, so leave it mostly as-is. Add repo-specific formatting here if any. If a README already exists, confirm the diff with the user before overwriting.
+
+## Phase 3. Create the scribe label
+
+Create the label attached to PRs once in the target repo. scribe's diff baseline (searching for the last merged scribe PR) also depends on this label.
+
+```bash
+gh label create scribe -R <owner/repo> -c '#0E8A16' -d 'scribe が提案する wiki 更新' 2>/dev/null || true
+```
+
+## Phase 4. Confirm the first run
+
+Confirm with the user "run the first scan now (read the whole codebase, seed the wiki, and open a PR)?". If running:
+
+```bash
+~/.claude/scribe/run.sh <repo の絶対パス>
+```
+
+codex runs, so it takes about 2 minutes and a hundred-some thousand tokens per repo. Report the PR URL when done. Approval is the user merging that PR. scribe never touches the default branch directly.


### PR DESCRIPTION
## What & Why

scribe-setup skill が `.ja` canonical + EN 翻訳ミラーの tracked ペアになり、scribe/SETUP.md の `/scribe-setup` 参照がテストで決定論的に守られる。これまで `skills/scribe-setup/` は未コミットの単一言語ファイルで、ADR-0073 のミラー規約に沿っていなかった。

## Changes

- `.ja/skills/scribe-setup/SKILL.md` を canonical として追加し、`skills/scribe-setup/SKILL.md` を EN ミラーとして追加する。prose のみ翻訳し、frontmatter の `name` / `when_to_use` と fenced code block は byte 一致で維持する
- frontmatter を mirror contract の形に正規化する。`when_to_use` を追加し、`user-invocable` を除去し、`allowed-tools` を space 区切り単一行にする
- `scribe/tests/test-setup-doc-accuracy.sh` に U-001 の 3 テスト (T-001〜T-003) を追加する。SETUP.md の `/scribe-setup` 参照解決、`.ja`/EN 構造リテラルの byte 一致、frontmatter 正規化を常時アサートする

## Design Decisions

- `.ja/` が canonical。JA と EN を同一コミットで揃える (ADR-0073)
- `name: scribe-setup` は変更しない。`scribe/SETUP.md` の参照が依存する
- EN 側は prose のみ英訳し、code block と `when_to_use` の JA トリガー句は verbatim 維持する
- skill list は session-start snapshot のため、翻訳後の invoke 確認は新 session で行う

## How to Test

1. `bash scribe/tests/test-setup-doc-accuracy.sh` を実行する
2. `PASS=4 FAIL=0` になることを確認する


---

_build workflow が自動生成。レビュアー向けの検証結果と未解決項目。_

Closes #190

`verify tests=pass gates=pass` · `scope-deviations 2` · `missing-tests 3`

_重い担保は人間駆動。必要ならこの PR に `/audit` (任意で `/polish`) を起動する。_

**前提 (veto 対象)**
- PR #189 は 2026-07-12 マージ済み(gh確認済み)。scribe/ は main に存在し、skills/scribe-setup/ のみ未コミット
- use-cli-codegraph / use-cli-gcloud / use-cli-heptabase は EN-only の前例だが、本issue は ADR-0073 準拠を採用(ユーザー決定)
- scribe/tests は mirror scope 外のため .ja コピー不要(.ja/scribe/ は存在しない)
- ミラーペアの contract は fix / commit / checkout の実例に従う(description 翻訳、when_to_use 両側 verbatim、code block byte 一致)

**Plan スコープ外の変更ファイル**
- `.ja/skills/scribe-setup/`
- `skills/scribe-setup/`

**テストとして見つからない plan の言明**
- SETUP.md の scribe-setup 参照が実在 skill に解決する: given scribe/SETUP.md が per-repo オンボーディングとして /scribe-setup スキルを参照している, when skills/scribe-setup/SKILL.md の存在と frontmatter の name: scribe-setup を検査する, then 両方成立で pass。skill ファイル不在または name 不一致で fail する
- .ja canonical と EN ミラーの構造リテラルが byte 一致する: given .ja/skills/scribe-setup/SKILL.md と skills/scribe-setup/SKILL.md のペア, when name / when_to_use / fenced code block を byte 比較する, then 全て一致で pass。.ja 側不在または不一致で fail する (着手時点は .ja 不在のため Red)
- frontmatter が mirror contract の形に正規化されている: given skills/scribe-setup/SKILL.md の frontmatter, when when_to_use キーの存在、user-invocable キーの不在、allowed-tools の space 区切り単一行を検査する, then 全て成立で pass (着手時点は when_to_use 欠落と user-invocable: true があるため Red)
