### PR TITLE
fix(build): 起動 args の decode / # 除去 / repo 必須化で誤停止を防ぐ

### DIFF
--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -3,7 +3,7 @@ export const meta = {
   description:
     "自律的な end-to-end build。/think + /issue で精緻化した Plan 節付き issue を入力に、Load (逐語 fetch → 決定論 id 収集 → 抽出 → validate + id クロスチェック) / Revalidate / Branch / Code / Cleanup / Verify / Ship を headless の決定論 script stage として実行する。Plan 節なし issue は入れ子の draft-plan workflow が plan を下書きする (ADR-0086)。正しさの確認は plan 自身のアンカー (前提、files スコープ、T-NNN 言明、conformance) との比較であり、開放的な欠陥探索ではない。重い担保 (/audit、/polish review) は draft PR に対して人間が起動する (ADR-0085)。",
   whenToUse:
-    'plan 付き issue の実装。issue 番号 ("123" / "#123") / URL / {issue, repo} を args に渡す。## Plan 節の無い issue は plan を自動生成する (ゴール + a11y、critic-design gate 付き。品質は /think + /issue path に劣る)。離席して戻れば、前提 / conformance findings / 決定論 verify 結果を記録した draft PR ができている。スコープ外の backlog 候補は workflow の戻り値で返り、/issue で起票する。途中で舵を取る場合は phase を対話的に進める。',
+    'plan 付き issue の実装。args には {issue, repo} を渡す (issue は番号 "123" / "#123" か URL、repo は対象リポジトリの絶対パス)。repo の無い args は no-repo で早期 stop する。## Plan 節の無い issue は plan を自動生成する (ゴール + a11y、critic-design gate 付き。品質は /think + /issue path に劣る)。離席して戻れば、前提 / conformance findings / 決定論 verify 結果を記録した draft PR ができている。スコープ外の backlog 候補は workflow の戻り値で返り、/issue で起票する。途中で舵を取る場合は phase を対話的に進める。',
   phases: [
     { title: "Load" },
     { title: "Revalidate" },
@@ -21,8 +21,16 @@ export const meta = {
 
 phase("Load");
 
-const input = typeof args === "object" && args ? args : {};
-const issueRef = String(typeof args === "string" ? args : input.issue || "").trim();
+// ハーネスはオブジェクト args を JSON 文字列化して渡すことがある。その形も decode する。
+let argsValue = args;
+if (typeof argsValue === "string" && argsValue.trim().startsWith("{")) {
+  try {
+    const decoded = JSON.parse(argsValue);
+    if (decoded && typeof decoded === "object") argsValue = decoded;
+  } catch {}
+}
+const input = typeof argsValue === "object" && argsValue ? argsValue : {};
+const issueRef = String(typeof argsValue === "string" ? argsValue : input.issue || "").trim();
 // 受け付けるのは数字単体 / #数字 / issue URL のみ。数字を含むだけの自由記述
 // ("a11y" など) を issue 参照と読まない。
 const issueNumber =
@@ -34,17 +42,20 @@ if (!issueRef || !issueNumber) {
   };
 }
 
-// repo 指定時は session cwd に関わらず全 step をそのリポジトリへ固定する。anchor() が
-// 絶対パスの cd を前置し、guard が取り消しにくい git 変更 (branch / commit / push / PR)
-// の前に repo ルートを確認させる。
+// 全 step を session cwd に関わらず対象リポジトリへ固定する。anchor() が絶対パスの
+// cd を前置し、guard が取り消しにくい git 変更 (branch / commit / push / PR) の前に
+// repo ルートを確認させる。repo が無いと agent は自身の cwd から「リポジトリ」を
+// 解決し、別の checkout で step を実行しうる。
 const repo = typeof input.repo === "string" ? input.repo : "";
+if (!repo) {
+  return {
+    stopped: "no-repo",
+    why: `対象リポジトリを args.repo (絶対パス) で渡す: Workflow({name: "build", args: {issue: "${issueNumber}", repo: "/abs/path"}})。`,
+  };
+}
 const anchor = (p) =>
-  repo
-    ? `すべての git / ファイル / ビルドコマンドを ${repo} のリポジトリから実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`
-    : p;
-const guard = repo
-  ? ` この step で最初の commit / push / ブランチ変更を行う前に \`cd ${repo} && git rev-parse --show-toplevel\` を実行し、出力が ${repo} であることを確認する。異なる場合は git を変更せず中断し、不一致を報告する。`
-  : "";
+  `すべての git / ファイル / ビルドコマンドを ${repo} のリポジトリから実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`;
+const guard = ` この step で最初の commit / push / ブランチ変更を行う前に \`cd ${repo} && git rev-parse --show-toplevel\` を実行し、出力が ${repo} であることを確認する。異なる場合は git を変更せず中断し、不一致を報告する。`;
 // plugin 配布では sibling が build: 名前空間、bundled が ~/.claude/plugins を解決する。
 // どちらも素の dev tree 形を先に試すので、dev tree はそのまま動く。
 const sibling = async (name, a) => {
@@ -74,10 +85,12 @@ const FETCH_SCHEMA = obj(["found", "body"], {
 });
 
 // ---- Load: 逐語 fetch → Plan 見出し確認 → 決定論 id 収集 → 抽出 → validate + クロスチェック ----
+// 先頭の "#" はシェルコメントになり gh の引数がゼロになる。除去する。
+const fetchRef = issueRef.replace(/^#/, "");
 const fetched = await agent(
   anchor(
-    `GitHub issue ${issueRef} の本文を固定コマンドで取得する。要約や整形をしない。` +
-      `\`gh issue view ${issueRef} --json body --jq .body\` を正確に実行し、その stdout を body として逐語で返す。` +
+    `GitHub issue ${fetchRef} の本文を固定コマンドで取得する。要約や整形をしない。` +
+      `\`gh issue view ${fetchRef} --json body --jq .body\` を正確に実行し、その stdout を body として逐語で返す。` +
       `コマンドが非ゼロで終了した場合 (issue が無い / 取得失敗) は found: false を返す。`,
   ),
   {

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -3,7 +3,7 @@ export const meta = {
   description:
     "Autonomous end-to-end build. Taking an issue with a Plan section refined via /think + /issue as input, Load (verbatim fetch -> deterministic id collection -> extract -> validate + id cross-check) / Revalidate / Branch / Code / Cleanup / Verify / Ship run headlessly as deterministic script stages. A plan-less issue has its plan drafted by the nested draft-plan workflow (ADR-0086). Correctness checking is a comparison against the plan's own anchors (preconditions, files scope, T-NNN statements, conformance), not an open-ended defect hunt; heavy assurance (/audit, /polish review) is human-invoked on the draft PR (ADR-0085).",
   whenToUse:
-    'Implementation of a plan-backed issue. Pass an issue number ("123" / "#123") / URL / {issue, repo} as args. An issue without a ## Plan section has a plan auto-drafted (goal + a11y, critic-design gated); its quality is below the /think + /issue path. Step away and come back to a draft PR with recorded assumptions, conformance findings, and deterministic verify results; out-of-scope backlog candidates are returned in the workflow result for you to file via /issue. If in-flight steering is needed, drive the phases interactively.',
+    'Implementation of a plan-backed issue. Pass {issue, repo} as args, where issue is a number ("123" / "#123") or URL and repo is the absolute path of the target repository; args without repo stop early as no-repo. An issue without a ## Plan section has a plan auto-drafted (goal + a11y, critic-design gated); its quality is below the /think + /issue path. Step away and come back to a draft PR with recorded assumptions, conformance findings, and deterministic verify results; out-of-scope backlog candidates are returned in the workflow result for you to file via /issue. If in-flight steering is needed, drive the phases interactively.',
   phases: [
     { title: "Load" },
     { title: "Revalidate" },
@@ -22,8 +22,16 @@ export const meta = {
 
 phase("Load");
 
-const input = typeof args === "object" && args ? args : {};
-const issueRef = String(typeof args === "string" ? args : input.issue || "").trim();
+// The harness may deliver object args as a JSON-encoded string; decode that form too.
+let argsValue = args;
+if (typeof argsValue === "string" && argsValue.trim().startsWith("{")) {
+  try {
+    const decoded = JSON.parse(argsValue);
+    if (decoded && typeof decoded === "object") argsValue = decoded;
+  } catch {}
+}
+const input = typeof argsValue === "object" && argsValue ? argsValue : {};
+const issueRef = String(typeof argsValue === "string" ? argsValue : input.issue || "").trim();
 // Accept only a bare number, #number, or an issue URL. A freeform description that
 // merely contains digits (e.g. "a11y") must not be read as an issue reference.
 const issueNumber =
@@ -35,17 +43,21 @@ if (!issueRef || !issueNumber) {
   };
 }
 
-// When repo is set, pin every step to that repository regardless of the session cwd:
+// Every step is pinned to the target repository regardless of the session cwd:
 // anchor() prepends an absolute cd; guard makes the agent confirm the repo root
-// before the hard-to-reverse git mutations (branch / commit / push / PR).
+// before the hard-to-reverse git mutations (branch / commit / push / PR). Without
+// repo, agents resolve "the repository" from their own cwd and can run steps in
+// the wrong checkout.
 const repo = typeof input.repo === "string" ? input.repo : "";
+if (!repo) {
+  return {
+    stopped: "no-repo",
+    why: `Pass the target repository as args.repo (absolute path): Workflow({name: "build", args: {issue: "${issueNumber}", repo: "/abs/path"}}).`,
+  };
+}
 const anchor = (p) =>
-  repo
-    ? `Run every git, file, and build command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`).\n\n${p}`
-    : p;
-const guard = repo
-  ? ` Before the first commit / push / branch change in this step, run \`cd ${repo} && git rev-parse --show-toplevel\` and confirm the output is ${repo}. If it differs, abort without mutating git and report the mismatch.`
-  : "";
+  `Run every git, file, and build command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`).\n\n${p}`;
+const guard = ` Before the first commit / push / branch change in this step, run \`cd ${repo} && git rev-parse --show-toplevel\` and confirm the output is ${repo}. If it differs, abort without mutating git and report the mismatch.`;
 // As a plugin, sibling resolves the build: namespace and bundled resolves
 // ~/.claude/plugins. Both try the bare dev-tree form first, so the dev tree keeps working.
 const sibling = async (name, a) => {
@@ -75,10 +87,12 @@ const FETCH_SCHEMA = obj(["found", "body"], {
 });
 
 // ---- Load: verbatim fetch -> Plan heading check -> deterministic id collection -> extract -> validate + cross-check ----
+// A leading "#" would start a shell comment and leave gh with zero args; strip it.
+const fetchRef = issueRef.replace(/^#/, "");
 const fetched = await agent(
   anchor(
-    `Fetch the body of GitHub issue ${issueRef} with a fixed command; do not summarize or reformat. ` +
-      `Run exactly \`gh issue view ${issueRef} --json body --jq .body\` and return its stdout verbatim as body. ` +
+    `Fetch the body of GitHub issue ${fetchRef} with a fixed command; do not summarize or reformat. ` +
+      `Run exactly \`gh issue view ${fetchRef} --json body --jq .body\` and return its stdout verbatim as body. ` +
       `If the command exits non-zero (issue not found / fetch failed), return found: false.`,
   ),
   {


### PR DESCRIPTION
## 変更概要

workflows/build.js の起動入力処理を、#204 で実測した 3 つの誤停止要因に対して堅牢化する。

## 変更内容

- Workflow tool がオブジェクト args を JSON 文字列化して渡す形式を decode する (欠陥 1)
- fetch コマンドの issueRef 先頭 `#` を除去し、シェルコメント化による引数欠落を防ぐ (欠陥 2)
- args.repo 未指定時は no-repo で早期 stop し、agent が自身の cwd から別リポジトリを対象に選ぶ迷子を遮断する (欠陥 3)。whenToUse も {issue, repo} 必須に更新
- .ja canonical と EN ミラーを同一コミットで更新 (ADR-0073)

## 判断

#204 で tentative だった欠陥 3 の対処は、whenToUse の指示変更と repo 欠落時 stop の両建てを採った。指示変更だけでは呼び出し側 LLM の裁量が残るため、決定論の stop を backstop に置く。トレードオフとして "190" 単体の起動は 1 往復増える (stop メッセージが repo 付き再起動を案内する)。

## 検証

- 欠陥 1 の decode は同内容の session copy 修正で検証済み。run wf_7946f51c-f6f が文字列化 {issue, repo} args で Load を通過し PR #205 まで完走した
- kai (Nikkei/ise-pl-app#2267) にも同修正を適用済み

Closes #204

https://claude.ai/code/session_0128jzoeQ7KdzvreFZ4Fm19b
