### PR TITLE
fix(skills): pageshot の agent-browser 呼び出しに chrome engine を指定

### DIFF
--- a/.ja/skills/use-workflow-pageshot/SKILL.md
+++ b/.ja/skills/use-workflow-pageshot/SKILL.md
@@ -18,6 +18,10 @@ user-invocable: false
 
 PR 本文は `/pr` から文字列として渡される。Preview URL または How to Test が欠落していれば、`mode: failed` と欠落フィールド名を返し、判断は `/pr` に任せる。
 
+## ブラウザ engine
+
+すべての agent-browser 呼び出しに `--session pageshot --engine chrome` を付ける。既定の lightpanda はグラフィックレンダリングエンジンを持たず、screenshot はプレースホルダー PNG を exit 0 で返し、record も同じレンダリング制約を受ける。engine は毎コマンドの解決値で決まりセッションには保持されないため、フラグを落とした呼び出しが 1 つ混ざるだけでブラウザが lightpanda で再起動し、そこまでのページ状態が失われる。`--session pageshot` で既定セッションから隔離し、普段 lightpanda で進めている作業を壊さない。
+
 ## モード選択
 
 | Steps の数 | モード     | 成果物      |

--- a/.ja/skills/use-workflow-pageshot/SKILL.md
+++ b/.ja/skills/use-workflow-pageshot/SKILL.md
@@ -20,7 +20,7 @@ PR 本文は `/pr` から文字列として渡される。Preview URL または 
 
 ## ブラウザ engine
 
-すべての agent-browser 呼び出しに `--session pageshot --engine chrome` を付ける。既定の lightpanda はグラフィックレンダリングエンジンを持たず、screenshot はプレースホルダー PNG を exit 0 で返し、record も同じレンダリング制約を受ける。engine は毎コマンドの解決値で決まりセッションには保持されないため、フラグを落とした呼び出しが 1 つ混ざるだけでブラウザが lightpanda で再起動し、そこまでのページ状態が失われる。`--session pageshot` で既定セッションから隔離し、普段 lightpanda で進めている作業を壊さない。
+すべての agent-browser 呼び出しに `--session pageshot --engine chrome` を付ける。既定の lightpanda は screenshot でプレースホルダー PNG を返す。
 
 ## モード選択
 

--- a/skills/use-workflow-pageshot/SKILL.md
+++ b/skills/use-workflow-pageshot/SKILL.md
@@ -20,7 +20,7 @@ PR body is passed as a string from `/pr`. If Preview URL or How to Test is missi
 
 ## Browser engine
 
-Pass `--session pageshot --engine chrome` on every agent-browser call. The default lightpanda has no graphics rendering engine, so screenshot returns a placeholder PNG with exit 0 and record runs under the same rendering limit. The engine is resolved per command and is not retained on the session, so a single call missing the flag restarts the browser on lightpanda and loses the page state built up so far. `--session pageshot` isolates this from the default session and leaves work already running on lightpanda intact.
+Pass `--session pageshot --engine chrome` on every agent-browser call. The default lightpanda returns a placeholder PNG for screenshot.
 
 ## Mode Selection
 

--- a/skills/use-workflow-pageshot/SKILL.md
+++ b/skills/use-workflow-pageshot/SKILL.md
@@ -18,6 +18,10 @@ user-invocable: false
 
 PR body is passed as a string from `/pr`. If Preview URL or How to Test is missing, return `mode: failed` with the missing field name and let `/pr` decide.
 
+## Browser engine
+
+Pass `--session pageshot --engine chrome` on every agent-browser call. The default lightpanda has no graphics rendering engine, so screenshot returns a placeholder PNG with exit 0 and record runs under the same rendering limit. The engine is resolved per command and is not retained on the session, so a single call missing the flag restarts the browser on lightpanda and loses the page state built up so far. `--session pageshot` isolates this from the default session and leaves work already running on lightpanda intact.
+
 ## Mode Selection
 
 | Steps count | Mode       | Artifact    |


### PR DESCRIPTION
## What

`use-workflow-pageshot` の全 agent-browser 呼び出しに `--session pageshot --engine chrome` を指定する節を追加した。

既定の lightpanda はグラフィックレンダリングエンジンを持たず、screenshot がプレースホルダー PNG を exit 0 で返す。record も同じレンダリング制約を受ける。`/pr` はその PNG を成果物として扱うため、失敗が exit code に出ないまま壊れた画像が添付されていた。

engine はセッションに保持されず毎コマンドで解決されるので、フラグを 1 つ落とすとブラウザが lightpanda で再起動し、そこまでのページ状態が失われる。全呼び出しに付ける必要がある。`--session pageshot` は既定セッションから隔離し、lightpanda で進行中の他作業を壊さないためのもの。

## Why this PR exists separately

`.ja/` 側の追記がローカルに未コミットで残っているのを #227 の作業中に見つけた。英語側ミラーがなかったため、ADR-0073 に従って両側を同一コミットに揃えた。

## Test

`agent-browser --engine chrome` の挙動は実行時に確認する。本 PR は skill の指示文のみの変更。

https://claude.ai/code/session_01MBw12BAAeBzk8WqGedAqU7