### PR TITLE
polish workflow に fix 後の Rejudge stage を追加

### DIFF
--- a/.ja/workflows/polish.js
+++ b/.ja/workflows/polish.js
@@ -286,7 +286,7 @@ if (mode !== "cleanup") {
     );
 
     // ---- Rejudge: fix が finding を実際に解消したかの再判定 ----
-    // fixed[] は fix agent の自己申告なので、post-fix diff を読み直す critic-audit を挟む。
+    // fixed[] は fix agent の自己申告なので、それを resolved の根拠にしない。
     phase("Rejudge");
     const rejudged = await agent(
       anchor(
@@ -308,7 +308,7 @@ if (mode !== "cleanup") {
       },
     );
     if (rejudged) {
-      // agent が落とした指摘を resolved に流さないため、欠けた評決は still_open に倒す。
+      // agent が評決を落としたとき、それを resolved と読まない。
       const byVerdict = new Map(rejudged.verdicts.map((v) => [v.id, v]));
       reopened = survivors
         .filter((s) => (byVerdict.get(s.id) || {}).verdict !== "resolved")
@@ -319,7 +319,7 @@ if (mode !== "cleanup") {
         }));
       log(`rejudge: reopened ${reopened.length} / survivors ${survivors.length}`);
     } else {
-      // 空配列だと「再判定して 0 件」と読めてしまうので、未判定は null で区別する。
+      // 空配列にすると「再判定して 0 件」と読めてしまう。
       reopened = null;
       rejudgeNotes =
         "rejudge agent が結果を返さなかったため resolved / still_open を判定していない";

--- a/.ja/workflows/polish.js
+++ b/.ja/workflows/polish.js
@@ -1,10 +1,16 @@
 export const meta = {
   name: "polish",
   description:
-    'Codex review + cleanup を決定論的に行う workflow。Codex の findings は critic-audit の challenge を必ず通り、triage (confirmed / disputed / downgraded / needs_context) は script が判定するため、fact 扱いの集約や challenge の skip が起きない。単体でも、build から workflow("polish") 経由の入れ子でも呼べる。',
+    'Codex review + cleanup を決定論的に行う workflow。Codex の findings は critic-audit の challenge を必ず通り、triage (confirmed / disputed / downgraded / needs_context) は script が判定するため、fact 扱いの集約や challenge の skip が起きない。fix 後は critic-audit が post-fix diff で resolved / still_open を再判定し、still_open は reopened として結果に出る。単体でも、build から workflow("polish") 経由の入れ子でも呼べる。',
   whenToUse:
-    "diff の外部レンズ review と AI slop 除去を headless に行う。args は scope 文字列、または {scope, repo, mode, base}。scope 省略時は uncommitted な変更、無ければ base branch (既定 main) より先行する commit の diff (push 済み branch diff) を対象とする。mode: full (既定) は review -> fix -> cleanup、review は challenge 済み findings を返すだけ (fix しない)、cleanup は simplify + enhancer-code + テスト検証のみ。内部 reviewer の深い audit は audit workflow を使う。",
-  phases: [{ title: "Review" }, { title: "Challenge" }, { title: "Fix" }, { title: "Cleanup" }],
+    "diff の外部レンズ review と AI slop 除去を headless に行う。args は scope 文字列、または {scope, repo, mode, base}。scope 省略時は uncommitted な変更、無ければ base branch (既定 main) より先行する commit の diff (push 済み branch diff) を対象とする。mode: full (既定) は review -> fix -> rejudge -> cleanup、review は challenge 済み findings を返すだけ (fix しない)、cleanup は simplify + enhancer-code + テスト検証のみ。内部 reviewer の深い audit は audit workflow を使う。",
+  phases: [
+    { title: "Review" },
+    { title: "Challenge" },
+    { title: "Fix" },
+    { title: "Rejudge" },
+    { title: "Cleanup" },
+  ],
 };
 
 // triage 表を script に置くのは、agent に verdict の解釈を任せると
@@ -40,6 +46,9 @@ const scopeNote = (diffKind) =>
     : diffKind === "branch"
       ? `対象は git diff ${base}...HEAD (push 済み branch diff)。diff 外のファイルに触れる fix は落とす。`
       : "対象は git diff HEAD (staged + unstaged)。diff 外のファイルに触れる fix は落とす。";
+// fix agent は commit しないため、fix の編集は working tree に残る。branch diff でも
+// base...HEAD では fix の編集が見えないので、base と working tree を比べる 2 点 diff を渡す。
+const postFixDiff = (diffKind) => (diffKind === "branch" ? `git diff ${base}` : "git diff HEAD");
 
 const CODEX_SCHEMA = {
   type: "object",
@@ -100,6 +109,31 @@ const VERDICTS_SCHEMA = {
   },
 };
 
+const REJUDGE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["verdicts"],
+  properties: {
+    verdicts: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "verdict"],
+        properties: {
+          id: { type: "string" },
+          verdict: {
+            type: "string",
+            enum: ["resolved", "still_open"],
+            description: "post-fix diff が finding を解消しているか",
+          },
+          why: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
 const FIX_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -140,6 +174,8 @@ let verdicts = [];
 let survivors = [];
 let needsContext = [];
 let fix = null;
+let reopened = [];
+let rejudgeNotes = "";
 
 if (mode !== "cleanup") {
   // ---- Review: 外部 Codex レンズ ----
@@ -249,6 +285,48 @@ if (mode !== "cleanup") {
         effort: "high",
       },
     );
+
+    // ---- Rejudge: fix が finding を実際に解消したかの再判定 ----
+    // fixed[] は fix agent の自己申告なので、post-fix diff を読み直す critic-audit を挟む。
+    // still_open から reopened への変換は script が持ち、agent の裁量に渡さない。
+    phase("Rejudge");
+    const rejudged = await agent(
+      anchor(
+        `critic-audit。fix stage 後の diff (\`${postFixDiff(codex.diff_kind)}\`) を読み、survivor ごとに finding が解消したかを判定する。\n` +
+          `verdict の基準は次のとおり。resolved = post-fix diff の変更が finding を解消している / still_open = diff に該当する変更が無い、または変更が finding を解消していない。\n` +
+          `fix agent の自己申告は根拠にせず diff を根拠にする。該当する変更が diff に見当たらない survivor は still_open とする。\n` +
+          `この diff には base branch が先に進んだぶんの他人の変更も混ざる。survivor が指す箇所に対応する変更だけを根拠にし、無関係な変更を解消の根拠にしない。\n` +
+          (scope ? `対象 scope は ${scope}。scope 外の変更は根拠にしない。\n` : "") +
+          `参考として fix stage の自己申告は fixed: ${JSON.stringify(fix ? fix.fixed : [])} / stashed: ${JSON.stringify(fix ? fix.stashed : [])}。\n` +
+          `Survivors は次のとおり。\n${JSON.stringify(survivors)}`,
+      ),
+      {
+        agentType: "critic-audit",
+        phase: "Rejudge",
+        label: "rejudge",
+        schema: REJUDGE_SCHEMA,
+        model: "opus",
+        effort: "xhigh",
+      },
+    );
+    if (rejudged) {
+      // verdict が欠けた survivor は still_open 扱い。agent が落とした指摘を resolved に流さない。
+      const byVerdict = new Map(rejudged.verdicts.map((v) => [v.id, v]));
+      reopened = survivors
+        .filter((s) => (byVerdict.get(s.id) || {}).verdict !== "resolved")
+        .map((s) => ({
+          id: s.id,
+          severity: s.severity,
+          why: (byVerdict.get(s.id) || {}).why || "",
+        }));
+      log(`rejudge: reopened ${reopened.length} / survivors ${survivors.length}`);
+    } else {
+      // ここは fail-open しない。誰も再判定していない状態を reopened 0 件と読み違えさせないため、
+      // 空配列ではなく null を返して未判定であることを呼び出し元に伝える。
+      reopened = null;
+      rejudgeNotes =
+        "rejudge agent が結果を返さなかったため resolved / still_open を判定していない";
+    }
   }
 }
 
@@ -305,6 +383,8 @@ return {
   survivors: survivors.length,
   fixed: fix ? fix.fixed : [],
   stashed_fixes: fix ? fix.stashed : [],
+  reopened,
+  rejudge_notes: rejudgeNotes,
   needs_context: needsContext,
   cleanup,
 };

--- a/.ja/workflows/polish.js
+++ b/.ja/workflows/polish.js
@@ -46,8 +46,7 @@ const scopeNote = (diffKind) =>
     : diffKind === "branch"
       ? `対象は git diff ${base}...HEAD (push 済み branch diff)。diff 外のファイルに触れる fix は落とす。`
       : "対象は git diff HEAD (staged + unstaged)。diff 外のファイルに触れる fix は落とす。";
-// fix agent は commit しないため、fix の編集は working tree に残る。branch diff でも
-// base...HEAD では fix の編集が見えないので、base と working tree を比べる 2 点 diff を渡す。
+// fix agent は commit しないので、fix の編集は base...HEAD では拾えない。
 const postFixDiff = (diffKind) => (diffKind === "branch" ? `git diff ${base}` : "git diff HEAD");
 
 const CODEX_SCHEMA = {
@@ -288,7 +287,6 @@ if (mode !== "cleanup") {
 
     // ---- Rejudge: fix が finding を実際に解消したかの再判定 ----
     // fixed[] は fix agent の自己申告なので、post-fix diff を読み直す critic-audit を挟む。
-    // still_open から reopened への変換は script が持ち、agent の裁量に渡さない。
     phase("Rejudge");
     const rejudged = await agent(
       anchor(
@@ -310,7 +308,7 @@ if (mode !== "cleanup") {
       },
     );
     if (rejudged) {
-      // verdict が欠けた survivor は still_open 扱い。agent が落とした指摘を resolved に流さない。
+      // agent が落とした指摘を resolved に流さないため、欠けた評決は still_open に倒す。
       const byVerdict = new Map(rejudged.verdicts.map((v) => [v.id, v]));
       reopened = survivors
         .filter((s) => (byVerdict.get(s.id) || {}).verdict !== "resolved")
@@ -321,8 +319,7 @@ if (mode !== "cleanup") {
         }));
       log(`rejudge: reopened ${reopened.length} / survivors ${survivors.length}`);
     } else {
-      // ここは fail-open しない。誰も再判定していない状態を reopened 0 件と読み違えさせないため、
-      // 空配列ではなく null を返して未判定であることを呼び出し元に伝える。
+      // 空配列だと「再判定して 0 件」と読めてしまうので、未判定は null で区別する。
       reopened = null;
       rejudgeNotes =
         "rejudge agent が結果を返さなかったため resolved / still_open を判定していない";

--- a/.ja/workflows/polish/tests/polish.rejudge.test.js
+++ b/.ja/workflows/polish/tests/polish.rejudge.test.js
@@ -1,6 +1,5 @@
-// polish の Rejudge stage: fix agent の fixed[] 自己申告を鵜呑みにせず、critic-audit が
-// post-fix diff を読んで survivor ごとに resolved / still_open を判定する。
-// still_open から reopened への変換は script 側の判定なので、外形挙動として固定する。
+// still_open から reopened への変換は agent でなく script 側の判定なので、
+// fix agent の自己申告に引きずられない外形挙動としてここで固定する。
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
@@ -10,8 +9,7 @@ import { runWorkflow } from "../../_lib/run-workflow.js";
 const here = dirname(fileURLToPath(import.meta.url));
 const polishJs = join(here, "..", "..", "polish.js");
 
-// Review -> Challenge -> Fix -> Rejudge -> Cleanup を通す最小 stub。
-// challenge の verdict と rejudge の返り値だけ差し替える。
+// Cleanup まで通す最小 stub。challenge の verdict と rejudge の返り値だけ差し替える。
 const agentStub = ({ diffKind = "uncommitted", challenge, rejudge } = {}) => {
   const stub = (prompt, opts) => {
     const label = opts && opts.label;

--- a/.ja/workflows/polish/tests/polish.rejudge.test.js
+++ b/.ja/workflows/polish/tests/polish.rejudge.test.js
@@ -1,0 +1,157 @@
+// polish の Rejudge stage: fix agent の fixed[] 自己申告を鵜呑みにせず、critic-audit が
+// post-fix diff を読んで survivor ごとに resolved / still_open を判定する。
+// still_open から reopened への変換は script 側の判定なので、外形挙動として固定する。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const polishJs = join(here, "..", "..", "polish.js");
+
+// Review -> Challenge -> Fix -> Rejudge -> Cleanup を通す最小 stub。
+// challenge の verdict と rejudge の返り値だけ差し替える。
+const agentStub = ({ diffKind = "uncommitted", challenge, rejudge } = {}) => {
+  const stub = (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "codex") {
+      return {
+        available: true,
+        has_changes: true,
+        diff_kind: diffKind,
+        findings: [
+          { id: "F1", title: "finding title", detail: "finding detail", severity: "P1" },
+          { id: "F2", title: "other title", detail: "other detail", severity: "P2" },
+        ],
+      };
+    }
+    if (label === "challenge") {
+      return (
+        challenge || {
+          verdicts: [
+            { id: "F1", verdict: "confirmed" },
+            { id: "F2", verdict: "confirmed" },
+          ],
+        }
+      );
+    }
+    if (label === "fix") {
+      return { fixed: ["F1 fixed", "F2 fixed"], stashed: [], tests_pass: true };
+    }
+    if (label === "rejudge") {
+      return rejudge;
+    }
+    if (label === "validate") {
+      return { edits: [], tests_pass: true, stashed: false };
+    }
+    return undefined;
+  };
+  return stub;
+};
+
+const bothResolved = {
+  verdicts: [
+    { id: "F1", verdict: "resolved" },
+    { id: "F2", verdict: "resolved" },
+  ],
+};
+
+const callOf = (calls, label) => calls.agent.find((c) => c.opts && c.opts.label === label);
+
+test("T-001 rejudge agent に survivor 一覧と post-fix diff の再判定指示が渡る", async () => {
+  const uncommitted = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub({ diffKind: "uncommitted", rejudge: bothResolved }) },
+  });
+  const call = callOf(uncommitted.calls, "rejudge");
+  assert.ok(call, "rejudge agent が起動する");
+  assert.equal(call.opts.agentType, "critic-audit", "再判定は critic-audit が担う");
+  assert.match(call.prompt, /"id":"F1"/, "survivor 一覧が prompt に載る");
+  assert.match(call.prompt, /"id":"F2"/, "survivor 一覧が prompt に載る");
+  assert.match(call.prompt, /git diff HEAD/, "uncommitted の post-fix diff は git diff HEAD");
+  assert.deepEqual(
+    call.opts.schema.properties.verdicts.items.properties.verdict.enum,
+    ["resolved", "still_open"],
+    "評決は resolved / still_open の 2 値",
+  );
+
+  const branch = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub({ diffKind: "branch", rejudge: bothResolved }) },
+  });
+  assert.match(
+    callOf(branch.calls, "rejudge").prompt,
+    /git diff main(?!\.)/,
+    "branch の post-fix diff は base と working tree の 2 点 diff (fix は commit されないため)",
+  );
+});
+
+test("T-002 still_open と判定された finding が reopened に id と severity 付きで載る", async () => {
+  const { result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: {
+      agent: agentStub({
+        rejudge: {
+          verdicts: [
+            { id: "F1", verdict: "resolved" },
+            { id: "F2", verdict: "still_open", why: "diff に該当変更なし" },
+          ],
+        },
+      }),
+    },
+  });
+  assert.deepEqual(result.reopened, [{ id: "F2", severity: "P2", why: "diff に該当変更なし" }]);
+  assert.equal(result.rejudge_notes, "", "判定できたときは notes を付けない");
+});
+
+test("T-002b 評決が欠けた survivor は still_open 扱いで reopened に載る", async () => {
+  const { result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: {
+      agent: agentStub({ rejudge: { verdicts: [{ id: "F1", verdict: "resolved" }] } }),
+    },
+  });
+  assert.deepEqual(
+    result.reopened.map((r) => r.id),
+    ["F2"],
+    "評決から落ちた survivor を resolved に流さない",
+  );
+});
+
+test("T-003 rejudge agent が結果を返さないとき reopened は null になり理由が付く", async () => {
+  const { result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub({ rejudge: undefined }) },
+  });
+  assert.equal(result.reopened, null, "未判定を reopened 0 件と読み違えさせない");
+  assert.match(result.rejudge_notes, /rejudge/, "未判定の理由が付く");
+});
+
+test("T-004 survivor がゼロのとき rejudge agent は起動しない", async () => {
+  const { calls, result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: {
+      agent: agentStub({
+        challenge: {
+          verdicts: [
+            { id: "F1", verdict: "disputed" },
+            { id: "F2", verdict: "disputed" },
+          ],
+        },
+      }),
+    },
+  });
+  assert.equal(result.survivors, 0);
+  assert.equal(callOf(calls, "rejudge"), undefined);
+  assert.deepEqual(result.reopened, [], "起動しないときの reopened は空配列");
+});
+
+test("T-005 mode review のとき rejudge agent は起動しない", async () => {
+  const { calls, result } = await runWorkflow(polishJs, {
+    args: { mode: "review" },
+    stubs: { agent: agentStub({ rejudge: bothResolved }) },
+  });
+  assert.equal(callOf(calls, "rejudge"), undefined);
+  assert.equal(result.reopened, undefined, "review の返り値に reopened は含まれない");
+});

--- a/workflows/polish.js
+++ b/workflows/polish.js
@@ -47,9 +47,7 @@ const scopeNote = (diffKind) =>
     : diffKind === "branch"
       ? `The target is git diff ${base}...HEAD (the pushed branch diff). Drop any fix touching files outside the diff.`
       : "The target is git diff HEAD (staged + unstaged). Drop any fix touching files outside the diff.";
-// The fix agent does not commit, so its edits stay in the working tree. Even for a
-// branch diff, base...HEAD hides those edits, so pass a two-dot diff comparing base
-// against the working tree.
+// The fix agent does not commit, so base...HEAD cannot pick up its edits.
 const postFixDiff = (diffKind) => (diffKind === "branch" ? `git diff ${base}` : "git diff HEAD");
 
 const CODEX_SCHEMA = {
@@ -297,8 +295,7 @@ if (mode !== "cleanup") {
     );
 
     // ---- Rejudge: did the fix actually resolve each finding? ----
-    // fixed[] is the fix agent's own report, so a critic-audit re-reads the post-fix
-    // diff. Turning still_open into reopened stays in the script, not the agent's hands.
+    // fixed[] is the fix agent's own report, so a critic-audit re-reads the post-fix diff.
     phase("Rejudge");
     const rejudged = await agent(
       anchor(
@@ -320,8 +317,8 @@ if (mode !== "cleanup") {
       },
     );
     if (rejudged) {
-      // A survivor with no verdict counts as still_open, so a finding the agent
-      // dropped never leaks through as resolved.
+      // A missing verdict falls to still_open so a finding the agent dropped
+      // never leaks through as resolved.
       const byVerdict = new Map(rejudged.verdicts.map((v) => [v.id, v]));
       reopened = survivors
         .filter((s) => (byVerdict.get(s.id) || {}).verdict !== "resolved")
@@ -332,8 +329,7 @@ if (mode !== "cleanup") {
         }));
       log(`rejudge: ${reopened.length} reopened / ${survivors.length} survivors`);
     } else {
-      // No fail-open here. Returning null instead of an empty array keeps the caller
-      // from reading "nobody rejudged" as "zero reopened".
+      // An empty array would read as "rejudged, zero reopened", so null marks undecided.
       reopened = null;
       rejudgeNotes = "the rejudge agent returned nothing, so resolved / still_open is undecided";
     }

--- a/workflows/polish.js
+++ b/workflows/polish.js
@@ -295,7 +295,7 @@ if (mode !== "cleanup") {
     );
 
     // ---- Rejudge: did the fix actually resolve each finding? ----
-    // fixed[] is the fix agent's own report, so a critic-audit re-reads the post-fix diff.
+    // fixed[] is the fix agent's own report, so it is not evidence of resolution.
     phase("Rejudge");
     const rejudged = await agent(
       anchor(
@@ -317,8 +317,7 @@ if (mode !== "cleanup") {
       },
     );
     if (rejudged) {
-      // A missing verdict falls to still_open so a finding the agent dropped
-      // never leaks through as resolved.
+      // A verdict the agent dropped is not read as resolved.
       const byVerdict = new Map(rejudged.verdicts.map((v) => [v.id, v]));
       reopened = survivors
         .filter((s) => (byVerdict.get(s.id) || {}).verdict !== "resolved")
@@ -329,7 +328,7 @@ if (mode !== "cleanup") {
         }));
       log(`rejudge: ${reopened.length} reopened / ${survivors.length} survivors`);
     } else {
-      // An empty array would read as "rejudged, zero reopened", so null marks undecided.
+      // An empty array would read as "rejudged, zero reopened".
       reopened = null;
       rejudgeNotes = "the rejudge agent returned nothing, so resolved / still_open is undecided";
     }

--- a/workflows/polish.js
+++ b/workflows/polish.js
@@ -1,10 +1,16 @@
 export const meta = {
   name: "polish",
   description:
-    'Deterministic Codex review + cleanup. Codex findings always pass through a critic-audit challenge, and the triage (confirmed / disputed / downgraded / needs_context) is decided by the script, so findings are never aggregated as facts and the challenge cannot be skipped. Callable standalone or nested from build via workflow("polish").',
+    'Deterministic Codex review + cleanup. Codex findings always pass through a critic-audit challenge, and the triage (confirmed / disputed / downgraded / needs_context) is decided by the script, so findings are never aggregated as facts and the challenge cannot be skipped. After the fix, critic-audit rejudges each survivor against the post-fix diff as resolved / still_open, and still_open surfaces as reopened in the result. Callable standalone or nested from build via workflow("polish").',
   whenToUse:
-    "Headless external-lens review of a diff plus AI-slop removal. args is a scope string, or {scope, repo, mode, base}. When scope is omitted, the target is the uncommitted changes, else the diff of commits ahead of the base branch (default main) — the pushed branch diff. mode: full (default) runs review -> fix -> cleanup; review returns the challenged findings without fixing; cleanup runs only simplify + enhancer-code + test validation. For a deep internal-reviewer audit use the audit workflow.",
-  phases: [{ title: "Review" }, { title: "Challenge" }, { title: "Fix" }, { title: "Cleanup" }],
+    "Headless external-lens review of a diff plus AI-slop removal. args is a scope string, or {scope, repo, mode, base}. When scope is omitted, the target is the uncommitted changes, else the diff of commits ahead of the base branch (default main) — the pushed branch diff. mode: full (default) runs review -> fix -> rejudge -> cleanup; review returns the challenged findings without fixing; cleanup runs only simplify + enhancer-code + test validation. For a deep internal-reviewer audit use the audit workflow.",
+  phases: [
+    { title: "Review" },
+    { title: "Challenge" },
+    { title: "Fix" },
+    { title: "Rejudge" },
+    { title: "Cleanup" },
+  ],
 };
 
 // The triage table lives in the script because
@@ -41,6 +47,10 @@ const scopeNote = (diffKind) =>
     : diffKind === "branch"
       ? `The target is git diff ${base}...HEAD (the pushed branch diff). Drop any fix touching files outside the diff.`
       : "The target is git diff HEAD (staged + unstaged). Drop any fix touching files outside the diff.";
+// The fix agent does not commit, so its edits stay in the working tree. Even for a
+// branch diff, base...HEAD hides those edits, so pass a two-dot diff comparing base
+// against the working tree.
+const postFixDiff = (diffKind) => (diffKind === "branch" ? `git diff ${base}` : "git diff HEAD");
 
 const CODEX_SCHEMA = {
   type: "object",
@@ -104,6 +114,31 @@ const VERDICTS_SCHEMA = {
   },
 };
 
+const REJUDGE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["verdicts"],
+  properties: {
+    verdicts: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "verdict"],
+        properties: {
+          id: { type: "string" },
+          verdict: {
+            type: "string",
+            enum: ["resolved", "still_open"],
+            description: "whether the post-fix diff resolves the finding",
+          },
+          why: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
 const FIX_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -144,6 +179,8 @@ let verdicts = [];
 let survivors = [];
 let needsContext = [];
 let fix = null;
+let reopened = [];
+let rejudgeNotes = "";
 
 if (mode !== "cleanup") {
   // ---- Review: external Codex lens ----
@@ -258,6 +295,48 @@ if (mode !== "cleanup") {
         effort: "high",
       },
     );
+
+    // ---- Rejudge: did the fix actually resolve each finding? ----
+    // fixed[] is the fix agent's own report, so a critic-audit re-reads the post-fix
+    // diff. Turning still_open into reopened stays in the script, not the agent's hands.
+    phase("Rejudge");
+    const rejudged = await agent(
+      anchor(
+        `critic-audit. Read the post-fix diff (\`${postFixDiff(codex.diff_kind)}\`) and judge, per survivor, whether the finding is resolved.\n` +
+          `The verdict criteria are as follows. resolved = a change in the post-fix diff resolves the finding / still_open = the diff carries no corresponding change, or the change does not resolve the finding.\n` +
+          `Base the judgment on the diff, not on the fix agent's own report. Any survivor with no corresponding change in the diff is still_open.\n` +
+          `This diff also carries other people's changes from the base branch moving ahead. Cite only changes corresponding to the spot each survivor points at; never treat an unrelated change as evidence of resolution.\n` +
+          (scope ? `The target scope is ${scope}. Do not cite changes outside it.\n` : "") +
+          `For reference, the fix stage self-reported fixed: ${JSON.stringify(fix ? fix.fixed : [])} / stashed: ${JSON.stringify(fix ? fix.stashed : [])}.\n` +
+          `The survivors are as follows.\n${JSON.stringify(survivors)}`,
+      ),
+      {
+        agentType: "critic-audit",
+        phase: "Rejudge",
+        label: "rejudge",
+        schema: REJUDGE_SCHEMA,
+        model: "opus",
+        effort: "xhigh",
+      },
+    );
+    if (rejudged) {
+      // A survivor with no verdict counts as still_open, so a finding the agent
+      // dropped never leaks through as resolved.
+      const byVerdict = new Map(rejudged.verdicts.map((v) => [v.id, v]));
+      reopened = survivors
+        .filter((s) => (byVerdict.get(s.id) || {}).verdict !== "resolved")
+        .map((s) => ({
+          id: s.id,
+          severity: s.severity,
+          why: (byVerdict.get(s.id) || {}).why || "",
+        }));
+      log(`rejudge: ${reopened.length} reopened / ${survivors.length} survivors`);
+    } else {
+      // No fail-open here. Returning null instead of an empty array keeps the caller
+      // from reading "nobody rejudged" as "zero reopened".
+      reopened = null;
+      rejudgeNotes = "the rejudge agent returned nothing, so resolved / still_open is undecided";
+    }
   }
 }
 
@@ -316,6 +395,8 @@ return {
   survivors: survivors.length,
   fixed: fix ? fix.fixed : [],
   stashed_fixes: fix ? fix.stashed : [],
+  reopened,
+  rejudge_notes: rejudgeNotes,
   needs_context: needsContext,
   cleanup,
 };

--- a/workflows/polish/tests/polish.rejudge.test.js
+++ b/workflows/polish/tests/polish.rejudge.test.js
@@ -1,6 +1,5 @@
-// polish の Rejudge stage: fix agent の fixed[] 自己申告を鵜呑みにせず、critic-audit が
-// post-fix diff を読んで survivor ごとに resolved / still_open を判定する。
-// still_open から reopened への変換は script 側の判定なので、外形挙動として固定する。
+// still_open から reopened への変換は agent でなく script 側の判定なので、
+// fix agent の自己申告に引きずられない外形挙動としてここで固定する。
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
@@ -10,8 +9,7 @@ import { runWorkflow } from "../../_lib/run-workflow.js";
 const here = dirname(fileURLToPath(import.meta.url));
 const polishJs = join(here, "..", "..", "polish.js");
 
-// Review -> Challenge -> Fix -> Rejudge -> Cleanup を通す最小 stub。
-// challenge の verdict と rejudge の返り値だけ差し替える。
+// Cleanup まで通す最小 stub。challenge の verdict と rejudge の返り値だけ差し替える。
 const agentStub = ({ diffKind = "uncommitted", challenge, rejudge } = {}) => {
   const stub = (prompt, opts) => {
     const label = opts && opts.label;

--- a/workflows/polish/tests/polish.rejudge.test.js
+++ b/workflows/polish/tests/polish.rejudge.test.js
@@ -1,0 +1,157 @@
+// polish の Rejudge stage: fix agent の fixed[] 自己申告を鵜呑みにせず、critic-audit が
+// post-fix diff を読んで survivor ごとに resolved / still_open を判定する。
+// still_open から reopened への変換は script 側の判定なので、外形挙動として固定する。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const polishJs = join(here, "..", "..", "polish.js");
+
+// Review -> Challenge -> Fix -> Rejudge -> Cleanup を通す最小 stub。
+// challenge の verdict と rejudge の返り値だけ差し替える。
+const agentStub = ({ diffKind = "uncommitted", challenge, rejudge } = {}) => {
+  const stub = (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "codex") {
+      return {
+        available: true,
+        has_changes: true,
+        diff_kind: diffKind,
+        findings: [
+          { id: "F1", title: "finding title", detail: "finding detail", severity: "P1" },
+          { id: "F2", title: "other title", detail: "other detail", severity: "P2" },
+        ],
+      };
+    }
+    if (label === "challenge") {
+      return (
+        challenge || {
+          verdicts: [
+            { id: "F1", verdict: "confirmed" },
+            { id: "F2", verdict: "confirmed" },
+          ],
+        }
+      );
+    }
+    if (label === "fix") {
+      return { fixed: ["F1 fixed", "F2 fixed"], stashed: [], tests_pass: true };
+    }
+    if (label === "rejudge") {
+      return rejudge;
+    }
+    if (label === "validate") {
+      return { edits: [], tests_pass: true, stashed: false };
+    }
+    return undefined;
+  };
+  return stub;
+};
+
+const bothResolved = {
+  verdicts: [
+    { id: "F1", verdict: "resolved" },
+    { id: "F2", verdict: "resolved" },
+  ],
+};
+
+const callOf = (calls, label) => calls.agent.find((c) => c.opts && c.opts.label === label);
+
+test("T-001 rejudge agent に survivor 一覧と post-fix diff の再判定指示が渡る", async () => {
+  const uncommitted = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub({ diffKind: "uncommitted", rejudge: bothResolved }) },
+  });
+  const call = callOf(uncommitted.calls, "rejudge");
+  assert.ok(call, "rejudge agent が起動する");
+  assert.equal(call.opts.agentType, "critic-audit", "再判定は critic-audit が担う");
+  assert.match(call.prompt, /"id":"F1"/, "survivor 一覧が prompt に載る");
+  assert.match(call.prompt, /"id":"F2"/, "survivor 一覧が prompt に載る");
+  assert.match(call.prompt, /git diff HEAD/, "uncommitted の post-fix diff は git diff HEAD");
+  assert.deepEqual(
+    call.opts.schema.properties.verdicts.items.properties.verdict.enum,
+    ["resolved", "still_open"],
+    "評決は resolved / still_open の 2 値",
+  );
+
+  const branch = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub({ diffKind: "branch", rejudge: bothResolved }) },
+  });
+  assert.match(
+    callOf(branch.calls, "rejudge").prompt,
+    /git diff main(?!\.)/,
+    "branch の post-fix diff は base と working tree の 2 点 diff (fix は commit されないため)",
+  );
+});
+
+test("T-002 still_open と判定された finding が reopened に id と severity 付きで載る", async () => {
+  const { result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: {
+      agent: agentStub({
+        rejudge: {
+          verdicts: [
+            { id: "F1", verdict: "resolved" },
+            { id: "F2", verdict: "still_open", why: "diff に該当変更なし" },
+          ],
+        },
+      }),
+    },
+  });
+  assert.deepEqual(result.reopened, [{ id: "F2", severity: "P2", why: "diff に該当変更なし" }]);
+  assert.equal(result.rejudge_notes, "", "判定できたときは notes を付けない");
+});
+
+test("T-002b 評決が欠けた survivor は still_open 扱いで reopened に載る", async () => {
+  const { result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: {
+      agent: agentStub({ rejudge: { verdicts: [{ id: "F1", verdict: "resolved" }] } }),
+    },
+  });
+  assert.deepEqual(
+    result.reopened.map((r) => r.id),
+    ["F2"],
+    "評決から落ちた survivor を resolved に流さない",
+  );
+});
+
+test("T-003 rejudge agent が結果を返さないとき reopened は null になり理由が付く", async () => {
+  const { result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: { agent: agentStub({ rejudge: undefined }) },
+  });
+  assert.equal(result.reopened, null, "未判定を reopened 0 件と読み違えさせない");
+  assert.match(result.rejudge_notes, /rejudge/, "未判定の理由が付く");
+});
+
+test("T-004 survivor がゼロのとき rejudge agent は起動しない", async () => {
+  const { calls, result } = await runWorkflow(polishJs, {
+    args: {},
+    stubs: {
+      agent: agentStub({
+        challenge: {
+          verdicts: [
+            { id: "F1", verdict: "disputed" },
+            { id: "F2", verdict: "disputed" },
+          ],
+        },
+      }),
+    },
+  });
+  assert.equal(result.survivors, 0);
+  assert.equal(callOf(calls, "rejudge"), undefined);
+  assert.deepEqual(result.reopened, [], "起動しないときの reopened は空配列");
+});
+
+test("T-005 mode review のとき rejudge agent は起動しない", async () => {
+  const { calls, result } = await runWorkflow(polishJs, {
+    args: { mode: "review" },
+    stubs: { agent: agentStub({ rejudge: bothResolved }) },
+  });
+  assert.equal(callOf(calls, "rejudge"), undefined);
+  assert.equal(result.reopened, undefined, "review の返り値に reopened は含まれない");
+});


### PR DESCRIPTION
## What & Why

polish の Fix stage は fix agent の fixed[]自己申告で完結し、修正が finding を実際に解消したかを誰も検証していなかった。Fix 後に critic-audit が post-fix diff を読み、survivor ごとに resolved / still_open を判定する Rejudge stage を追加する。still_open は reopened として workflow 結果に出るので、次の polish 実行か人間が拾える。レビューは script 側の判定 (still_open から reopened への変換、評決欠落の扱い) と post-fix diff の指定に絞ってほしい。

## Changes

- `.ja/workflows/polish.js` と EN ミラーに Rejudge stage を追加。critic-audit 起動と REJUDGE_SCHEMA (resolved / still_open) を Challenge stage と同形で複製し、meta.phases に Rejudge を入れた
- still_open から reopened への変換を script 側に置いた。評決が欠けた survivor も still_open 扱いにして、agent が落とした指摘が resolved に流れないようにする
- rejudge agent が結果を返さないときは fail-open せず reopened を null にし、rejudge_notes に理由を入れる
- rejudge テストを 6 件追加 (T-001 から T-005 と評決欠落ケース)。両ツリー同一コピーにするため、assertion は label 名、id、severity、git diff コマンドという言語非依存な部分に寄せた

## Scope

- Not included: reopened を修正する二周目 fix loop (次の polish 実行か人間が扱う)、codex exec resume 経路、Codex 観点別並列レビュー

## Design Decisions

- 起動 gate は survivors.length のみ。mode review と cleanup は Fix ブロックごと通らないので、追加の分岐を書かずに AC を満たす
- post-fix diff は branch でも `<base>...HEAD` ではなく `git diff <base>`。fix agent は commit しないため `<base>...HEAD` では fix の編集が見えない。base が先に進んだぶんの他人の変更が混ざる点は、prompt で「無関係な変更を解消の根拠にしない」と縛った
- Issue の AC が言う notes は rejudge_notes という名前にした。polish 結果に裸の notes を足すと、何についての notes か読めなくなる
- テストファイルは .ja と EN の同一コピー。workflows 配下の既存テスト 10 本中 5 本が同一で、assertion を言語非依存にしたので翻訳差分が出ない

## How to Test

1. `node --test "workflows/polish/tests/*.test.js" ".ja/workflows/polish/tests/*.test.js"` を実行する
2. 24 tests / 24 pass になる (既存 diff-kind 4 件と effort 2 件が両ツリーで green のまま、rejudge 6 件が追加で green)

## Related

- Closes #215

https://claude.ai/code/session_01MBw12BAAeBzk8WqGedAqU7
