### PR TITLE
refactor(skills): use-herdr-agentchat を use-cli-herdr にリネーム

### DIFF
--- a/.ja/docs/SKILLS_AGENTS.md
+++ b/.ja/docs/SKILLS_AGENTS.md
@@ -31,13 +31,13 @@ graph LR
 
 `dr` は DR file と index を Write/Edit で生成し、`commit` は `git commit` を実行する。そのため Skill の状態と出力は許可ツールと手順に依存する。
 
-| 観点         | Skills                             | Agents           |
-| ------------ | ---------------------------------- | ---------------- |
+| 観点         | Skills                              | Agents           |
+| ------------ | ----------------------------------- | ---------------- |
 | 役割         | ナレッジベースまたは手順 (What/How) | 実行者 (Do)      |
-| 起動         | 自動ロードまたはコマンド参照       | Task ツール経由  |
-| コンテキスト | メイン または fork                 | 常に fork        |
-| 状態         | 読み取りまたは変更                 | 可変             |
-| 出力         | 情報、ファイル、または実行結果     | アーティファクト |
+| 起動         | 自動ロードまたはコマンド参照        | Task ツール経由  |
+| コンテキスト | メイン または fork                  | 常に fork        |
+| 状態         | 読み取りまたは変更                  | 可変             |
+| 出力         | 情報、ファイル、または実行結果      | アーティファクト |
 
 ## Skills
 
@@ -49,11 +49,11 @@ Skills は「ナレッジ モジュール」。AI がタスク実行時にドメ
 
 `/code`、`/audit`、`/polish` は `workflows/*.js` の Workflow であり、Skill ではない。User-invocable Skills は下表の 14 件。
 
-| カテゴリ       | Skills                                                                                                     | 用途                                  |
-| -------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| Workflow       | use-workflow-tdd-cycle, use-workflow-pageshot                                                              | 多段ワークフロー定義                  |
-| Context        | use-context-reviewer-\*, use-context-root-cause-analysis                                                   | エージェント向けドメイン知識          |
-| CLI ラッパー   | use-cli-codegraph, use-cli-recall, use-cli-scout, use-cli-gcloud, use-cli-heptabase                       | CLI ツール統合                        |
+| カテゴリ       | Skills                                                                                                    | 用途                                  |
+| -------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Workflow       | use-workflow-tdd-cycle, use-workflow-pageshot                                                             | 多段ワークフロー定義                  |
+| Context        | use-context-reviewer-\*, use-context-root-cause-analysis                                                  | エージェント向けドメイン知識          |
+| CLI ラッパー   | use-cli-codegraph, use-cli-recall, use-cli-scout, use-cli-gcloud, use-cli-heptabase, use-cli-herdr        | CLI ツール統合                        |
 | User-invocable | census, challenge, checkout, commit, dr, fix, issue, outcome, pr, preview, research, scribe, slice, think | スラッシュ コマンド エントリ ポイント |
 
 ### ロード機構
@@ -119,26 +119,26 @@ agents/
 
 ### Reviewer Agents (18 種)
 
-| Agent                  | 焦点                             |
-| ---------------------- | -------------------------------- |
-| reviewer-accessibility | WCAG 2.2 適合                    |
-| reviewer-causation     | 5 Whys 根本原因分析              |
-| reviewer-conformance   | diff と spec の適合性            |
-| reviewer-coverage      | テスト カバレッジ品質            |
+| Agent                  | 焦点                              |
+| ---------------------- | --------------------------------- |
+| reviewer-accessibility | WCAG 2.2 適合                     |
+| reviewer-causation     | 5 Whys 根本原因分析               |
+| reviewer-conformance   | diff と spec の適合性             |
+| reviewer-coverage      | テスト カバレッジ品質             |
 | reviewer-design        | deletion test による module depth |
-| reviewer-duplication   | クロスファイル DRY 分析          |
-| reviewer-efficiency    | アルゴリズム コスト、ホット パス |
-| reviewer-operations    | エラー境界、ロギング             |
-| reviewer-progressive   | CSS-first、JS 削減               |
-| reviewer-prompt        | LLM プロンプト定義の品質         |
-| reviewer-react-pattern | React 設計パターン               |
-| reviewer-readability   | コード構造、可読性               |
-| reviewer-resilience    | 耐障害性の弱点分析               |
-| reviewer-reuse         | 既存コードの再利用機会           |
-| reviewer-rust          | Rust idiom と安全性              |
-| reviewer-security      | OWASP Top 10                     |
-| reviewer-silence       | サイレント失敗の検出             |
-| reviewer-testability   | テスト可能なコード設計           |
+| reviewer-duplication   | クロスファイル DRY 分析           |
+| reviewer-efficiency    | アルゴリズム コスト、ホット パス  |
+| reviewer-operations    | エラー境界、ロギング              |
+| reviewer-progressive   | CSS-first、JS 削減                |
+| reviewer-prompt        | LLM プロンプト定義の品質          |
+| reviewer-react-pattern | React 設計パターン                |
+| reviewer-readability   | コード構造、可読性                |
+| reviewer-resilience    | 耐障害性の弱点分析                |
+| reviewer-reuse         | 既存コードの再利用機会            |
+| reviewer-rust          | Rust idiom と安全性               |
+| reviewer-security      | OWASP Top 10                      |
+| reviewer-silence       | サイレント失敗の検出              |
+| reviewer-testability   | テスト可能なコード設計            |
 
 ### Task ツールでの起動
 

--- a/.ja/skills/use-cli-herdr/SKILL.md
+++ b/.ja/skills/use-cli-herdr/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: use-herdr-agentchat
+name: use-cli-herdr
 description: herdr-agentchat プラグイン経由で codex (coder) に実装を委譲し、2 ペイン会話で完成まで進める。
 when_to_use: codex と連携, coder に委譲, coder に任せる, ペア実装, herdr で 2 agent, leader として実装依頼, agentchat, 2 ペイン会話, send で依頼
 allowed-tools: Bash Read
 user-invocable: false
 ---
 
-# use-herdr-agentchat
+# use-cli-herdr
 
 ## 前提
 
@@ -26,12 +26,12 @@ bash ~/.config/herdr/plugins/github/thkt.agentchat-*/actions/send.sh --reply-to 
 
 指示には対象ファイル、完了条件、書き込み範囲の制約を含める。`--reply-to leader` により coder への返信手段が本文に自動で埋め込まれる。
 
-| exit | 意味                                             | 対応                                           |
-| ---- | ------------------------------------------------ | ---------------------------------------------- |
-| 0    | coder が着手した                                 | 報告を待つ                                     |
-| 3    | 同一内容の連投                                   | 再送しない                                     |
-| 5    | coder が blocked                                 | 人間の承認待ち。送らない                       |
-| 6    | 起こせなかった (本文は入力欄に残っている可能性)  | 再送せず `herdr agent read coder` で画面を確認 |
+| exit | 意味                                               | 対応                                           |
+| ---- | -------------------------------------------------- | ---------------------------------------------- |
+| 0    | coder が着手した                                   | 報告を待つ                                     |
+| 3    | 同一内容の連投                                     | 再送しない                                     |
+| 5    | coder が blocked                                   | 人間の承認待ち。送らない                       |
+| 6    | 起こせなかった (本文は入力欄に残っている可能性)    | 再送せず `herdr agent read coder` で画面を確認 |
 | 7    | 着手を観測できず (すでに working 中なら届いている) | `herdr agent get coder` で状態確認。再送しない |
 
 ## Phase 3. 報告の受領

--- a/docs/SKILLS_AGENTS.md
+++ b/docs/SKILLS_AGENTS.md
@@ -33,13 +33,13 @@ graph LR
 `git commit`. Skill state and output therefore depend on the permitted tools and
 procedure.
 
-| Aspect         | Skills                          | Agents        |
-| -------------- | ------------------------------- | ------------- |
-| **Role**       | Knowledge base or procedure     | Executor (Do) |
-| **Invocation** | Auto-load or command reference  | Via Task tool |
-| **Context**    | Main or fork                    | Always fork   |
-| **State**      | Read-only or mutable            | Mutable       |
-| **Output**     | Information, files, or actions  | Artifacts     |
+| Aspect         | Skills                         | Agents        |
+| -------------- | ------------------------------ | ------------- |
+| **Role**       | Knowledge base or procedure    | Executor (Do) |
+| **Invocation** | Auto-load or command reference | Via Task tool |
+| **Context**    | Main or fork                   | Always fork   |
+| **State**      | Read-only or mutable           | Mutable       |
+| **Output**     | Information, files, or actions | Artifacts     |
 
 ## Skills
 
@@ -52,11 +52,11 @@ Skills are "knowledge modules" that provide domain-specific knowledge when AI ex
 `/code`, `/audit`, and `/polish` are workflows under `workflows/*.js`, not
 Skills. The User-invocable row lists all 14 current Skills.
 
-| Category       | Skills                                                                                                     | Purpose                          |
-| -------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| Workflow       | use-workflow-tdd-cycle, use-workflow-pageshot                                                              | Multi-phase workflow definitions |
-| Context        | use-context-reviewer-\*, use-context-root-cause-analysis                                                   | Domain knowledge for agents      |
-| CLI wrapper    | use-cli-codegraph, use-cli-recall, use-cli-scout, use-cli-gcloud, use-cli-heptabase                       | CLI tool integration             |
+| Category       | Skills                                                                                                    | Purpose                          |
+| -------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| Workflow       | use-workflow-tdd-cycle, use-workflow-pageshot                                                             | Multi-phase workflow definitions |
+| Context        | use-context-reviewer-\*, use-context-root-cause-analysis                                                  | Domain knowledge for agents      |
+| CLI wrapper    | use-cli-codegraph, use-cli-recall, use-cli-scout, use-cli-gcloud, use-cli-heptabase, use-cli-herdr        | CLI tool integration             |
 | User-invocable | census, challenge, checkout, commit, dr, fix, issue, outcome, pr, preview, research, scribe, slice, think | Slash command entry points       |
 
 ### Loading Mechanism

--- a/skills/use-cli-herdr/SKILL.md
+++ b/skills/use-cli-herdr/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: use-herdr-agentchat
+name: use-cli-herdr
 description: Delegate implementation to codex (coder) via the herdr-agentchat plugin and drive a two-pane conversation to completion.
 when_to_use: codex と連携, coder に委譲, coder に任せる, ペア実装, herdr で 2 agent, leader として実装依頼, agentchat, 2 ペイン会話, send で依頼
 allowed-tools: Bash Read
 user-invocable: false
 ---
 
-# use-herdr-agentchat
+# use-cli-herdr
 
 ## Prerequisite
 


### PR DESCRIPTION
## What

`skills/use-herdr-agentchat/` を `skills/use-cli-herdr/` にリネームし、`docs/SKILLS_AGENTS.md` の CLI wrapper 行に登録した。`.ja/` 側も同一コミットで揃えてある。

## Why

このスキルがラップしているのは herdr CLI で、`use-cli-scout` や `use-cli-recall` と同じ CLI ラッパーにあたる。

| SKILL.md が呼ぶもの | 種別 |
| ------------------- | ---- |
| `herdr agent rename` / `read` / `send-keys` / `get` | herdr CLI |
| `herdr plugin action invoke` / `plugin log list` | herdr CLI |
| `~/.config/herdr/plugins/.../actions/send.sh` | herdr プラグインが配置した shell script |

`rules/conventions/SKILLS.md` § Naming は user-invocable でないスキルを `use-cli-<cli>` / `use-context-<agent>` / `use-workflow-<noun>` の 3 パターンで分類しており、`use-herdr-agentchat` はどれにも一致していなかった。

当初は「plugin をラップする第 4 パターンを規約に足す」案を検討したが取り下げた。`rules/core/BOUNDARIES.md` § YAGNI Boundary が抽象化のゲートを呼び出し箇所 2 以上で開くと定めており、該当するスキルは 1 件しかない。既存パターンに名前を合わせるほうが規約を広げずに済む。

`docs/SKILLS_AGENTS.md` への登録はリネーム前から欠けていた。

## Test

| 確認 | 結果 |
| ---- | ---- |
| `git ls-files \| xargs ugrep -l 'use-herdr-agentchat'` | 残存参照なし (`workspace/history/` の監査ログを除く) |
| skill 数 | 27 で変化なし |
| skill loader | 本セッションで `use-cli-herdr` として認識済み |

`docs/SKILLS_AGENTS.md` の差分のうち内容の変更は CLI wrapper 行の 1 行だけで、残りは formatter による区切り行の幅調整。`git show -w` で確認できる。

Refs #240

https://claude.ai/code/session_01MBw12BAAeBzk8WqGedAqU7