### PR TITLE
polish の rejudge に effort guard を足し、effort テストのコメントを揃える

### DIFF
--- a/.ja/workflows/audit/tests/audit.effort.test.js
+++ b/.ja/workflows/audit/tests/audit.effort.test.js
@@ -1,7 +1,5 @@
-// U-003: audit workflow の integrate agent (enhancer-integration) は effort: high、
-// challenge (critic-audit) / verify (critic-evidence) agent は effort: xhigh のまま。
-// runWorkflow behavioral capture で Review -> Challenge -> Verify -> Integrate の各段の
-// opts.effort を検査し、per-stage 配分をテストで固定する。
+// effort の配分は実行結果に現れないので、値を変えてもここ以外のテストは落ちない。
+// per-stage の値を固定して drift を可視にする。
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
@@ -12,11 +10,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 const auditJs = join(here, "..", "..", "audit.js");
 
 // Review -> Challenge/Verify -> Integrate まで到達させる最小 stub。
-// - route: 1 file (sample.js) を返し、focus: "security" で reviewer を security/silence の
-//   2 件に絞る (routing 表で両方とも *.js に載っている)。
-// - security / silence review: 各 1 件 finding を返し、findings.length を非 0 にして
-//   Challenge/Verify/Integrate まで進める (findings 空だと早期 return して到達しない)。
-// - skipPreflight: true で pre-flight agent 呼び出し自体を回避し、stub を最小に保つ。
+// findings が空だと早期 return して Challenge 以降へ進まない。focus: "security" を選ぶのは
+// routing 表で security と silence がどちらも *.js に載り、reviewer が 2 件に収まるため。
+// skipPreflight: true は pre-flight agent の stub を不要にする。
 const agentStub = (prompt, opts) => {
   const label = opts && opts.label;
   if (label === "route") {
@@ -51,7 +47,7 @@ test("integrate agent の effort が high である", async () => {
   assert.equal(integrateCalls[0].opts.effort, "high", "integrate agent の effort が high である");
 });
 
-test("challenge / verify agent の effort が xhigh のままである", async () => {
+test("challenge / verify agent の effort が xhigh である", async () => {
   const { calls } = await runToIntegrate();
   const challengeCalls = calls.agent.filter((c) => c.opts && c.opts.label === "challenge");
   const verifyCalls = calls.agent.filter((c) => c.opts && c.opts.label === "verify");

--- a/.ja/workflows/polish/tests/polish.effort.test.js
+++ b/.ja/workflows/polish/tests/polish.effort.test.js
@@ -1,7 +1,5 @@
-// U-004: polish workflow の fix agent (general-purpose) は effort: high、
-// challenge (critic-audit) agent は難易度軸で effort: xhigh。
-// runWorkflow behavioral capture で Review -> Challenge -> Fix まで到達させ、
-// 各段の opts.effort を検査して per-stage 配分をテストで固定する。
+// effort の配分は実行結果に現れないので、値を変えてもここ以外のテストは落ちない。
+// per-stage の値を固定して drift を可視にする。
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
@@ -11,12 +9,9 @@ import { runWorkflow } from "../../_lib/run-workflow.js";
 const here = dirname(fileURLToPath(import.meta.url));
 const polishJs = join(here, "..", "..", "polish.js");
 
-// Review -> Challenge -> Fix -> Cleanup まで到達させる最小 stub (mode: full)。
-// - codex review: 1 件 finding (P1) を返し has_changes: true にして Challenge へ進める。
-// - challenge: 同じ id を confirmed で返し、triage で survivors に載せて Fix へ進める。
-// - fix: 最小の FIX_SCHEMA 形状を返す。
-// - validate (Cleanup): 最小の CLEANUP_SCHEMA 形状を返す。
-// - simplify / enhancer は戻り値を消費しないので undefined のままでよい。
+// Review -> Challenge -> Fix -> Rejudge -> Cleanup まで到達させる最小 stub (mode: full)。
+// severity を P1、challenge の verdict を confirmed にしないと triage が survivors を
+// 空にして Fix 以降へ進まない。simplify / enhancer は戻り値を消費しないので undefined でよい。
 const agentStub = (prompt, opts) => {
   const label = opts && opts.label;
   if (label === "codex") {
@@ -51,9 +46,12 @@ test("fix agent の effort が high である", async () => {
   assert.equal(fixCalls[0].opts.effort, "high", "fix agent の effort が high である");
 });
 
-test("challenge agent の effort が xhigh である", async () => {
+test("challenge / rejudge agent の effort が xhigh である", async () => {
   const { calls } = await runToFix();
   const challengeCalls = calls.agent.filter((c) => c.opts && c.opts.label === "challenge");
+  const rejudgeCalls = calls.agent.filter((c) => c.opts && c.opts.label === "rejudge");
   assert.equal(challengeCalls.length, 1, "challenge agent (critic-audit) が 1 回呼ばれる");
+  assert.equal(rejudgeCalls.length, 1, "rejudge agent (critic-audit) が 1 回呼ばれる");
   assert.equal(challengeCalls[0].opts.effort, "xhigh", "challenge agent の effort が xhigh");
+  assert.equal(rejudgeCalls[0].opts.effort, "xhigh", "rejudge agent の effort が xhigh");
 });

--- a/workflows/audit/tests/audit.effort.test.js
+++ b/workflows/audit/tests/audit.effort.test.js
@@ -1,7 +1,5 @@
-// U-003: audit workflow の integrate agent (enhancer-integration) は effort: high、
-// challenge (critic-audit) / verify (critic-evidence) agent は effort: xhigh のまま。
-// runWorkflow behavioral capture で Review -> Challenge -> Verify -> Integrate の各段の
-// opts.effort を検査し、per-stage 配分をテストで固定する。
+// effort の配分は実行結果に現れないので、値を変えてもここ以外のテストは落ちない。
+// per-stage の値を固定して drift を可視にする。
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
@@ -12,11 +10,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 const auditJs = join(here, "..", "..", "audit.js");
 
 // Review -> Challenge/Verify -> Integrate まで到達させる最小 stub。
-// - route: 1 file (sample.js) を返し、focus: "security" で reviewer を security/silence の
-//   2 件に絞る (routing 表で両方とも *.js に載っている)。
-// - security / silence review: 各 1 件 finding を返し、findings.length を非 0 にして
-//   Challenge/Verify/Integrate まで進める (findings 空だと早期 return して到達しない)。
-// - skipPreflight: true で pre-flight agent 呼び出し自体を回避し、stub を最小に保つ。
+// findings が空だと早期 return して Challenge 以降へ進まない。focus: "security" を選ぶのは
+// routing 表で security と silence がどちらも *.js に載り、reviewer が 2 件に収まるため。
+// skipPreflight: true は pre-flight agent の stub を不要にする。
 const agentStub = (prompt, opts) => {
   const label = opts && opts.label;
   if (label === "route") {
@@ -51,7 +47,7 @@ test("integrate agent の effort が high である", async () => {
   assert.equal(integrateCalls[0].opts.effort, "high", "integrate agent の effort が high である");
 });
 
-test("challenge / verify agent の effort が xhigh のままである", async () => {
+test("challenge / verify agent の effort が xhigh である", async () => {
   const { calls } = await runToIntegrate();
   const challengeCalls = calls.agent.filter((c) => c.opts && c.opts.label === "challenge");
   const verifyCalls = calls.agent.filter((c) => c.opts && c.opts.label === "verify");

--- a/workflows/polish/tests/polish.effort.test.js
+++ b/workflows/polish/tests/polish.effort.test.js
@@ -1,7 +1,5 @@
-// U-004: polish workflow の fix agent (general-purpose) は effort: high、
-// challenge (critic-audit) agent は難易度軸で effort: xhigh。
-// runWorkflow behavioral capture で Review -> Challenge -> Fix まで到達させ、
-// 各段の opts.effort を検査して per-stage 配分をテストで固定する。
+// effort の配分は実行結果に現れないので、値を変えてもここ以外のテストは落ちない。
+// per-stage の値を固定して drift を可視にする。
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
@@ -11,12 +9,9 @@ import { runWorkflow } from "../../_lib/run-workflow.js";
 const here = dirname(fileURLToPath(import.meta.url));
 const polishJs = join(here, "..", "..", "polish.js");
 
-// Review -> Challenge -> Fix -> Cleanup まで到達させる最小 stub (mode: full)。
-// - codex review: 1 件 finding (P1) を返し has_changes: true にして Challenge へ進める。
-// - challenge: 同じ id を confirmed で返し、triage で survivors に載せて Fix へ進める。
-// - fix: 最小の FIX_SCHEMA 形状を返す。
-// - validate (Cleanup): 最小の CLEANUP_SCHEMA 形状を返す。
-// - simplify / enhancer は戻り値を消費しないので undefined のままでよい。
+// Review -> Challenge -> Fix -> Rejudge -> Cleanup まで到達させる最小 stub (mode: full)。
+// severity を P1、challenge の verdict を confirmed にしないと triage が survivors を
+// 空にして Fix 以降へ進まない。simplify / enhancer は戻り値を消費しないので undefined でよい。
 const agentStub = (prompt, opts) => {
   const label = opts && opts.label;
   if (label === "codex") {
@@ -51,9 +46,12 @@ test("fix agent の effort が high である", async () => {
   assert.equal(fixCalls[0].opts.effort, "high", "fix agent の effort が high である");
 });
 
-test("challenge agent の effort が xhigh である", async () => {
+test("challenge / rejudge agent の effort が xhigh である", async () => {
   const { calls } = await runToFix();
   const challengeCalls = calls.agent.filter((c) => c.opts && c.opts.label === "challenge");
+  const rejudgeCalls = calls.agent.filter((c) => c.opts && c.opts.label === "rejudge");
   assert.equal(challengeCalls.length, 1, "challenge agent (critic-audit) が 1 回呼ばれる");
+  assert.equal(rejudgeCalls.length, 1, "rejudge agent (critic-audit) が 1 回呼ばれる");
   assert.equal(challengeCalls[0].opts.effort, "xhigh", "challenge agent の effort が xhigh");
+  assert.equal(rejudgeCalls[0].opts.effort, "xhigh", "rejudge agent の effort が xhigh");
 });


### PR DESCRIPTION
## What & Why

polish の critic 層は challenge と rejudge の 2 段だが、effort を固定する guard は challenge にしかなかった。rejudge の値は変えても何も落ちないので、無言で drift する。同じ critic-audit が同じ理由で xhigh を取る段なので、片方だけ守る状態を閉じる。

## Review focus

- guard が実際に効くか。rejudge を一時的に high にしてテストが落ちることを確認済み
- コメントから削った内容が、本当に code から読めるものだけか

## Changes

- polish の effort テストに rejudge の検査を足した。stub の追加は要らず、既存の `runToFix` が challenge → survivors 1 件 → fix → rejudge まで到達している
- polish と audit の effort テストからコメントを削った。plan unit id の接頭、テスト名と assert が直接述べる値の列挙、runWorkflow の使い方、stub の返り値の形
- audit のテスト名を「xhigh のままである」から「xhigh である」にした

## Scope

- Not included: 他のテストファイル (`code.model.test.js` など) のコメント形式。今回触っていない

## Design Decisions

guard の実効は mutation で確かめた。rejudge は既に xhigh なので、assert を足しただけでは通ってしまい、guard が効くことの証拠にならない。`workflows/polish.js` の値を一時的に high にしてテストが落ちることを確認し、戻してから commit した。

テスト名を変えたのは、judge 段の xhigh が惰性で残った値ではなくなったため。難易度軸 (docs の "the hardest coding and agentic tasks") で選び直した値なので、過去との対比を含む「のまま」が事実と合わない。

audit の形式に合わせて 2 agent を 1 テストで検査する。`audit.effort.test.js` が challenge と verify を 1 テストで見ており、polish も challenge と rejudge を 1 つにまとめた。

## How to Test

1. `node --test workflows/polish/tests/*.test.js .ja/workflows/polish/tests/*.test.js workflows/audit/tests/audit.effort.test.js .ja/workflows/audit/tests/audit.effort.test.js` で 28 tests が pass する
2. `workflows/polish.js` の rejudge の effort を high にすると、`challenge / rejudge agent の effort が xhigh である` が落ちる
3. `diff .ja/workflows/polish/tests/polish.effort.test.js workflows/polish/tests/polish.effort.test.js` が空 (ja/en 一致)

## Related

- Refs #249
