### PR TITLE
chore(marketplace): build plugin を 4.1.0 に bump し起動入力の堅牢化を配布する

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Autonomous development workflow toolkit distributed as one self-contained plugin. Installing build clones the whole repository once, so every skill, agent, and workflow loads under the build: namespace with no cross-plugin duplication.",
-    "version": "4.0.2",
+    "version": "4.1.0",
     "architecture": "single-plugin",
     "adr": "docs/decisions/0083-collapse-marketplace-to-single-build-plugin.md"
   },
@@ -16,7 +16,7 @@
       "name": "build",
       "source": { "source": "github", "repo": "thkt/dotclaude" },
       "description": "End-to-end autonomous build. File an issue with /issue (optionally after /challenge, /research, and /think), hand the issue number to the build workflow, and get a draft PR after Load / Code / Audit / Polish / Ship. Bundles the full reviewer and critic agent set, the code / audit / polish / shake / assert / adrift workflows, and the planning and git skills (/think, /research, /commit, /pr).",
-      "version": "4.0.2",
+      "version": "4.1.0",
       "author": {
         "name": "thkt",
         "url": "https://github.com/thkt"


### PR DESCRIPTION
## 変更概要

build plugin を 4.1.0 に bump し、#206 の起動入力堅牢化 (args JSON 文字列 decode / issueRef 先頭 `#` 除去 / repo 必須化) を plugin consumer に配布する。

## 判断

repo 必須化は呼び出し契約の変更 (repo 無し args は no-repo で早期 stop) のため、#203 までの patch 前例でなく minor で上げる。

https://claude.ai/code/session_0128jzoeQ7KdzvreFZ4Fm19b
