### PR TITLE
fix(rules): 条件付き rules の paths に repo root 直下形を追加

### DIFF
--- a/.ja/rules/conventions/PLUGIN.md
+++ b/.ja/rules/conventions/PLUGIN.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - ".claude/.claude-plugin/**"
+  - ".claude-plugin/**"
 ---
 
 # Plugin Conventions

--- a/.ja/rules/conventions/SKILLS.md
+++ b/.ja/rules/conventions/SKILLS.md
@@ -1,6 +1,8 @@
 ---
 paths:
   - ".claude/skills/**"
+  - "skills/**"
+  - ".ja/skills/**"
 ---
 
 # Skill Conventions

--- a/.ja/rules/conventions/SUBAGENT.md
+++ b/.ja/rules/conventions/SUBAGENT.md
@@ -1,6 +1,8 @@
 ---
 paths:
   - ".claude/agents/**"
+  - "agents/**"
+  - ".ja/agents/**"
 ---
 
 # Subagent Conventions

--- a/.ja/rules/conventions/WORKFLOWS.md
+++ b/.ja/rules/conventions/WORKFLOWS.md
@@ -1,6 +1,8 @@
 ---
 paths:
   - ".claude/workflows/**"
+  - "workflows/**"
+  - ".ja/workflows/**"
 ---
 
 # Workflow Conventions

--- a/rules/conventions/PLUGIN.md
+++ b/rules/conventions/PLUGIN.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - ".claude/.claude-plugin/**"
+  - ".claude-plugin/**"
 ---
 
 # Plugin Conventions

--- a/rules/conventions/SKILLS.md
+++ b/rules/conventions/SKILLS.md
@@ -1,6 +1,8 @@
 ---
 paths:
   - ".claude/skills/**"
+  - "skills/**"
+  - ".ja/skills/**"
 ---
 
 # Skill Conventions

--- a/rules/conventions/SUBAGENT.md
+++ b/rules/conventions/SUBAGENT.md
@@ -1,6 +1,8 @@
 ---
 paths:
   - ".claude/agents/**"
+  - "agents/**"
+  - ".ja/agents/**"
 ---
 
 # Subagent Conventions

--- a/rules/conventions/WORKFLOWS.md
+++ b/rules/conventions/WORKFLOWS.md
@@ -1,6 +1,8 @@
 ---
 paths:
   - ".claude/workflows/**"
+  - "workflows/**"
+  - ".ja/workflows/**"
 ---
 
 # Workflow Conventions


### PR DESCRIPTION
## What

SKILLS / SUBAGENT / WORKFLOWS / PLUGIN の `paths` に repo root 直下形を追加した。

| ファイル | 追加した glob |
| -------- | ------------- |
| SKILLS.md | `skills/**`, `.ja/skills/**` |
| SUBAGENT.md | `agents/**`, `.ja/agents/**` |
| WORKFLOWS.md | `workflows/**`, `.ja/workflows/**` |
| PLUGIN.md | `.claude-plugin/**` |

## Why

この 4 ファイルの `paths` は `.claude/` プレフィックス付きの glob だけを持っていた。dotclaude は repo root が `~/.claude` 自体なので `skills/` や `agents/` は root 直下にあり、`.claude/skills/**` には一致しない。`~/.claude/.claude/` の実体は `OUTCOME.md` と `workspace/` だけで、skills / agents / workflows は存在しない。

結果として、このリポジトリで skill や subagent を編集しても対応する規約が読み込まれていなかった。`MARKDOWN.md` だけは既に `agents/**/*.md` / `rules/**/*.md` / `skills/**/*.md` を持っており、そこから漏れた 4 ファイルが残っていた形になる。

他プロジェクトでは `.claude/skills/**` が正しく機能するため、既存の glob は残してある。

## Test

修正前後をネストした claude セッションで比較した。

| 時点 | 操作 | 結果 |
| ---- | ---- | ---- |
| 修正前 | 本セッションで `agents/critics/critic-design.md` を Read | SUBAGENT.md は注入されない |
| 修正後 | `claude -p` で `agents/critics/critic-audit.md` を Read させ、注入の有無を報告させる | SUBAGENT.md が注入され、見出し `## YAML Frontmatter` / `## Finding severity` を引用。両見出しの実在も確認 |

rules は session 開始時に読み込まれるため、同一セッション内では修正が反映されない。検証にネストセッションを使ったのはこのため。

Refs #235

https://claude.ai/code/session_01MBw12BAAeBzk8WqGedAqU7
