### PR TITLE
fix(rules): 発火していなかった規約と実態の乖離 3 件を解消する

### DIFF
--- a/.ja/agents/_lib/calibration-examples.md
+++ b/.ja/agents/_lib/calibration-examples.md
@@ -252,72 +252,6 @@ app.get("/users", async (req, res) => {
 | Filter | Context Test: allowlist による検証                                |
 | Signal | `ALLOWED_SORTS.includes()` が補間前にユーザー入力をゲートしている |
 
-## TS (reviewer-strictness)
-
-### REPORT
-
-```typescript
-async function fetchUser(id: string): Promise<User> {
-  const res = await fetch(`/api/users/${id}`);
-  const data = await res.json();
-  return data as User; // no runtime validation
-}
-```
-
-| Field   | Value                                                  |
-| ------- | ------------------------------------------------------ |
-| Filter  | Harm Test pass: 検証なしの外部境界                     |
-| Trigger | API が予期しない形を返す (フィールド改名、null 追加)   |
-| Impact  | アサート位置から離れたランタイムクラッシュ; debug 困難 |
-
-### SKIP
-
-```typescript
-const schema = z.object({ name: z.string(), email: z.string().email() });
-
-function parseUser(raw: unknown): User {
-  const parsed = schema.parse(raw);
-  return parsed as User; // Zod already validated; type narrowing
-}
-```
-
-| Field  | Value                                               |
-| ------ | --------------------------------------------------- |
-| Filter | Context Test: 検証済み入力                          |
-| Signal | `schema.parse()` がアサート前にランタイム保証を提供 |
-
-## TD (reviewer-encapsulation)
-
-### REPORT
-
-```rust
-pub struct Order {
-    pub items: Vec<Item>,
-    pub total: f64,      // must equal sum of items - not enforced
-    pub status: String,  // "pending" | "paid" | "shipped" - not enforced
-}
-```
-
-| Field   | Value                                                            |
-| ------- | ---------------------------------------------------------------- |
-| Filter  | Harm Test pass: 不正状態が構築可能                               |
-| Trigger | `Order { items: vec![], total: 999.0, status: "banana".into() }` |
-| Impact  | total 不一致や不正 status からビジネスロジックバグ               |
-
-### SKIP
-
-```rust
-pub struct Point {
-    pub x: f64,
-    pub y: f64,
-}
-```
-
-| Field  | Value                                                 |
-| ------ | ----------------------------------------------------- |
-| Filter | Context Test: 強制すべき不変条件なし                  |
-| Signal | (x, y) はどんな組合せも有効; encapsulation は価値ゼロ |
-
 ## RP (reviewer-react-pattern)
 
 ### REPORT
@@ -479,51 +413,6 @@ function formatCurrency(amount: number, locale: string): string {
 | ------ | ------------------------------------------------------- |
 | Filter | Context Test: 純粋関数、隠れた依存なし                  |
 | Signal | `Intl.NumberFormat` は決定的; input/output でテスト可能 |
-
-## PERF (reviewer-performance)
-
-### REPORT
-
-```tsx
-function ChatList({ messages }: { messages: Message[] }) {
-  return (
-    <ul>
-      {messages.map((msg) => (
-        <ChatBubble
-          key={msg.id}
-          message={msg}
-          onReply={() => handleReply(msg.id)} // new function every render
-          style={{ padding: msg.isOwn ? 10 : 20 }} // new object every render
-        />
-      ))}
-    </ul>
-  );
-}
-```
-
-| Field   | Value                                                         |
-| ------- | ------------------------------------------------------------- |
-| Filter  | Harm Test pass: 親 render ごとに N 個の子 re-render           |
-| Trigger | 親の任意 state 変更; 100+ アイテムのリスト                    |
-| Impact  | inline arrow + inline object が全子の `React.memo` を破壊する |
-
-### SKIP
-
-```tsx
-function SettingsToggle({ label, checked, onChange }: Props) {
-  return (
-    <label>
-      {label}
-      <input type="checkbox" checked={checked} onChange={() => onChange(!checked)} />
-    </label>
-  );
-}
-```
-
-| Field  | Value                                                            |
-| ------ | ---------------------------------------------------------------- |
-| Filter | Context Test: leaf component、re-render する子なし               |
-| Signal | leaf の inline arrow; メモ化しても (subtree なし) 何も得られない |
 
 ## PE (reviewer-progressive)
 
@@ -713,11 +602,6 @@ function validateInvoiceDate(date: Date, billingCycle: BillingCycle): boolean {
 | Filter | Context Test: 既存等価物のないドメイン特化ロジック |
 | Signal | billing cycle 検証はこの機能固有                   |
 
-## DOC (reviewer-document)
-
-### REPORT
-
-```markdown
 ## Installation
 
 Install globally: $ npm install -g myapp

--- a/.ja/agents/enhancers/enhancer-evidence.md
+++ b/.ja/agents/enhancers/enhancer-evidence.md
@@ -40,16 +40,7 @@ audit workflow の enhancer-integration が統合済みの findings。すでに 
 critic-audit の生出力。finding_id ごとに verdict と severity を読む。stall 時の扱いは Phase 6 参照。
 
 ```json
-{
-  "challenges": [
-    {
-      "finding_id": "F-042",
-      "verdict": "confirmed",
-      "original_severity": "high",
-      "adjusted_severity": null
-    }
-  ]
-}
+{ "challenges": [{ "finding_id": "F-042", "verdict": "confirmed", "original_severity": "high", "adjusted_severity": null }] }
 ```
 
 ### Codex findings への Verification pass (critic-evidence, raw)
@@ -57,16 +48,7 @@ critic-audit の生出力。finding_id ごとに verdict と severity を読む�
 critic-evidence の生出力。finding_id ごとに verdict、budget_exhausted、evidence を読む。
 
 ```json
-{
-  "verifications": [
-    {
-      "finding_id": "F-042",
-      "verdict": "verified",
-      "budget_exhausted": false,
-      "evidence": "type, detail with file:line references"
-    }
-  ]
-}
+{ "verifications": [{ "finding_id": "F-042", "verdict": "verified", "budget_exhausted": false, "evidence": "type, detail with file:line references" }] }
 ```
 
 ### Promoted adversarial findings
@@ -74,15 +56,7 @@ critic-evidence の生出力。finding_id ごとに verdict、budget_exhausted�
 intent triage で「実バグ」と判定された adversarial テストの失敗。そのまま issues に含める。
 
 ```json
-[
-  {
-    "file": "path/to/file.rs",
-    "line": 42,
-    "severity": "high",
-    "summary": "[adversarial] assertion text: failure detail",
-    "source": "adversarial"
-  }
-]
+[{ "file": "path/to/file.rs", "line": 42, "severity": "high", "summary": "[adversarial] assertion text: failure detail", "source": "adversarial" }]
 ```
 
 ### 動的 evidence

--- a/.ja/rules/conventions/SKILLS.md
+++ b/.ja/rules/conventions/SKILLS.md
@@ -7,7 +7,7 @@ paths:
 
 # Skill Conventions
 
-`.claude/skills/` 配下のスキルファイルに対する規約。
+`skills/` 配下のスキルファイルに対する規約。
 
 ## 命名
 

--- a/.ja/rules/conventions/SUBAGENT.md
+++ b/.ja/rules/conventions/SUBAGENT.md
@@ -70,15 +70,7 @@ memory を付与する必須条件は以下のとおり。付与後、project �
 
 ## 指摘の重要度
 
-reviewer- 系が advisory な指摘を列挙するときは、各指摘に下記いずれかのラベルを付ける。`/audit` やユーザーが must-fix と好みを切り分けられるようにするため。ラベルがないと Critical と Nit が混ざり、Nit の洪水で must-fix が埋もれる。
-
-独自のゲート判定を返すエージェント (critic- 系の confirmed / disputed など) は自分の方式に従い、このラベルは併用しない。
-
-| ラベル   | 意味                                                   |
-| -------- | ------------------------------------------------------ |
-| Critical | 直さないと正しさ / 安全性 / 動作が壊れる。ブロック対象 |
-| Nit      | 直すと良いが任意。スタイルや軽微な可読性               |
-| Optional | 提案。採否は実装者判断で、見送っても問題ない           |
+reviewer- 系は `~/.claude/agents/_lib/finding-schema.md` の Severity (critical / high / medium / low) に従う。独自のゲート判定を返すエージェント (critic- 系の confirmed / disputed など) は自分の方式に従う。
 
 ## 参照記法
 

--- a/.ja/rules/conventions/SUBAGENT.md
+++ b/.ja/rules/conventions/SUBAGENT.md
@@ -7,7 +7,7 @@ paths:
 
 # Subagent Conventions
 
-`.claude/agents/` 配下のサブエージェントファイルに対する規約。
+`agents/` 配下のサブエージェントファイルに対する規約。
 
 ## 命名
 

--- a/.ja/rules/conventions/WORKFLOWS.md
+++ b/.ja/rules/conventions/WORKFLOWS.md
@@ -7,7 +7,7 @@ paths:
 
 # Workflow Conventions
 
-`.claude/workflows/` 配下の workflow script (headless で決定論的に走る pipeline) に対する規約。
+`workflows/` 配下の workflow script (headless で決定論的に走る pipeline) に対する規約。
 
 ## Degradation の記録
 

--- a/agents/_lib/calibration-examples.md
+++ b/agents/_lib/calibration-examples.md
@@ -252,72 +252,6 @@ app.get("/users", async (req, res) => {
 | Filter | Context Test: allowlist validation                               |
 | Signal | `ALLOWED_SORTS.includes()` gates user input before interpolation |
 
-## TS (reviewer-strictness)
-
-### REPORT
-
-```typescript
-async function fetchUser(id: string): Promise<User> {
-  const res = await fetch(`/api/users/${id}`);
-  const data = await res.json();
-  return data as User;  // no runtime validation
-}
-```
-
-| Field   | Value                                                    |
-| ------- | -------------------------------------------------------- |
-| Filter  | Harm Test pass - external boundary without validation    |
-| Trigger | API returns unexpected shape (field renamed, null added) |
-| Impact  | Runtime crash far from the assertion site; hard to debug |
-
-### SKIP
-
-```typescript
-const schema = z.object({ name: z.string(), email: z.string().email() });
-
-function parseUser(raw: unknown): User {
-  const parsed = schema.parse(raw);
-  return parsed as User;  // Zod already validated; type narrowing
-}
-```
-
-| Field  | Value                                                        |
-| ------ | ------------------------------------------------------------ |
-| Filter | Context Test: validated input                                |
-| Signal | `schema.parse()` provides runtime guarantee before assertion |
-
-## TD (reviewer-encapsulation)
-
-### REPORT
-
-```rust
-pub struct Order {
-    pub items: Vec<Item>,
-    pub total: f64,      // must equal sum of items - not enforced
-    pub status: String,  // "pending" | "paid" | "shipped" - not enforced
-}
-```
-
-| Field   | Value                                                            |
-| ------- | ---------------------------------------------------------------- |
-| Filter  | Harm Test pass - invalid state is constructible                  |
-| Trigger | `Order { items: vec![], total: 999.0, status: "banana".into() }` |
-| Impact  | Business logic bugs from inconsistent total or invalid status    |
-
-### SKIP
-
-```rust
-pub struct Point {
-    pub x: f64,
-    pub y: f64,
-}
-```
-
-| Field  | Value                                                        |
-| ------ | ------------------------------------------------------------ |
-| Filter | Context Test: no invariants to enforce                       |
-| Signal | Any (x, y) combination is valid; encapsulation adds no value |
-
 ## RP (reviewer-react-pattern)
 
 ### REPORT
@@ -472,51 +406,6 @@ function formatCurrency(amount: number, locale: string): string {
 | ------ | ------------------------------------------------------------ |
 | Filter | Context Test: pure function, no hidden dependencies          |
 | Signal | `Intl.NumberFormat` is deterministic; test with input/output |
-
-## PERF (reviewer-performance)
-
-### REPORT
-
-```tsx
-function ChatList({ messages }: { messages: Message[] }) {
-  return (
-    <ul>
-      {messages.map(msg => (
-        <ChatBubble
-          key={msg.id}
-          message={msg}
-          onReply={() => handleReply(msg.id)}  // new function every render
-          style={{ padding: msg.isOwn ? 10 : 20 }}  // new object every render
-        />
-      ))}
-    </ul>
-  );
-}
-```
-
-| Field   | Value                                                          |
-| ------- | -------------------------------------------------------------- |
-| Filter  | Harm Test pass - N child re-renders per parent render          |
-| Trigger | Any state change in parent; list with 100+ items               |
-| Impact  | Inline arrow + inline object break `React.memo` on every child |
-
-### SKIP
-
-```tsx
-function SettingsToggle({ label, checked, onChange }: Props) {
-  return (
-    <label>
-      {label}
-      <input type="checkbox" checked={checked} onChange={() => onChange(!checked)} />
-    </label>
-  );
-}
-```
-
-| Field  | Value                                                      |
-| ------ | ---------------------------------------------------------- |
-| Filter | Context Test: leaf component, no children to re-render     |
-| Signal | Inline arrow on leaf; memoizing saves nothing (no subtree) |
 
 ## PE (reviewer-progressive)
 
@@ -706,11 +595,6 @@ function validateInvoiceDate(date: Date, billingCycle: BillingCycle): boolean {
 | Filter | Context Test: domain-specific logic with no existing equivalent |
 | Signal | Billing cycle validation is unique to this feature              |
 
-## DOC (reviewer-document)
-
-### REPORT
-
-```markdown
 ## Installation
 
 Install globally: $ npm install -g myapp

--- a/agents/enhancers/enhancer-evidence.md
+++ b/agents/enhancers/enhancer-evidence.md
@@ -40,16 +40,7 @@ The audit workflow's enhancer-integration integrated findings. These have alread
 critic-audit raw output. Read verdict and severity per finding_id. See Phase 6 for stall handling.
 
 ```json
-{
-  "challenges": [
-    {
-      "finding_id": "F-042",
-      "verdict": "confirmed",
-      "original_severity": "high",
-      "adjusted_severity": null
-    }
-  ]
-}
+{ "challenges": [{ "finding_id": "F-042", "verdict": "confirmed", "original_severity": "high", "adjusted_severity": null }] }
 ```
 
 ### Verification pass on Codex findings (critic-evidence, raw)
@@ -57,16 +48,7 @@ critic-audit raw output. Read verdict and severity per finding_id. See Phase 6 f
 critic-evidence raw output. Read verdict, budget_exhausted, and evidence per finding_id.
 
 ```json
-{
-  "verifications": [
-    {
-      "finding_id": "F-042",
-      "verdict": "verified",
-      "budget_exhausted": false,
-      "evidence": "type, detail with file:line references"
-    }
-  ]
-}
+{ "verifications": [{ "finding_id": "F-042", "verdict": "verified", "budget_exhausted": false, "evidence": "type, detail with file:line references" }] }
 ```
 
 ### Promoted adversarial findings
@@ -74,15 +56,7 @@ critic-evidence raw output. Read verdict, budget_exhausted, and evidence per fin
 Adversarial test failures that intent triage judged to be real bugs. Include them into issues as-is.
 
 ```json
-[
-  {
-    "file": "path/to/file.rs",
-    "line": 42,
-    "severity": "high",
-    "summary": "[adversarial] assertion text: failure detail",
-    "source": "adversarial"
-  }
-]
+[{ "file": "path/to/file.rs", "line": 42, "severity": "high", "summary": "[adversarial] assertion text: failure detail", "source": "adversarial" }]
 ```
 
 ### Dynamic evidence

--- a/rules/conventions/SKILLS.md
+++ b/rules/conventions/SKILLS.md
@@ -7,7 +7,7 @@ paths:
 
 # Skill Conventions
 
-Conventions for skill files under `.claude/skills/`.
+Conventions for skill files under `skills/`.
 
 ## Naming
 

--- a/rules/conventions/SUBAGENT.md
+++ b/rules/conventions/SUBAGENT.md
@@ -7,7 +7,7 @@ paths:
 
 # Subagent Conventions
 
-Conventions for sub-agent files under `.claude/agents/`.
+Conventions for sub-agent files under `agents/`.
 
 ## Naming
 

--- a/rules/conventions/SUBAGENT.md
+++ b/rules/conventions/SUBAGENT.md
@@ -70,15 +70,7 @@ The required conditions for granting memory are below. After assignment, remove 
 
 ## Finding severity
 
-When a reviewer- agent lists advisory findings, tag each with one of the labels below so the consumer (/audit or the user) separates must-fix from preference. Unlabeled findings mix Critical with Nit, and the nit flood buries the must-fix items.
-
-Agents returning their own gate verdict (critic- confirmed / disputed, etc.) use their own scheme and do not layer this label on top.
-
-| Label    | Meaning                                                       |
-| -------- | ------------------------------------------------------------- |
-| Critical | Correctness / safety / behavior breaks unless fixed. Blocking |
-| Nit      | Good to fix but optional. Style or minor readability          |
-| Optional | A suggestion. The implementer decides, fine to skip           |
+A reviewer- agent follows the Severity field (critical / high / medium / low) in `~/.claude/agents/_lib/finding-schema.md`. Agents returning their own gate verdict (critic- confirmed / disputed, etc.) use their own scheme.
 
 ## Reference notation
 

--- a/rules/conventions/WORKFLOWS.md
+++ b/rules/conventions/WORKFLOWS.md
@@ -7,7 +7,7 @@ paths:
 
 # Workflow Conventions
 
-Conventions for workflow scripts (headless deterministic pipelines) under `.claude/workflows/`.
+Conventions for workflow scripts (headless deterministic pipelines) under `workflows/`.
 
 ## Degradation recording
 


### PR DESCRIPTION
## What

| コミット | 対象 | 内容 |
| -------- | ---- | ---- |
| c8ffc288 | SKILLS / SUBAGENT / WORKFLOWS | 対象パス表記を `.claude/skills/` 等から repo root 直下に修正 |
| cd4a27e9 | SUBAGENT.md § Finding severity | Critical / Nit / Optional を廃し、finding-schema.md の critical / high / medium / low に一本化 |
| (3 つ目) | agents/enhancers/enhancer-evidence.md | JSON 例を 1 行にまとめて 219 行から 193 行に |

## Why

この 3 ファイルは `paths` が `.claude/` プレフィックスのみで、dotclaude では一度も発火していなかった (PR #237 で修正)。発火していない間に実装が先に進み、規約が追従していない箇所が残っていた。

| # | 乖離 | 直した側 |
| - | ---- | -------- |
| 1 | 規約が `.claude/skills/` を対象と書くが実体は root 直下 | 規約 |
| 2 | 規約が 3 ラベルを要求するが reviewer 18 件は finding-schema の 4 段階を返す | 規約 |
| 3 | agent 本文が 200 行閾値を 19 行超過 | 実装 |

2 の代償として、must-fix と好みを分ける軸が失われる。切り分けが必要になった時点で finding-schema.md 側にフィールドを足す。

## Test

| 確認 | 結果 |
| ---- | ---- |
| agent 本文の行数 | EN / `.ja` とも 200 行超えなし |
| enhancer-evidence.md の JSON ブロック | `json.loads` を全ブロック通過 |

## 判定に迷った点

`agents/_lib/calibration-examples.md` は 840 行あるが対象外とした。SUBAGENT.md § Size limit の「本文は 200 行」は agent 本文を指し、`_lib/` は agent 定義ではなく参照資料にあたる。規約に `_lib/` の扱いは明記されていない。

Closes #240

https://claude.ai/code/session_01MBw12BAAeBzk8WqGedAqU7