### PR TITLE
[scribe] 変更起因でないテスト失敗の明示, PR スコープの分離, git 管理外パスへの参照 を追加/更新

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -6,27 +6,28 @@
 ## 昇格待ち (根拠2件以上、cap 超過持ち越し)
 
 - plugin 配布は fix PR 後に marketplace.json の version bump を別 PR で行い、桁は fix=patch / 呼び出し契約変更=minor #200 #203 #207
-- PR と無関係な既存 fail は「main 時点から fail / 変更対象外」と verify 節で明示する #167 #178 #179 #180
 - linter の false positive は緩和でなく理由コメント付き disable で抑止する #167 #168 #171 #176
 - prose/grep 照合だけの brittle テストや対象消滅した dead テストは理由記録付きで削除する #166 #167 #174 #180
 - 成果物が gitignore 配下 (output-styles/ workspace/) の作業は PR にせず手動 close する #33 #37 #38 #42
 - 根本原因が Claude Code runtime 側のバグは repo 側 wontfix + upstream 起票 + guard 文言で close する #132 #133 #177
 - 横展開の要否は ugrep 全ツリー確認で確定してから scope を固定する #49 #50 #53 #57
-- narrow な PR に無関係な rules/doctrine 変更を混ぜない (scope_creep 再発指摘) #189 #192 #194
 - reviewer 系の新設・再構築は Recall / FP baseline を計測して close する #24 #28 #43
 - 外部発想の issue には source:<origin> ラベルを付ける #30 #31 #32 #33 #39 #40 #41
 - 軽量バックログ複数件は 1 PR に束ねて複数 Closes する #44 #45
 - script/agent 出力は JSON stdout / error stderr / banner なしの機械可読形式にする #13 #54
 - audit report 命名は <YYYY-MM-DD>-<HHMMSS>-<slug>.md、slug は skill 名一致 #47 #51 #52 #53
 - 翻訳は情報系 prose のみ、file:line / severity / Closes 等の構造化フィールドは verbatim #175 #176
-- policy 値 (effort/model) は per-file 定数でなく behavioral capture テストで固定する #191 #192 #199
+- policy 値 (effort/model) は per-file 定数でなく behavioral capture テストで固定する #191 #192 #199 #223 #224
 - hook payload の形状は smoke test で実測確定し fixture 化してから gate を作る #150 #154
-- 挙動が実 run で観測できるまで PR は draft に据え置く #143 #159 #162 #163
-- 計画/umbrella issue は実装 issue へ切り直して superseded close する #37 #42 #46
-- session-start snapshot のため hook/agent 定義変更は同一 session で検証できず次 session 検証を明記する #162 #163
-- untracked ファイルへの参照が main に載ると dangling 参照になる #188 #190
+- 挙動が実 run で観測できるまで PR は draft に据え置く #143 #159 #162 #163 #226
+- 計画/umbrella issue は実装 issue へ切り直して superseded close する #37 #42 #46 #136
+- session-start snapshot のため hook/agent 定義変更は同一 session で検証できず次 session 検証を明記する #162 #163 #209
 - PostToolUse:Agent は launch 時のみ発火し async 完了で 2 度目が来ない。completion 依存の gate は成立しない #150 #154 #160
 - 出力パスの変更前に、予測可能な名前で読む consumer の有無を再確認する #40 #52
+- サイズ / 形式の判定は script の決定論チェックに置き、内容の判断だけを agent に渡す #210 #220 #222 #230
+- 閾値・tier・スコープは印象でなく実測値を根拠に決める #219 #220 #224 #225
+- 前提が harness / upstream の更新で消滅した issue は not planned で close し、消滅した前提を close コメントに残す #136 #184 #210
+- 未検証の推測は inferred と明記する。実機検証で棄却されうる (research) #210
 
 ## 単発 (根拠1件)
 

--- a/docs/wiki/ja-mirror-drift.md
+++ b/docs/wiki/ja-mirror-drift.md
@@ -2,7 +2,7 @@
 
 ## 内容
 
-.ja/ を canonical として編集し EN を同一コミットでミラーする運用 (`rules/conventions/MARKDOWN.md` の File scope、DR-0073) の下で、移行・削除を伴う変更時に片側ツリーへの反映が漏れ、dead な参照や promise タグが残る drift が繰り返し発生している。規約そのものは rules にあるが、規約だけでは防げていないため、変更時の両ツリー全域 grep を手順として固定する。
+.ja/ を canonical として編集し EN を同一コミットでミラーする運用 (`rules/conventions/MIRROR.md`、DR-0073) の下で、移行・削除を伴う変更時に片側ツリーへの反映が漏れ、dead な参照や promise タグが残る drift が繰り返し発生している。規約そのものは rules にあるが、規約だけでは防げていないため、変更時の両ツリー全域 grep を手順として固定する。
 
 ## 定型手順
 
@@ -18,4 +18,4 @@
 - #144 逆方向の drift。.ja/skills/swarm は削除済みだが EN 側が残存していた
 - #169 anchorless な .gitignore ルールにより .ja 側の test fixture 9 件が silently 欠落していた
 - #60 drift 事例の再発を受けて JA canonical + 同一コミット規律を DR-0073 に明文化した
-- 現行コード: `rules/conventions/MARKDOWN.md:18` (File scope 規約)、`docs/decisions/0073-adopt-ja-as-canonical-source-for-mirror.md`
+- 現行コード: `rules/conventions/MIRROR.md` の Canonical side and mirroring、`docs/decisions/0073-adopt-ja-as-canonical-source-for-mirror.md`

--- a/docs/wiki/pr-scope-separation.md
+++ b/docs/wiki/pr-scope-separation.md
@@ -1,0 +1,25 @@
+# PR スコープの分離
+
+## 内容
+
+1 つの issue を閉じる PR に、その issue が宣言していない変更を混ぜない。作業ツリーに別件が同居していたら、コミット前に分離して別 PR にする。分離できず混在したままコミットした場合は、PR 本文に scope 外のファイルを列挙し、レビューの焦点を宣言スコープ側に示す。
+
+## 定型手順
+
+1. コミット前に `git status` で作業ツリー全体を見て、issue の Scope に無いファイルを洗い出す
+2. 別件があれば別ブランチへ分離し、独立した PR にする
+3. 混在したままコミット済みなら、PR 本文に scope 外のファイルを列挙し、レビューの焦点を宣言スコープ側に書く
+4. 意図的に複数件をまとめる PR では、コミットを件ごとに分け、本文にコミット単位の表を置く
+
+## 参照コード
+
+- `workflows/build.js` の `scopeDeviations` (Verify が plan の files スコープ外の変更ファイルを列挙する)
+- `agents/reviewers/reviewer-conformance.md` (diff と issue/spec の突き合わせで scope creep を報告する)
+
+## 根拠
+
+- #189 #192 #194 narrow な PR に無関係な rules / doctrine 変更を混ぜた再発指摘
+- #210 degradation 記録の PR に PR 本文レンダラの変更が同梱され、conformance レビューが scope_creep として検出した
+- #211 #210 の scope 外 2 件を独立した PR として切り出した
+- #214 scope-deviations 14 件。model pin migration / scribe skill 変更 / context-monitor 変更の 3 系統が宣言スコープ外と指摘された
+- #228 作業ツリーに溜まっていた 5 件を 1 PR にまとめ、コミット単位の表を本文に置いて読み分けられるようにした

--- a/docs/wiki/pre-existing-failure-disclosure.md
+++ b/docs/wiki/pre-existing-failure-disclosure.md
@@ -1,0 +1,24 @@
+# 変更起因でないテスト失敗の明示
+
+## 内容
+
+PR の verify でテストが失敗したとき、その PR の変更に起因しないものは、いつから赤か、なぜこの PR の対象外かを verify 節に書く。分類は推測でなく、分岐点の commit で同じテストを実行して確認する。env 変数や手動受け入れを要求する意図的な gate は、解除条件まで書く。
+
+## 定型手順
+
+1. verify でテストが失敗したら、分岐点の commit で同じテストを実行する
+2. そこでも失敗するなら変更起因ではない。verify 節に、いつから赤か、なぜこの PR の対象外かを書く
+3. 意図的な gate (env 変数や手動受け入れ待ち) は、gate であることと解除条件を書く
+4. 変更起因の失敗と件数を分けて書く
+
+## 参照コード
+
+- `workflows/build/tests/build.behavior.test.js` の `ADR0085_MANUAL_ACCEPTANCE` gate (env 未設定のとき意図的に fail するテスト)
+
+## 根拠
+
+- #167 #178 #179 #180 変更起因でない fail を verify 節で切り分ける運用の初出
+- #214 19 fail のうち 1 件を「37fc4a7b とは無関係な設計上の失敗」と分類し、残り 18 件を no-repo gate 起因として切り分けた
+- #220「失敗 1 件は ADR0085_MANUAL_ACCEPTANCE 環境変数を要求する既存の manual gate」と How to Test に明記した
+- #222 verify 出力に「deliberate manual-acceptance gate、not a code defect、no fix was attempted」と記録した
+- #226「fail 2 件は EN/JA 同一の manual acceptance gate で、変更前から赤」と明記した

--- a/docs/wiki/untracked-reference-dangling.md
+++ b/docs/wiki/untracked-reference-dangling.md
@@ -1,0 +1,21 @@
+# git 管理外パスへの参照
+
+## 内容
+
+git 管理外のファイル (gitignore 配下、ローカル生成物) のパスを、commit される成果物から参照しない。参照側だけが main に載り、他の環境には参照先が無い状態になる。参照の実在を機械的に確認する仕組みがあると、その参照は壊れていると判定される。
+
+## 定型手順
+
+1. commit する文書にパスを書く前に、`git ls-files <path>` でそのパスが管理下かを確認する
+2. 管理外なら、パスの代わりに由来の種別だけを書く
+3. 参照を残したいなら、参照先を tracked にするか、参照側を gitignore 配下へ移す
+
+## 参照コード
+
+- `skills/scribe/SKILL.md` の Reference traceability 不変条件 (`workspace/research/` のパスを `docs/wiki/` 配下に書かない)
+- `skills/scribe/SKILL.md` Phase 4 の参照掃除 (ファイルの実在とシンボル名の grep 一致を機械的に確認し、壊れていれば共通項を不成立にする)
+
+## 根拠
+
+- #188 #190 untracked ファイルへの参照が main に載り dangling になった
+- #232 `workspace/research/` を scribe の入力に追加する際、evidence として research のファイルパスを wiki page に書く案を、Phase 4 の参照掃除が壊れた参照と判定するためこの理由で落とした


### PR DESCRIPTION
前回の scribe PR (#208, mergedAt 2026-07-19T06:45:52Z) 以降に closed になった PR 13 件 / issue 11 件と、mtime がそれ以降の research ファイル 1 件から抽出した。research を入力に含む初回 run。

## 追加したページ (3)

| ページ | 根拠 |
| --- | --- |
| `pre-existing-failure-disclosure.md` 変更起因でないテスト失敗の明示 | #167 #178 #179 #180 #214 #220 #222 #226 |
| `pr-scope-separation.md` PR スコープの分離 | #189 #192 #194 #210 #211 #214 #228 |
| `untracked-reference-dangling.md` git 管理外パスへの参照 | #188 #190 #232 |

いずれも `_candidates.md` の昇格待ちにあった項目で、今回のスコープで新たな根拠が付いたため昇格した。昇格した 3 行は候補から削除した。

## 候補への追記

新規 4 件。

- サイズ / 形式の判定は script の決定論チェックに置き、内容の判断だけを agent に渡す #210 #220 #222 #230
- 閾値・tier・スコープは印象でなく実測値を根拠に決める #219 #220 #224 #225
- 前提が harness / upstream の更新で消滅した issue は not planned で close し、消滅した前提を close コメントに残す #136 #184 #210
- 未検証の推測は inferred と明記する。実機検証で棄却されうる (research) #210

既存 4 行に根拠を追加。

- policy 値 (effort/model) は behavioral capture テストで固定する → #223 #224 を追加
- 挙動が実 run で観測できるまで PR は draft に据え置く → #226 を追加
- 計画/umbrella issue は実装 issue へ切り直して superseded close する → #136 を追加
- session-start snapshot のため次 session 検証を明記する → #209 を追加

## 参照修理

`ja-mirror-drift.md` の参照コードを `rules/conventions/MARKDOWN.md:18` (File scope) から `rules/conventions/MIRROR.md` の Canonical side and mirroring へ張り替えた。PR #226 が `.ja/` ミラー運用の規約を MARKDOWN.md から MIRROR.md へ切り出したため、File scope 節はファイル種別のスコープ定義だけになりミラー規約の参照先ではなくなっていた。

## 読んだ範囲

- PR: #209 #210 #211 #214 #220 #222 #223 #224 #226 #228 #230 #231 #232
- issue: #136 #184 #185 #186 #187 #213 #215 #218 #219 #221 #225
- research: 1 件

## 検証で落とした項目

なし。3 ページとも参照コードの実在を確認済み。

- `workflows/build/tests/build.behavior.test.js` の `ADR0085_MANUAL_ACCEPTANCE` gate (1180-1184 行に存在)
- `workflows/build.js` の `scopeDeviations` (882 行) と `agents/reviewers/reviewer-conformance.md`
- `skills/scribe/SKILL.md` の Reference traceability 不変条件 (20 行) と Phase 4 参照掃除 (63 行)

由来リンクは 3 ページとも該当なし。反事実テスト (その DR が supersede されたらページの書き換えが要るか) がいずれも No だった。既存 3 ページに由来節は無く、掃除対象なし。

## 打ち切った残し

1 run 3 ページの cap に達したため、次の 1 件を持ち越した。

- `incident-driven-deferral.md` の根拠追記。#186 (incident 未発生で close、再起票トリガーを #187 の Backlog candidates に記録)、#184 (harness 更新で前提消滅、not planned で close) の 2 件が該当する

https://claude.ai/code/session_01MBw12BAAeBzk8WqGedAqU7
