### PR TITLE
fix(rules): PLUGIN.md を単一プラグイン構成の実態に合わせる

### DIFF
--- a/.ja/rules/conventions/PLUGIN.md
+++ b/.ja/rules/conventions/PLUGIN.md
@@ -6,14 +6,14 @@ paths:
 
 # Plugin Conventions
 
-`.claude/.claude-plugin/` 配下の Claude Code プラグイン定義に対するルール。
+`.claude-plugin/` 配下の Claude Code プラグイン定義に対するルール。
 
 ## 制約
 
-プラグインはロード時にキャッシュされ、自身の境界外のファイルを参照できない。外部ホスティングは既存のクロス参照を壊すため、以下のルールを設ける。
+プラグインは install 時にリポジトリ全体を clone し、`skills/` `agents/` `workflows/` を無条件に auto-discovery する。`plugins` の `commands` / `agents` / `skills` フィールドは広告範囲の指定でしかない。プラグインを分割すると、各プラグインが同一の skill / agent を別 namespace で再登録する。
 
-| ルール             | ガイドライン                                |
-| ------------------ | ------------------------------------------- |
-| ソースを一元化     | `marketplace.json` で `source: "./"` を使用 |
-| 参照を保つ         | skills/, rules/, agents/ のクロス参照を保持 |
-| 外部プラグイン禁止 | 外部ホスティングのプラグインへの分割を禁止  |
+| ルール         | ガイドライン                                              |
+| -------------- | --------------------------------------------------------- |
+| 単一プラグイン | `marketplace.json` の `plugins` は build 1 件に保つ       |
+| ソース         | `{ "source": "github", "repo": "thkt/dotclaude" }` を使用 |
+| 参照を保つ     | skills/, rules/, agents/ のクロス参照を保持               |

--- a/rules/conventions/PLUGIN.md
+++ b/rules/conventions/PLUGIN.md
@@ -6,14 +6,14 @@ paths:
 
 # Plugin Conventions
 
-Rules for Claude Code plugin definitions under `.claude/.claude-plugin/`.
+Rules for Claude Code plugin definitions under `.claude-plugin/`.
 
 ## Constraints
 
-Plugins are cached at load time and cannot reference files outside their boundary. External hosting breaks existing cross-references between `skills/`, `rules/`, and `agents/`.
+A plugin clones the whole repository at install time and auto-discovers `skills/`, `agents/`, and `workflows/` unconditionally. The `commands` / `agents` / `skills` fields on a plugin only declare what it advertises. Splitting into several plugins makes each one re-register the same skill and agent under a different namespace.
 
-| Rule                | Guideline                                             |
-| ------------------- | ----------------------------------------------------- |
-| Monolithic source   | Use `source: "./"` in `marketplace.json`              |
-| Preserve references | Keep skills/, rules/, agents/ cross-references intact |
-| No external plugins | Do not split into externally-hosted plugins           |
+| Rule                | Guideline                                                   |
+| ------------------- | ----------------------------------------------------------- |
+| Single plugin       | Keep `plugins` in `marketplace.json` to the one build entry |
+| Source              | Use `{ "source": "github", "repo": "thkt/dotclaude" }`      |
+| Preserve references | Keep skills/, rules/, agents/ cross-references intact       |


### PR DESCRIPTION
## What

`rules/conventions/PLUGIN.md` の記述を `.claude-plugin/marketplace.json` の実態に合わせた。

| 行 | 変更前 | 変更後 |
| -- | ------ | ------ |
| 制約の前提 | プラグインは境界外のファイルを参照できず、外部ホスティングがクロス参照を壊す | install 時にリポジトリ全体を clone し、skills/ agents/ workflows/ を無条件に auto-discovery する |
| ソース | `source: "./"` を使用 | `{ "source": "github", "repo": "thkt/dotclaude" }` を使用 |
| 外部プラグイン禁止 | 外部ホスティングのプラグインへの分割を禁止 | 単一プラグイン。`plugins` は build 1 件に保つ |
| 対象パス | `.claude/.claude-plugin/` 配下 | `.claude-plugin/` 配下 |

## Why

`marketplace.json:17` の実値は `{ "source": "github", "repo": "thkt/dotclaude" }` で、PLUGIN.md が指示する `source: "./"` と食い違っていた。github source への移行は PR #182 で行われ、単一プラグインへの集約はその移行を前提に決まっている。

「プラグインは境界外を参照できないので外部ホスティングはクロス参照を壊す」という前提も実装と異なる。プラグインは install 時にリポジトリ全体を clone し、`skills/` `agents/` `workflows/` を無条件に auto-discovery する。分割が問題になるのは参照が切れるからではなく、各プラグインが同一実体を別 namespace で再登録するため。

この乖離は #237 の検証中に見つかった。PLUGIN.md は `paths` が `.claude/.claude-plugin/**` のみで、このリポジトリでは一度も発火しておらず、実装変更に追従する機会がなかった。

## Test

`.claude-plugin/marketplace.json` と ADR-0083 の記述に照らして各行を確認した。ルールファイルの記述変更のみで、実行される処理はない。

Refs #235

https://claude.ai/code/session_01MBw12BAAeBzk8WqGedAqU7