### PR TITLE
docs(wiki): パス参照の棚卸し手順を追加

### DIFF
--- a/docs/wiki/path-reference-audit.md
+++ b/docs/wiki/path-reference-audit.md
@@ -1,0 +1,33 @@
+# パス参照の棚卸し
+
+## 内容
+
+skill / agent / workflow / rule に書かれたパス参照は 3 形式あり、指す先が異なる。棚卸しでは形式ごとに展開規則を変え、実在チェックだけで壊れと判定しない。対象プロジェクト側を指す参照と glob パターンが偽陽性になる。
+
+| 形式                      | 指す先                 | 展開                                                    |
+| ------------------------- | ---------------------- | ------------------------------------------------------- |
+| `~/.claude/...`           | dotclaude 内のリソース | そのまま。cwd 非依存                                    |
+| `${CLAUDE_SKILL_DIR}/...` | skill 自身の配下       | skill ディレクトリ起点。`../../` は `~/.claude/` に届く |
+| 相対パス                  | 起動プロジェクト内     | 起動時の cwd 起点                                       |
+
+## 定型手順
+
+1. `git ls-files` で skills / agents / workflows / rules / output-styles / CLAUDE.md と `.ja/` 対応を対象にする
+2. 3 形式を正規表現で抽出し、末尾の句読点とバッククォートを落とす
+3. `.ja/` 配下のファイルは prefix を除いたパスを起点に展開する。`.ja/` は canonical であって実行体ではない
+4. glob (`*` を含む) は展開せず目視に回す
+5. 実在しないものを次の型で仕分ける。いずれにも当たらないものだけが壊れた参照
+
+| 偽陽性の型               | 例                                                          |
+| ------------------------ | ----------------------------------------------------------- |
+| 対象プロジェクト側のパス | `docs/pull_request_template.md` の探索順序                  |
+| ファイルパターンの表記   | `agents/*.md`, `skills/SKILL.md`                            |
+| 実行時に作られる出力先   | `${CLAUDE_SKILL_DIR}/../../workspace/pageshot/`             |
+| 規約内の記法説明         | `rules/conventions/SKILLS.md` の `${CLAUDE_SKILL_DIR}` 例示 |
+
+## 根拠
+
+- #239 audit skill の attic 退避後、reviewer 18 件が `finding-schema.md` を裸のファイル名で参照し続け、どこからも解決できなかった
+- #243 全 323 参照を棚卸しし、解決不能ゼロを確認した。MISSING 判定 4 件はすべて上表の偽陽性
+- 現行コード: `rules/conventions/SUBAGENT.md` § Reference notation、`rules/conventions/SKILLS.md` § Reference notation
+- 未検証: plugin 経由起動での解決可否。plugin cache が古い版のままだと現状を測れない


### PR DESCRIPTION
## What

`docs/wiki/path-reference-audit.md` を追加した。パス参照を 3 形式に分け、形式ごとの展開規則と偽陽性の型を定型手順として残す。

## 棚卸し結果 (#243 項目 1-3)

skills / agents / workflows / rules / output-styles / CLAUDE.md と `.ja/` 対応の 324 ファイルから 323 参照を抽出した。

| 形式 | 件数 | 指す先 |
| ---- | ---- | ------ |
| `~/.claude/...` | 130 | dotclaude 内のリソース |
| `${CLAUDE_SKILL_DIR}/...` | 119 | skill 自身の配下 |
| 相対パス | 74 | 起動プロジェクト内、または glob / ディレクトリの説明 |

| 判定 | 件数 |
| ---- | ---- |
| 解決する | 265 |
| glob (展開せず目視) | 38 |
| 規約内の記法説明 | 10 |
| 実在しない | 10 (ユニーク 4 種、すべて偽陽性) |

実在しない 4 種の内訳。

| 参照 | 実体 |
| ---- | ---- |
| `skills/SKILL.md` | reviewer-prompt.md の対象ファイルパターン表記 |
| `docs/getting-started.md` | issue テンプレートの Good / Bad 例 |
| `docs/pull_request_template.md` | PR テンプレートの探索順序 |
| `${CLAUDE_SKILL_DIR}/../../workspace/pageshot/` | 実行時に作られる出力先 |

修正対象はゼロ。`SUBAGENT.md` § Reference notation が避けるとする「dotclaude 内のリソースを相対で指す」用法は 1 件もなかった。相対パスはすべて起動プロジェクト内 (scribe の `docs/wiki/` など) か説明表記だった。

## 判定スクリプトを恒久化しなかった理由

修正対象がゼロだったため、常駐スクリプトの維持コストに見合わない。偽陽性 4 件の除外リストを保守し続ける必要もある。抽出パターンと判定基準を wiki に残し、必要時に書き直す。

## 未検証

plugin 経由起動での解決可否。現在の plugin cache は 4.0.0 / 4.0.1 で `marketplace.json` は 4.1.0 のため、`agents/_lib/` を含まない古い版しか測れない。wiki ページの根拠欄に未検証として明記した。

Closes #243

https://claude.ai/code/session_01MBw12BAAeBzk8WqGedAqU7