### PR TITLE
feat(workflows): polish の diff_kind 判定と build PR 本文折り畳み

### DIFF
--- a/.ja/workflows/build/pr-body.py
+++ b/.ja/workflows/build/pr-body.py
@@ -8,13 +8,14 @@ always carry the verify result and the standing note that heavier assurance
 only the lead "## Summary" (the human reviewer's entry point) and appends this
 tail below it.
 
-Format is deliberately terse and markdown-structured (a one-line label naming the
-block as auto-generated, a one-line status, bold labels, bullets, a collapsed
-<details> for a failure log). Safety-critical facts
-live in the always-present status line / callout; purely informational lists
-(assumptions, scope deviations, missing test statements, anomalies) are shown
-only when non-empty, so a clean run stays short instead of repeating "None" per
-section.
+Format is deliberately terse and markdown-structured: a one-line label naming the
+block as auto-generated, the Closes line, then a collapsed <details> whose
+<summary> is the status line (HTML <code>, since markdown does not render inside
+<summary>). Safety-critical facts stay visible even collapsed because they live
+in that summary; the audit invitation, the failure log (a nested <details>), and
+the purely informational lists (assumptions, scope deviations, missing test
+statements, anomalies) fold away, shown only when non-empty, so a clean run
+stays short instead of repeating "None" per section.
 
 Fail-closed in two directions: an unparseable payload OR one missing a
 safety-critical key (tests_pass / gates_pass) exits 1 with nothing on
@@ -108,17 +109,23 @@ def render(payload):
 
     out = [L["tail_header"], f"Closes #{issue}" if issue else "Closes #"]
 
-    out.append(
-        f"`verify tests={tests} gates={gates}` · `scope-deviations {len(scope)}` · `missing-tests {len(missing)}`"
+    # Everything below the status line folds into one <details> (reviewer request:
+    # the tail should not dominate the PR body). The status line itself is the
+    # <summary>, so pass/FAIL stays visible while collapsed; markdown does not
+    # render inside <summary>, hence <code> instead of backticks.
+    summary = (
+        f"<code>verify tests={tests} gates={gates}</code> · "
+        f"<code>scope-deviations {len(scope)}</code> · "
+        f"<code>missing-tests {len(missing)}</code>"
     )
-    out.append(L["audit_invite"])
+    folded = [L["audit_invite"]]
 
     if tests == "FAIL" or gates == "FAIL":
         detail = payload.get("verify_output")
         if detail:
             body = detail if isinstance(detail, str) else json.dumps(detail, indent=2)
             fence = _fence(body)
-            out.append(
+            folded.append(
                 f"<details><summary>{L['verify_output']}</summary>\n\n{fence}\n{body}\n{fence}\n\n</details>"
             )
 
@@ -137,7 +144,7 @@ def render(payload):
             # Keep each item on one line so an embedded newline can't break the list
             # or promote a following line to a heading.
             lines.append("- " + " ".join(str(text).split("\n")))
-        out.append(f"**{label}**\n" + "\n".join(lines))
+        folded.append(f"**{label}**\n" + "\n".join(lines))
 
     section(L["assumptions"], payload.get("assumptions"), str)
     section(L["scope_deviations"], scope, lambda f: f"`{f}`")
@@ -156,6 +163,14 @@ def render(payload):
         lambda a: (
             f"{a.get('unit', '?')} ({a.get('kind', '?')}): {a.get('notes', '')}".rstrip()
         ),
+    )
+
+    # Blank lines around the folded content keep GitHub rendering the markdown
+    # inside the HTML <details> block.
+    out.append(
+        f"<details>\n<summary>{summary}</summary>\n\n"
+        + "\n\n".join(folded)
+        + "\n\n</details>"
     )
 
     # Lead with a blank line + rule so this machine tail stays separated when appended

--- a/.ja/workflows/build/tests/pr_body_test.py
+++ b/.ja/workflows/build/tests/pr_body_test.py
@@ -43,11 +43,14 @@ CLEAN = {"issue": "9", "tests_pass": True, "gates_pass": True}
 
 
 class RenderTest(unittest.TestCase):
-    def test_closes_and_status_line(self):
+    def test_closes_and_status_summary(self):
+        # The status line is the <summary> of the folded tail: HTML <code> (markdown
+        # does not render inside <summary>) so pass/FAIL stays visible while collapsed.
         body = pr_body.render(FULL)
         self.assertIn("Closes #123", body)
         self.assertIn(
-            "`verify tests=pass gates=pass` · `scope-deviations 1` · `missing-tests 1`",
+            "<summary><code>verify tests=pass gates=pass</code> · "
+            "<code>scope-deviations 1</code> · <code>missing-tests 1</code></summary>",
             body,
         )
 
@@ -91,7 +94,7 @@ class RenderTest(unittest.TestCase):
         body = pr_body.render(FULL)
         self.assertIn("**Issue conformance (review independently)**", body)
         self.assertIn("- [missing] no test for T-003 (pay.js:12, T-003 rejects negative)", body)
-        self.assertIn("`scope-deviations 1`", body)
+        self.assertIn("<code>scope-deviations 1</code>", body)
 
     def test_clean_run_omits_empty_sections_and_stays_short(self):
         body = pr_body.render(CLEAN)
@@ -101,18 +104,19 @@ class RenderTest(unittest.TestCase):
         self.assertNotIn("**Planned test statements", body)
         self.assertNotIn("**Issue conformance", body)
         self.assertNotIn("**Anomalies", body)
-        self.assertIn("`scope-deviations 0` · `missing-tests 0`", body)
+        self.assertIn("<code>scope-deviations 0</code> · <code>missing-tests 0</code>", body)
         non_empty = [
             ln for ln in body.splitlines() if ln.strip() and ln.strip() != "---"
         ]
-        # header label + Closes line + status line + audit invitation
-        self.assertEqual(len(non_empty), 4, non_empty)
+        # header label + Closes line + <details> + <summary> status + audit
+        # invitation + </details>
+        self.assertEqual(len(non_empty), 6, non_empty)
 
     def test_verify_failure_uses_collapsed_details(self):
         body = pr_body.render(
             {**FULL, "tests_pass": False, "verify_output": "boom stacktrace"}
         )
-        self.assertIn("`verify tests=FAIL gates=pass`", body)
+        self.assertIn("<code>verify tests=FAIL gates=pass</code>", body)
         self.assertIn("<details><summary>verify output</summary>", body)
         self.assertIn("```\nboom stacktrace\n```", body)
 
@@ -123,10 +127,23 @@ class RenderTest(unittest.TestCase):
         # The chosen fence is longer than the longest backtick run in the log.
         self.assertIn("````\n" + log + "\n````", body)
 
-    def test_verify_pass_has_no_details_block(self):
+    def test_verify_pass_has_no_nested_log_details(self):
+        # The outer fold is always present; the nested verify-output log is not.
         body = pr_body.render(FULL)
-        self.assertNotIn("<details>", body)
+        self.assertEqual(body.count("<details>"), 1)
+        self.assertNotIn("verify output", body)
         self.assertNotIn("```", body)
+
+    def test_informational_content_is_inside_the_fold(self):
+        # The header and Closes stay visible; the audit invite and every
+        # informational section collapse below the status summary.
+        body = pr_body.render(FULL)
+        opens = body.index("<summary>")
+        closes = body.rindex("</details>")
+        self.assertLess(body.index("Closes #123"), body.index("<details>"))
+        for marker in ("run `/audit`", "**Assumptions", "**Anomalies"):
+            self.assertLess(opens, body.index(marker), marker)
+            self.assertLess(body.index(marker), closes, marker)
 
     def test_non_dict_item_degrades_instead_of_crashing(self):
         # A malformed (non-dict) list item must not raise and drop the whole tail.

--- a/.ja/workflows/polish.js
+++ b/.ja/workflows/polish.js
@@ -3,7 +3,7 @@ export const meta = {
   description:
     'Codex review + cleanup を決定論的に行う workflow。Codex の findings は critic-audit の challenge を必ず通り、triage (confirmed / disputed / downgraded / needs_context) は script が判定するため、fact 扱いの集約や challenge の skip が起きない。単体でも、build から workflow("polish") 経由の入れ子でも呼べる。',
   whenToUse:
-    "diff の外部レンズ review と AI slop 除去を headless に行う。args は scope 文字列、または {scope, repo, mode}。mode: full (既定) は review -> fix -> cleanup、review は challenge 済み findings を返すだけ (fix しない)、cleanup は simplify + enhancer-code + テスト検証のみ。内部 reviewer の深い audit は audit workflow を使う。",
+    "diff の外部レンズ review と AI slop 除去を headless に行う。args は scope 文字列、または {scope, repo, mode, base}。scope 省略時は uncommitted な変更、無ければ base branch (既定 main) より先行する commit の diff (push 済み branch diff) を対象とする。mode: full (既定) は review -> fix -> cleanup、review は challenge 済み findings を返すだけ (fix しない)、cleanup は simplify + enhancer-code + テスト検証のみ。内部 reviewer の深い audit は audit workflow を使う。",
   phases: [{ title: "Review" }, { title: "Challenge" }, { title: "Fix" }, { title: "Cleanup" }],
 };
 
@@ -28,24 +28,33 @@ const opts = parseArgs();
 const scope = typeof opts.scope === "string" ? opts.scope : "";
 const repo = typeof opts.repo === "string" ? opts.repo : "";
 const mode = opts.mode === "review" || opts.mode === "cleanup" ? opts.mode : "full";
+const base = typeof opts.base === "string" ? opts.base : "main";
 
 const anchor = (p) =>
   repo
     ? `git / ファイル / ビルドのコマンドはすべて ${repo} の repository から実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`
     : p;
-const scopeNote = scope
-  ? `対象 scope は ${scope}。scope 外のファイルに触れる fix は落とす。`
-  : "対象は git diff HEAD (staged + unstaged)。diff 外のファイルに触れる fix は落とす。";
+const scopeNote = (diffKind) =>
+  scope
+    ? `対象 scope は ${scope}。scope 外のファイルに触れる fix は落とす。`
+    : diffKind === "branch"
+      ? `対象は git diff ${base}...HEAD (push 済み branch diff)。diff 外のファイルに触れる fix は落とす。`
+      : "対象は git diff HEAD (staged + unstaged)。diff 外のファイルに触れる fix は落とす。";
 
 const CODEX_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["available", "has_changes", "findings"],
+  required: ["available", "has_changes", "diff_kind", "findings"],
   properties: {
     available: { type: "boolean", description: "codex CLI が使えたか" },
     has_changes: {
       type: "boolean",
       description: "diff に polish 対象の変更があるか",
+    },
+    diff_kind: {
+      type: "string",
+      enum: ["uncommitted", "branch", ""],
+      description: "対象 diff の種類。branch は base より先行する commit の diff",
     },
     findings: {
       type: "array",
@@ -126,7 +135,7 @@ const CLEANUP_SCHEMA = {
   },
 };
 
-let codex = { available: false, has_changes: true, findings: [] };
+let codex = { available: false, has_changes: true, diff_kind: "", findings: [] };
 let verdicts = [];
 let survivors = [];
 let needsContext = [];
@@ -135,13 +144,19 @@ let fix = null;
 if (mode !== "cleanup") {
   // ---- Review: 外部 Codex レンズ ----
   phase("Review");
+  const detectNote = scope
+    ? `まず \`git status\` と \`git diff HEAD\` で polish 対象の変更が存在するか確認する。無ければ has_changes: false、diff_kind 空で返す。あれば diff_kind: uncommitted とする。`
+    : `まず対象 diff の種類を判定する。\`git status --porcelain\` に出力があれば diff_kind: uncommitted。無ければ \`git rev-list --count ${base}..HEAD\` が 1 以上で diff_kind: branch (push 済み branch diff)。どちらにも該当しなければ has_changes: false、diff_kind 空で返す。`;
   codex = (await agent(
     anchor(
-      `外部 Codex review stage。まず \`git status\` と \`git diff HEAD\` で polish 対象の変更が存在するか確認する。無ければ has_changes: false で返す。\n` +
+      `外部 Codex review stage。${detectNote}\n` +
         `次に \`which codex\` を確認する。無ければ available: false、findings 空で返す。\n` +
-        `あれば \`codex review "Review for logic, architecture, data flow, and code simplicity (flag over-complexity and unnecessary indirection)"\` を実行する。` +
-        `codex 0.141.0 では scope flag (--uncommitted / --base / --commit) と PROMPT 引数が排他なので、simplicity レンズの PROMPT を渡すときは scope flag を付けない (Codex 自身が git status を読む)。PROMPT を省くと simplicity レンズが落ちるため必ず渡す。\n` +
-        `出力を findings に構造化する。id は F1, F2, ... と振り、severity は Codex の P1/P2/P3 を写す (無ければ影響度から判定する)。${scopeNote}`,
+        `diff_kind が branch のときは \`codex review --base ${base}\` を実行する (codex 0.144.6 では scope flag (--uncommitted / --base / --commit) と PROMPT 引数が排他のため、branch diff では PROMPT を渡せず simplicity レンズは Codex 既定レンズに落ちる)。\n` +
+        `それ以外は \`codex review "Review for logic, architecture, data flow, and code simplicity (flag over-complexity and unnecessary indirection)"\` を実行する。PROMPT を渡すときは scope flag を付けない (Codex 自身が git status を読む)。PROMPT を省くと simplicity レンズが落ちるため uncommitted では必ず渡す。\n` +
+        `出力を findings に構造化する。id は F1, F2, ... と振り、severity は Codex の P1/P2/P3 を写す (無ければ影響度から判定する)。` +
+        (scope
+          ? `対象 scope は ${scope}。scope 外のファイルに触れる findings は落とす。`
+          : `判定した diff (uncommitted なら git diff HEAD、branch なら git diff ${base}...HEAD) の外のファイルに触れる findings は落とす。`),
     ),
     {
       label: "codex",
@@ -150,7 +165,7 @@ if (mode !== "cleanup") {
       schema: CODEX_SCHEMA,
       model: "sonnet",
     },
-  )) || { available: false, has_changes: true, findings: [] };
+  )) || { available: false, has_changes: true, diff_kind: "", findings: [] };
   if (!codex.has_changes) {
     return { mode, polished: false, why: "diff に変更が無く polish 対象なし" };
   }
@@ -210,6 +225,7 @@ if (mode !== "cleanup") {
     return {
       mode,
       codex_available: codex.available,
+      diff_kind: codex.diff_kind,
       survivors,
       needs_context: needsContext,
     };
@@ -220,7 +236,7 @@ if (mode !== "cleanup") {
     phase("Fix");
     fix = await agent(
       anchor(
-        `challenge を生き残った findings を severity の高い順に修正する。${scopeNote}\n` +
+        `challenge を生き残った findings を severity の高い順に修正する。${scopeNote(codex.diff_kind)}\n` +
           `修正後にプロジェクトのテストコマンドを検出して実行し、テストを壊した fix は git stash で巻き戻す。commit しない。\n` +
           `Findings は次のとおり。\n${JSON.stringify(survivors)}`,
       ),
@@ -239,9 +255,11 @@ if (mode !== "cleanup") {
 // ---- Cleanup: simplify -> enhancer-code -> テスト検証 ----
 // どちらも bug 探しではないので critic-audit challenge を通さず直接適用する。
 phase("Cleanup");
+const cleanupTarget =
+  codex.diff_kind === "branch" ? `git diff ${base}...HEAD (push 済み branch diff)` : "現在の diff";
 await agent(
   anchor(
-    `Skill tool で skill "simplify" を呼び、現在の diff に cleanup 専用パス (reuse / simplification / efficiency / altitude) を適用する。引数なしで拒否されたら diff の scope を渡す。commit しない。`,
+    `Skill tool で skill "simplify" を呼び、${cleanupTarget}に cleanup 専用パス (reuse / simplification / efficiency / altitude) を適用する。引数なしで拒否されたら diff の scope を渡す。commit しない。`,
   ),
   {
     label: "simplify",
@@ -252,7 +270,7 @@ await agent(
 );
 await agent(
   anchor(
-    `現在の diff から AI slop を除去し simplification ルールを適用し、テストを監査する。simplify の編集より preservation ルール (迷ったら残す) を優先する。`,
+    `${cleanupTarget}から AI slop を除去し simplification ルールを適用し、テストを監査する。simplify の編集より preservation ルール (迷ったら残す) を優先する。`,
   ),
   {
     agentType: "enhancer-code",
@@ -282,6 +300,7 @@ const cleanup = (await agent(
 return {
   mode,
   codex_available: codex.available,
+  diff_kind: codex.diff_kind,
   findings: codex.findings.length,
   survivors: survivors.length,
   fixed: fix ? fix.fixed : [],

--- a/.ja/workflows/polish/tests/polish.diff-kind.test.js
+++ b/.ja/workflows/polish/tests/polish.diff-kind.test.js
@@ -1,0 +1,72 @@
+// polish の diff fallback: scope 省略時は uncommitted な変更、無ければ base...HEAD (push 済み branch diff)。
+// codex agent が返す diff_kind に応じて fix / cleanup の対象 diff が切り替わることをテストで固定する。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const polishJs = join(here, "..", "..", "polish.js");
+
+// Review -> Challenge -> Fix -> Cleanup を通す最小 stub。diff_kind だけ差し替える。
+const agentStub = (diffKind) => (prompt, opts) => {
+  const label = opts && opts.label;
+  if (label === "codex") {
+    return {
+      available: true,
+      has_changes: true,
+      diff_kind: diffKind,
+      findings: [{ id: "F1", title: "finding title", detail: "finding detail", severity: "P1" }],
+    };
+  }
+  if (label === "challenge") {
+    return { verdicts: [{ id: "F1", verdict: "confirmed" }] };
+  }
+  if (label === "fix") {
+    return { fixed: ["F1 fixed"], stashed: [], tests_pass: true };
+  }
+  if (label === "validate") {
+    return { edits: [], tests_pass: true, stashed: false };
+  }
+  return undefined;
+};
+
+const promptOf = (calls, label) => calls.agent.find((c) => c.opts && c.opts.label === label).prompt;
+
+test("scope 省略時の Review prompt に branch fallback 判定と --base 実行が含まれる", async () => {
+  const { calls } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub("branch") },
+  });
+  const review = promptOf(calls, "codex");
+  assert.match(review, /git rev-list --count main\.\.HEAD/, "rev-list による先行 commit 判定");
+  assert.match(review, /codex review --base main/, "branch diff は --base で codex 実行");
+});
+
+test("diff_kind: branch のとき fix と cleanup の対象が base...HEAD になる", async () => {
+  const { calls, result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub("branch") },
+  });
+  assert.match(promptOf(calls, "fix"), /git diff main\.\.\.HEAD/, "fix の対象は branch diff");
+  assert.match(promptOf(calls, "simplify"), /main\.\.\.HEAD/, "cleanup の対象は branch diff");
+  assert.equal(result.diff_kind, "branch", "返り値に diff_kind が出る");
+});
+
+test("diff_kind: uncommitted のとき fix の対象が git diff HEAD のままである", async () => {
+  const { calls } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub("uncommitted") },
+  });
+  assert.match(promptOf(calls, "fix"), /git diff HEAD/);
+});
+
+test("base 指定が Review / Fix の prompt に伝播する", async () => {
+  const { calls } = await runWorkflow(polishJs, {
+    args: { base: "develop" },
+    stubs: { agent: agentStub("branch") },
+  });
+  assert.match(promptOf(calls, "codex"), /codex review --base develop/);
+  assert.match(promptOf(calls, "fix"), /git diff develop\.\.\.HEAD/);
+});

--- a/workflows/build/pr-body.py
+++ b/workflows/build/pr-body.py
@@ -8,13 +8,14 @@ always carry the verify result and the standing note that heavier assurance
 only the lead "## Summary" (the human reviewer's entry point) and appends this
 tail below it.
 
-Format is deliberately terse and markdown-structured (a one-line label naming the
-block as auto-generated, a one-line status, bold labels, bullets, a collapsed
-<details> for a failure log). Safety-critical facts
-live in the always-present status line / callout; purely informational lists
-(assumptions, scope deviations, missing test statements, anomalies) are shown
-only when non-empty, so a clean run stays short instead of repeating "None" per
-section.
+Format is deliberately terse and markdown-structured: a one-line label naming the
+block as auto-generated, the Closes line, then a collapsed <details> whose
+<summary> is the status line (HTML <code>, since markdown does not render inside
+<summary>). Safety-critical facts stay visible even collapsed because they live
+in that summary; the audit invitation, the failure log (a nested <details>), and
+the purely informational lists (assumptions, scope deviations, missing test
+statements, anomalies) fold away, shown only when non-empty, so a clean run
+stays short instead of repeating "None" per section.
 
 Fail-closed in two directions: an unparseable payload OR one missing a
 safety-critical key (tests_pass / gates_pass) exits 1 with nothing on
@@ -108,17 +109,23 @@ def render(payload):
 
     out = [L["tail_header"], f"Closes #{issue}" if issue else "Closes #"]
 
-    out.append(
-        f"`verify tests={tests} gates={gates}` · `scope-deviations {len(scope)}` · `missing-tests {len(missing)}`"
+    # Everything below the status line folds into one <details> (reviewer request:
+    # the tail should not dominate the PR body). The status line itself is the
+    # <summary>, so pass/FAIL stays visible while collapsed; markdown does not
+    # render inside <summary>, hence <code> instead of backticks.
+    summary = (
+        f"<code>verify tests={tests} gates={gates}</code> · "
+        f"<code>scope-deviations {len(scope)}</code> · "
+        f"<code>missing-tests {len(missing)}</code>"
     )
-    out.append(L["audit_invite"])
+    folded = [L["audit_invite"]]
 
     if tests == "FAIL" or gates == "FAIL":
         detail = payload.get("verify_output")
         if detail:
             body = detail if isinstance(detail, str) else json.dumps(detail, indent=2)
             fence = _fence(body)
-            out.append(
+            folded.append(
                 f"<details><summary>{L['verify_output']}</summary>\n\n{fence}\n{body}\n{fence}\n\n</details>"
             )
 
@@ -137,7 +144,7 @@ def render(payload):
             # Keep each item on one line so an embedded newline can't break the list
             # or promote a following line to a heading.
             lines.append("- " + " ".join(str(text).split("\n")))
-        out.append(f"**{label}**\n" + "\n".join(lines))
+        folded.append(f"**{label}**\n" + "\n".join(lines))
 
     section(L["assumptions"], payload.get("assumptions"), str)
     section(L["scope_deviations"], scope, lambda f: f"`{f}`")
@@ -156,6 +163,14 @@ def render(payload):
         lambda a: (
             f"{a.get('unit', '?')} ({a.get('kind', '?')}): {a.get('notes', '')}".rstrip()
         ),
+    )
+
+    # Blank lines around the folded content keep GitHub rendering the markdown
+    # inside the HTML <details> block.
+    out.append(
+        f"<details>\n<summary>{summary}</summary>\n\n"
+        + "\n\n".join(folded)
+        + "\n\n</details>"
     )
 
     # Lead with a blank line + rule so this machine tail stays separated when appended

--- a/workflows/build/tests/pr_body_test.py
+++ b/workflows/build/tests/pr_body_test.py
@@ -43,11 +43,14 @@ CLEAN = {"issue": "9", "tests_pass": True, "gates_pass": True}
 
 
 class RenderTest(unittest.TestCase):
-    def test_closes_and_status_line(self):
+    def test_closes_and_status_summary(self):
+        # The status line is the <summary> of the folded tail: HTML <code> (markdown
+        # does not render inside <summary>) so pass/FAIL stays visible while collapsed.
         body = pr_body.render(FULL)
         self.assertIn("Closes #123", body)
         self.assertIn(
-            "`verify tests=pass gates=pass` · `scope-deviations 1` · `missing-tests 1`",
+            "<summary><code>verify tests=pass gates=pass</code> · "
+            "<code>scope-deviations 1</code> · <code>missing-tests 1</code></summary>",
             body,
         )
 
@@ -91,7 +94,7 @@ class RenderTest(unittest.TestCase):
         body = pr_body.render(FULL)
         self.assertIn("**Issue conformance (review independently)**", body)
         self.assertIn("- [missing] no test for T-003 (pay.js:12, T-003 rejects negative)", body)
-        self.assertIn("`scope-deviations 1`", body)
+        self.assertIn("<code>scope-deviations 1</code>", body)
 
     def test_clean_run_omits_empty_sections_and_stays_short(self):
         body = pr_body.render(CLEAN)
@@ -101,18 +104,19 @@ class RenderTest(unittest.TestCase):
         self.assertNotIn("**Planned test statements", body)
         self.assertNotIn("**Issue conformance", body)
         self.assertNotIn("**Anomalies", body)
-        self.assertIn("`scope-deviations 0` · `missing-tests 0`", body)
+        self.assertIn("<code>scope-deviations 0</code> · <code>missing-tests 0</code>", body)
         non_empty = [
             ln for ln in body.splitlines() if ln.strip() and ln.strip() != "---"
         ]
-        # header label + Closes line + status line + audit invitation
-        self.assertEqual(len(non_empty), 4, non_empty)
+        # header label + Closes line + <details> + <summary> status + audit
+        # invitation + </details>
+        self.assertEqual(len(non_empty), 6, non_empty)
 
     def test_verify_failure_uses_collapsed_details(self):
         body = pr_body.render(
             {**FULL, "tests_pass": False, "verify_output": "boom stacktrace"}
         )
-        self.assertIn("`verify tests=FAIL gates=pass`", body)
+        self.assertIn("<code>verify tests=FAIL gates=pass</code>", body)
         self.assertIn("<details><summary>verify output</summary>", body)
         self.assertIn("```\nboom stacktrace\n```", body)
 
@@ -123,10 +127,23 @@ class RenderTest(unittest.TestCase):
         # The chosen fence is longer than the longest backtick run in the log.
         self.assertIn("````\n" + log + "\n````", body)
 
-    def test_verify_pass_has_no_details_block(self):
+    def test_verify_pass_has_no_nested_log_details(self):
+        # The outer fold is always present; the nested verify-output log is not.
         body = pr_body.render(FULL)
-        self.assertNotIn("<details>", body)
+        self.assertEqual(body.count("<details>"), 1)
+        self.assertNotIn("verify output", body)
         self.assertNotIn("```", body)
+
+    def test_informational_content_is_inside_the_fold(self):
+        # The header and Closes stay visible; the audit invite and every
+        # informational section collapse below the status summary.
+        body = pr_body.render(FULL)
+        opens = body.index("<summary>")
+        closes = body.rindex("</details>")
+        self.assertLess(body.index("Closes #123"), body.index("<details>"))
+        for marker in ("run `/audit`", "**Assumptions", "**Anomalies"):
+            self.assertLess(opens, body.index(marker), marker)
+            self.assertLess(body.index(marker), closes, marker)
 
     def test_non_dict_item_degrades_instead_of_crashing(self):
         # A malformed (non-dict) list item must not raise and drop the whole tail.

--- a/workflows/polish.js
+++ b/workflows/polish.js
@@ -3,7 +3,7 @@ export const meta = {
   description:
     'Deterministic Codex review + cleanup. Codex findings always pass through a critic-audit challenge, and the triage (confirmed / disputed / downgraded / needs_context) is decided by the script, so findings are never aggregated as facts and the challenge cannot be skipped. Callable standalone or nested from build via workflow("polish").',
   whenToUse:
-    "Headless external-lens review of a diff plus AI-slop removal. args is a scope string, or {scope, repo, mode}. mode: full (default) runs review -> fix -> cleanup; review returns the challenged findings without fixing; cleanup runs only simplify + enhancer-code + test validation. For a deep internal-reviewer audit use the audit workflow.",
+    "Headless external-lens review of a diff plus AI-slop removal. args is a scope string, or {scope, repo, mode, base}. When scope is omitted, the target is the uncommitted changes, else the diff of commits ahead of the base branch (default main) — the pushed branch diff. mode: full (default) runs review -> fix -> cleanup; review returns the challenged findings without fixing; cleanup runs only simplify + enhancer-code + test validation. For a deep internal-reviewer audit use the audit workflow.",
   phases: [{ title: "Review" }, { title: "Challenge" }, { title: "Fix" }, { title: "Cleanup" }],
 };
 
@@ -29,19 +29,23 @@ const opts = parseArgs();
 const scope = typeof opts.scope === "string" ? opts.scope : "";
 const repo = typeof opts.repo === "string" ? opts.repo : "";
 const mode = opts.mode === "review" || opts.mode === "cleanup" ? opts.mode : "full";
+const base = typeof opts.base === "string" ? opts.base : "main";
 
 const anchor = (p) =>
   repo
     ? `Run every git, file, and build command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`).\n\n${p}`
     : p;
-const scopeNote = scope
-  ? `The target scope is ${scope}. Drop any fix touching files outside it.`
-  : "The target is git diff HEAD (staged + unstaged). Drop any fix touching files outside the diff.";
+const scopeNote = (diffKind) =>
+  scope
+    ? `The target scope is ${scope}. Drop any fix touching files outside it.`
+    : diffKind === "branch"
+      ? `The target is git diff ${base}...HEAD (the pushed branch diff). Drop any fix touching files outside the diff.`
+      : "The target is git diff HEAD (staged + unstaged). Drop any fix touching files outside the diff.";
 
 const CODEX_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["available", "has_changes", "findings"],
+  required: ["available", "has_changes", "diff_kind", "findings"],
   properties: {
     available: {
       type: "boolean",
@@ -50,6 +54,11 @@ const CODEX_SCHEMA = {
     has_changes: {
       type: "boolean",
       description: "whether the diff has changes to polish",
+    },
+    diff_kind: {
+      type: "string",
+      enum: ["uncommitted", "branch", ""],
+      description: "kind of target diff; branch means the diff of commits ahead of base",
     },
     findings: {
       type: "array",
@@ -130,7 +139,7 @@ const CLEANUP_SCHEMA = {
   },
 };
 
-let codex = { available: false, has_changes: true, findings: [] };
+let codex = { available: false, has_changes: true, diff_kind: "", findings: [] };
 let verdicts = [];
 let survivors = [];
 let needsContext = [];
@@ -139,13 +148,19 @@ let fix = null;
 if (mode !== "cleanup") {
   // ---- Review: external Codex lens ----
   phase("Review");
+  const detectNote = scope
+    ? `First check with \`git status\` and \`git diff HEAD\` whether changes to polish exist. If not, return has_changes: false with an empty diff_kind. If they do, set diff_kind: uncommitted.`
+    : `First determine the kind of target diff. If \`git status --porcelain\` prints anything, diff_kind: uncommitted. Otherwise, if \`git rev-list --count ${base}..HEAD\` is 1 or more, diff_kind: branch (the pushed branch diff). If neither applies, return has_changes: false with an empty diff_kind.`;
   codex = (await agent(
     anchor(
-      `External Codex review stage. First check with \`git status\` and \`git diff HEAD\` whether changes to polish exist. If not, return has_changes: false.\n` +
+      `External Codex review stage. ${detectNote}\n` +
         `Then check \`which codex\`. If missing, return available: false with empty findings.\n` +
-        `Otherwise run \`codex review "Review for logic, architecture, data flow, and code simplicity (flag over-complexity and unnecessary indirection)"\`. ` +
-        `In codex 0.141.0 the scope flags (--uncommitted / --base / --commit) are mutually exclusive with the PROMPT argument, so pass no scope flag when sending the simplicity-lens PROMPT (Codex reads git status itself). Omitting the PROMPT drops the simplicity lens, so always pass it.\n` +
-        `Structure the output into findings. Assign ids F1, F2, ..., and copy Codex's P1/P2/P3 as severity (judge from impact when absent). ${scopeNote}`,
+        `When diff_kind is branch, run \`codex review --base ${base}\` (in codex 0.144.6 the scope flags (--uncommitted / --base / --commit) are mutually exclusive with the PROMPT argument, so for a branch diff no PROMPT can be sent and the simplicity lens falls back to Codex's default lens).\n` +
+        `Otherwise run \`codex review "Review for logic, architecture, data flow, and code simplicity (flag over-complexity and unnecessary indirection)"\`. Pass no scope flag when sending the PROMPT (Codex reads git status itself). Omitting the PROMPT drops the simplicity lens, so always pass it for uncommitted.\n` +
+        `Structure the output into findings. Assign ids F1, F2, ..., and copy Codex's P1/P2/P3 as severity (judge from impact when absent). ` +
+        (scope
+          ? `The target scope is ${scope}. Drop any findings touching files outside it.`
+          : `Drop any findings touching files outside the determined diff (git diff HEAD for uncommitted, git diff ${base}...HEAD for branch).`),
     ),
     {
       label: "codex",
@@ -154,7 +169,7 @@ if (mode !== "cleanup") {
       schema: CODEX_SCHEMA,
       model: "sonnet",
     },
-  )) || { available: false, has_changes: true, findings: [] };
+  )) || { available: false, has_changes: true, diff_kind: "", findings: [] };
   if (!codex.has_changes) {
     return {
       mode,
@@ -219,6 +234,7 @@ if (mode !== "cleanup") {
     return {
       mode,
       codex_available: codex.available,
+      diff_kind: codex.diff_kind,
       survivors,
       needs_context: needsContext,
     };
@@ -229,7 +245,7 @@ if (mode !== "cleanup") {
     phase("Fix");
     fix = await agent(
       anchor(
-        `Fix the findings that survived the challenge, highest severity first. ${scopeNote}\n` +
+        `Fix the findings that survived the challenge, highest severity first. ${scopeNote(codex.diff_kind)}\n` +
           `After fixing, detect and run the project's test command; roll back any fix that breaks tests via git stash. Do not commit.\n` +
           `The findings are as follows.\n${JSON.stringify(survivors)}`,
       ),
@@ -248,9 +264,13 @@ if (mode !== "cleanup") {
 // ---- Cleanup: simplify -> enhancer-code -> test validation ----
 // Neither hunts bugs, so both apply directly without a critic-audit challenge.
 phase("Cleanup");
+const cleanupTarget =
+  codex.diff_kind === "branch"
+    ? `git diff ${base}...HEAD (the pushed branch diff)`
+    : "the current diff";
 await agent(
   anchor(
-    `Invoke the Skill tool with skill "simplify" for a cleanup-only pass (reuse, simplification, efficiency, altitude) on the current diff. If it rejects a no-arg invocation, pass the diff scope. Do not commit.`,
+    `Invoke the Skill tool with skill "simplify" for a cleanup-only pass (reuse, simplification, efficiency, altitude) on ${cleanupTarget}. If it rejects a no-arg invocation, pass the diff scope. Do not commit.`,
   ),
   {
     label: "simplify",
@@ -261,7 +281,7 @@ await agent(
 );
 await agent(
   anchor(
-    `Remove AI slop from the current diff, apply simplification rules, then audit tests. Your preservation rule (when in doubt, keep) takes priority over simplify's edits.`,
+    `Remove AI slop from ${cleanupTarget}, apply simplification rules, then audit tests. Your preservation rule (when in doubt, keep) takes priority over simplify's edits.`,
   ),
   {
     agentType: "enhancer-code",
@@ -291,6 +311,7 @@ const cleanup = (await agent(
 return {
   mode,
   codex_available: codex.available,
+  diff_kind: codex.diff_kind,
   findings: codex.findings.length,
   survivors: survivors.length,
   fixed: fix ? fix.fixed : [],

--- a/workflows/polish/tests/polish.diff-kind.test.js
+++ b/workflows/polish/tests/polish.diff-kind.test.js
@@ -1,0 +1,72 @@
+// polish の diff fallback: scope 省略時は uncommitted な変更、無ければ base...HEAD (push 済み branch diff)。
+// codex agent が返す diff_kind に応じて fix / cleanup の対象 diff が切り替わることをテストで固定する。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const polishJs = join(here, "..", "..", "polish.js");
+
+// Review -> Challenge -> Fix -> Cleanup を通す最小 stub。diff_kind だけ差し替える。
+const agentStub = (diffKind) => (prompt, opts) => {
+  const label = opts && opts.label;
+  if (label === "codex") {
+    return {
+      available: true,
+      has_changes: true,
+      diff_kind: diffKind,
+      findings: [{ id: "F1", title: "finding title", detail: "finding detail", severity: "P1" }],
+    };
+  }
+  if (label === "challenge") {
+    return { verdicts: [{ id: "F1", verdict: "confirmed" }] };
+  }
+  if (label === "fix") {
+    return { fixed: ["F1 fixed"], stashed: [], tests_pass: true };
+  }
+  if (label === "validate") {
+    return { edits: [], tests_pass: true, stashed: false };
+  }
+  return undefined;
+};
+
+const promptOf = (calls, label) => calls.agent.find((c) => c.opts && c.opts.label === label).prompt;
+
+test("scope 省略時の Review prompt に branch fallback 判定と --base 実行が含まれる", async () => {
+  const { calls } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub("branch") },
+  });
+  const review = promptOf(calls, "codex");
+  assert.match(review, /git rev-list --count main\.\.HEAD/, "rev-list による先行 commit 判定");
+  assert.match(review, /codex review --base main/, "branch diff は --base で codex 実行");
+});
+
+test("diff_kind: branch のとき fix と cleanup の対象が base...HEAD になる", async () => {
+  const { calls, result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub("branch") },
+  });
+  assert.match(promptOf(calls, "fix"), /git diff main\.\.\.HEAD/, "fix の対象は branch diff");
+  assert.match(promptOf(calls, "simplify"), /main\.\.\.HEAD/, "cleanup の対象は branch diff");
+  assert.equal(result.diff_kind, "branch", "返り値に diff_kind が出る");
+});
+
+test("diff_kind: uncommitted のとき fix の対象が git diff HEAD のままである", async () => {
+  const { calls } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub("uncommitted") },
+  });
+  assert.match(promptOf(calls, "fix"), /git diff HEAD/);
+});
+
+test("base 指定が Review / Fix の prompt に伝播する", async () => {
+  const { calls } = await runWorkflow(polishJs, {
+    args: { base: "develop" },
+    stubs: { agent: agentStub("branch") },
+  });
+  assert.match(promptOf(calls, "codex"), /codex review --base develop/);
+  assert.match(promptOf(calls, "fix"), /git diff develop\.\.\.HEAD/);
+});


### PR DESCRIPTION
## What & Why

PR #210 (issue #187 degradation 記録) のビルド中に同梱された scope 外の隣接変更 2 件を、conformance / audit 指摘に従い独立 PR として分離した。機能はビルド時に検証済み (pr_body_test 20 件 + polish.diff-kind.test 全 pass)。

- workflows/polish.js: scope 省略時の diff 対象を uncommitted / branch diff (diff_kind) で判別し、base 引数 (default main) を追加
- workflows/build/pr-body.py: PR 本文の verify tail を単一の折り畳み details にまとめる (status line は summary の code に保持)

## 未解決の audit findings (wf_933fcaff-202 から移管)

本 PR のコードに対する verified findings。merge 前に修正するか受容を判断する。

| severity | site | 内容 |
| --- | --- | --- |
| high | polish.js:267-270 | mode:full + branch diff で Fix stage の uncommitted 編集が cleanup の base...HEAD (committed range) から漏れ、直したばかりのコードが cleanup されない |
| medium | polish.js:148 | cleanup mode で diff_kind 未計算、caller の base 引数が無言で無視される |
| medium | polish.js:172 | review stall の fallback が diff_kind を '' に戻し、branch cleanup が uncommitted scope へ無言降格 |
| medium | pr-body.py:132-166 | html.escape / redaction 無しで public draft PR へ出力 (fold 破壊、後続 audit への hidden コメント混入、失敗 stderr の秘密漏洩) |
| low | polish.js:158-159 | degradation 状態 (lens 縮退・invalid base・substep stall) が返り値に記録されない |
| low | pr-body.py:171 | FAIL 時に verify ログが二重折り畳みの 2 クリック先、terminal では details タグが素で見える |

## 関連

- 分離元: #210 (issue #187)
- audit run: wf_933fcaff-202 (27 agents、challenge + verify 通過済み findings のみ)

https://claude.ai/code/session_01CAqzpEV3ARYX5BeGXrUez5