### PR TITLE
calibration の孤児セクションを整理し参照関係を照合テストで固定する

### DIFF
--- a/.ja/agents/_lib/calibration-examples.md
+++ b/.ja/agents/_lib/calibration-examples.md
@@ -602,30 +602,6 @@ function validateInvoiceDate(date: Date, billingCycle: BillingCycle): boolean {
 | Filter | Context Test: 既存等価物のないドメイン特化ロジック |
 | Signal | billing cycle 検証はこの機能固有                   |
 
-## Installation
-
-Install globally: $ npm install -g myapp
-```
-
-| Field   | Value                                                    |
-| ------- | -------------------------------------------------------- |
-| Filter  | Harm Test pass: 古い手順がユーザー失敗を招く             |
-| Trigger | ユーザーが非推奨の global install に従う; npx 利用と衝突 |
-| Impact  | 初回セットアップ失敗; ユーザー離脱                       |
-
-### SKIP
-
-```markdown
-## Architecture
-
-The system uses a pipeline pattern where each stage transforms the input and passes it to the next stage.
-```
-
-| Field  | Value                                              |
-| ------ | -------------------------------------------------- |
-| Filter | Context Test: 正確な散文、好みの問題で欠陥ではない |
-| Signal | 内容は正確; diagram 追加は改善で fix ではない      |
-
 ## PQ (reviewer-prompt)
 
 ### REPORT

--- a/.ja/agents/_lib/tests/calibration-wiring.test.js
+++ b/.ja/agents/_lib/tests/calibration-wiring.test.js
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const sides = {
+  ja: {
+    cal: join(root, ".ja", "agents", "_lib", "calibration-examples.md"),
+    rev: join(root, ".ja", "agents", "reviewers"),
+  },
+  en: {
+    cal: join(root, "agents", "_lib", "calibration-examples.md"),
+    rev: join(root, "agents", "reviewers"),
+  },
+};
+
+// "## CHX (reviewer-resilience)" 形の見出しから、セクション記号と所有 reviewer を取る。
+const sectionsOf = (calPath) =>
+  new Map(
+    [...readFileSync(calPath, "utf8").matchAll(/^## ([A-Z0-9]+) \((reviewer-[a-z-]+)\)$/gm)].map(
+      (m) => [m[1], m[2]],
+    ),
+  );
+
+// reviewer 定義が参照するセクション記号。Calibration 節を持たない reviewer は null。
+const refsOf = (revDir) => {
+  const out = new Map();
+  for (const file of readdirSync(revDir).filter((f) => f.endsWith(".md"))) {
+    const doc = readFileSync(join(revDir, file), "utf8");
+    // en は "section SEC"、ja は "の SEC セクション" で記号の位置が逆になる。
+    const m =
+      doc.match(/calibration-examples\.md[^\n]*?section ([A-Z0-9]+)/) ||
+      doc.match(/calibration-examples\.md[^\n]*?の ([A-Z0-9]+) セクション/);
+    out.set(file.replace(/\.md$/, ""), m ? m[1] : null);
+  }
+  return out;
+};
+
+// 参照先が消えても reviewer は黙って較正なしで走る。実行時に気づけないので突き合わせる。
+test("reviewer が参照するセクションが実在する", () => {
+  for (const [lang, { cal, rev }] of Object.entries(sides)) {
+    const sections = sectionsOf(cal);
+    for (const [reviewer, ref] of refsOf(rev)) {
+      if (ref === null || sections.has(ref)) continue;
+      // 不在を許すのは、reviewer 側が較正なしの振る舞いを決めているときだけ。
+      const doc = readFileSync(join(rev, `${reviewer}.md`), "utf8");
+      assert.match(
+        doc,
+        /pending_calibration/,
+        `${lang}: ${reviewer} が参照する ${ref} が無く、フォールバックの指定も無い`,
+      );
+    }
+  }
+});
+
+// セクションを書いても reviewer 側に Calibration 節が無ければ読まれない。CHX が
+// この状態で放置されていた。
+test("すべてのセクションに読み手がいる", () => {
+  for (const [lang, { cal, rev }] of Object.entries(sides)) {
+    const used = new Set([...refsOf(rev).values()].filter(Boolean));
+    for (const [symbol, owner] of sectionsOf(cal)) {
+      assert.ok(used.has(symbol), `${lang}: ${symbol} (${owner}) を読む reviewer がいない`);
+    }
+  }
+});
+
+// 例の中の見出しが code fence の外に出ると、トップレベル見出しとして浮く。DOC
+// セクションはこの壊れ方をしていて、セクション自体が検出できなくなっていた。
+test("トップレベル見出しがセクション見出しだけである", () => {
+  for (const [lang, { cal }] of Object.entries(sides)) {
+    const doc = readFileSync(cal, "utf8").replace(/^```[a-z]*\n.*?^```/gms, "");
+    const strays = [...doc.matchAll(/^## (.+)$/gm)]
+      .map((m) => m[1])
+      .filter((h) => !/^[A-Z0-9]+ \(reviewer-[a-z-]+\)$/.test(h));
+    assert.deepEqual(strays, [], `${lang}: セクション見出し以外が浮いている`);
+  }
+});
+
+// コード例は翻訳対象外。ja と en で内容が割れると、同じ較正を与えたつもりで別の
+// コードを見せることになる。
+test("コード例が ja と en で一致する", () => {
+  const blocks = (p) => readFileSync(p, "utf8").match(/^```[a-z]*\n[\s\S]*?^```/gm) || [];
+  const ja = blocks(sides.ja.cal);
+  const en = blocks(sides.en.cal);
+  assert.equal(ja.length, en.length, "コードブロックの個数が一致する");
+  ja.forEach((block, i) => assert.equal(block, en[i], `${i + 1} 番目のコードブロックが一致する`));
+});

--- a/.ja/agents/reviewers/reviewer-resilience.md
+++ b/.ja/agents/reviewers/reviewer-resilience.md
@@ -49,9 +49,13 @@ background: true
 | medium   | 体験の劣化、回復可能                         |
 | low      | エッジケース、ユーザー影響は最小             |
 
+## キャリブレーション
+
+`~/.claude/agents/_lib/calibration-examples.md` の CHX セクションを参照。
+
 ## アウトプット
 
-~/.claude/agents/_lib/finding-schema.md に従う。コードが見つからないときは "No code to review" を報告する。共通ガード (glob 空、tool エラー) は ~/.claude/agents/_lib/finding-schema.md のデフォルトに従う。
+~/.claude/agents/\_lib/finding-schema.md に従う。コードが見つからないときは "No code to review" を報告する。共通ガード (glob 空、tool エラー) は ~/.claude/agents/\_lib/finding-schema.md のデフォルトに従う。
 
 | フィールド   | 値                                                         |
 | ------------ | ---------------------------------------------------------- |

--- a/agents/_lib/calibration-examples.md
+++ b/agents/_lib/calibration-examples.md
@@ -262,19 +262,23 @@ function OrderPage() {
   const [filter, setFilter] = useState("");
   const [sort, setSort] = useState("date");
 
-  useEffect(() => { fetch("/api/orders").then(r => r.json()).then(setOrders); }, []);
+  useEffect(() => {
+    fetch("/api/orders")
+      .then((r) => r.json())
+      .then(setOrders);
+  }, []);
 
-  const filtered = orders.filter(o => o.name.includes(filter));
-  const sorted = filtered.sort((a, b) => a[sort] > b[sort] ? 1 : -1);
+  const filtered = orders.filter((o) => o.name.includes(filter));
+  const sorted = filtered.sort((a, b) => (a[sort] > b[sort] ? 1 : -1));
 
   return (
     <div>
-      <input value={filter} onChange={e => setFilter(e.target.value)} />
-      <select value={sort} onChange={e => setSort(e.target.value)}>
+      <input value={filter} onChange={(e) => setFilter(e.target.value)} />
+      <select value={sort} onChange={(e) => setSort(e.target.value)}>
         <option value="date">Date</option>
         <option value="name">Name</option>
       </select>
-      {sorted.map(o => (
+      {sorted.map((o) => (
         <div key={o.id}>
           <h3>{o.name}</h3>
           <p>{o.total}</p>
@@ -296,8 +300,11 @@ function OrderPage() {
 
 ```tsx
 function UserAvatar({ name, src }: { name: string; src: string }) {
-  const initials = name.split(" ").map(n => n[0]).join("");
-  return <img src={src} alt={initials} onError={e => (e.target.textContent = initials)} />;
+  const initials = name
+    .split(" ")
+    .map((n) => n[0])
+    .join("");
+  return <img src={src} alt={initials} onError={(e) => (e.target.textContent = initials)} />;
 }
 ```
 
@@ -314,11 +321,11 @@ function UserAvatar({ name, src }: { name: string; src: string }) {
 const ButtonWrapper = (props: ButtonProps) => <Button {...props} />;
 ```
 
-| Field   | Value                                                                                |
-| ------- | ------------------------------------------------------------------------------------ |
+| Field   | Value                                                                                 |
+| ------- | ------------------------------------------------------------------------------------- |
 | Filter  | Deletion test: removing collapses to `<Button>` at every call site with no logic loss |
-| Trigger | Component forwards props 1:1 with no own state/effect/derivation                     |
-| Impact  | Adds an indirection without hiding any behavior                                      |
+| Trigger | Component forwards props 1:1 with no own state/effect/derivation                      |
+| Impact  | Adds an indirection without hiding any behavior                                       |
 
 ### REPORT (shallow, Rust)
 
@@ -334,7 +341,7 @@ impl AppLogger {
 
 | Field   | Value                                                                              |
 | ------- | ---------------------------------------------------------------------------------- |
-| Filter  | Deletion test: callers invoke tracing macros directly; no abstraction is lost     |
+| Filter  | Deletion test: callers invoke tracing macros directly; no abstraction is lost      |
 | Trigger | Methods forward 1:1 to `tracing::event!` with no aggregation, validation, or state |
 | Impact  | Renames a primitive without earning the wrapper                                    |
 
@@ -370,10 +377,10 @@ impl Redactor {
 }
 ```
 
-| Field  | Value                                                                                       |
-| ------ | ------------------------------------------------------------------------------------------- |
+| Field  | Value                                                                                        |
+| ------ | -------------------------------------------------------------------------------------------- |
 | Filter | Deletion test: removing forces callers to re-implement compile+validate+apply+reverse-lookup |
-| Signal | Owns invariants (placeholder uniqueness), borrowed-vs-owned optimization, error taxonomy    |
+| Signal | Owns invariants (placeholder uniqueness), borrowed-vs-owned optimization, error taxonomy     |
 
 ## TEST (reviewer-testability)
 
@@ -431,7 +438,7 @@ window.addEventListener("resize", () => {
 
 ```javascript
 const observer = new IntersectionObserver((entries) => {
-  entries.forEach(entry => {
+  entries.forEach((entry) => {
     if (entry.isIntersecting) {
       loadMoreItems();
       observer.unobserve(entry.target);
@@ -452,7 +459,7 @@ observer.observe(sentinelRef.current);
 
 ```tsx
 function DashboardPage() {
-  const { data } = useSWR("/api/dashboard", fetcher);  // can throw
+  const { data } = useSWR("/api/dashboard", fetcher); // can throw
   return (
     <main>
       <h1>Dashboard</h1>
@@ -493,7 +500,7 @@ async function saveOrder(order: Order) {
     await db.save(order);
   } catch {
     await sleep(500);
-    await db.save(order);  // retry hides the real problem
+    await db.save(order); // retry hides the real problem
   }
 }
 ```
@@ -512,7 +519,7 @@ async function fetchExternalRate(currency: string): Promise<number> {
   return retry(() => fetch(`https://api.rates.com/${currency}`), {
     retries: 3,
     delay: 1000,
-    retryOn: [503, 429],  // only transient errors
+    retryOn: [503, 429], // only transient errors
   });
 }
 ```
@@ -595,30 +602,6 @@ function validateInvoiceDate(date: Date, billingCycle: BillingCycle): boolean {
 | Filter | Context Test: domain-specific logic with no existing equivalent |
 | Signal | Billing cycle validation is unique to this feature              |
 
-## Installation
-
-Install globally: $ npm install -g myapp
-```
-
-| Field   | Value                                                            |
-| ------- | ---------------------------------------------------------------- |
-| Filter  | Harm Test pass - outdated instruction causes user failure        |
-| Trigger | User follows deprecated global install; conflicts with npx usage |
-| Impact  | Setup failure on first experience; user abandons                 |
-
-### SKIP
-
-```markdown
-## Architecture
-
-The system uses a pipeline pattern where each stage transforms the input and passes it to the next stage.
-```
-
-| Field  | Value                                                          |
-| ------ | -------------------------------------------------------------- |
-| Filter | Context Test: accurate prose, style preference not defect      |
-| Signal | Content is correct; adding a diagram is improvement, not a fix |
-
 ## PQ (reviewer-prompt)
 
 ### REPORT
@@ -658,8 +641,10 @@ function Dropdown({ items, onSelect }: Props) {
       <div onClick={() => setOpen(!open)}>Select...</div>
       {open && (
         <ul>
-          {items.map(item => (
-            <li key={item.id} onClick={() => onSelect(item)}>{item.label}</li>
+          {items.map((item) => (
+            <li key={item.id} onClick={() => onSelect(item)}>
+              {item.label}
+            </li>
           ))}
         </ul>
       )}
@@ -678,7 +663,11 @@ function Dropdown({ items, onSelect }: Props) {
 
 ```tsx
 function SubmitButton({ onClick, children }: Props) {
-  return <button type="submit" onClick={onClick}>{children}</button>;
+  return (
+    <button type="submit" onClick={onClick}>
+      {children}
+    </button>
+  );
 }
 ```
 

--- a/agents/_lib/tests/calibration-wiring.test.js
+++ b/agents/_lib/tests/calibration-wiring.test.js
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const sides = {
+  ja: {
+    cal: join(root, ".ja", "agents", "_lib", "calibration-examples.md"),
+    rev: join(root, ".ja", "agents", "reviewers"),
+  },
+  en: {
+    cal: join(root, "agents", "_lib", "calibration-examples.md"),
+    rev: join(root, "agents", "reviewers"),
+  },
+};
+
+// "## CHX (reviewer-resilience)" 形の見出しから、セクション記号と所有 reviewer を取る。
+const sectionsOf = (calPath) =>
+  new Map(
+    [...readFileSync(calPath, "utf8").matchAll(/^## ([A-Z0-9]+) \((reviewer-[a-z-]+)\)$/gm)].map(
+      (m) => [m[1], m[2]],
+    ),
+  );
+
+// reviewer 定義が参照するセクション記号。Calibration 節を持たない reviewer は null。
+const refsOf = (revDir) => {
+  const out = new Map();
+  for (const file of readdirSync(revDir).filter((f) => f.endsWith(".md"))) {
+    const doc = readFileSync(join(revDir, file), "utf8");
+    // en は "section SEC"、ja は "の SEC セクション" で記号の位置が逆になる。
+    const m =
+      doc.match(/calibration-examples\.md[^\n]*?section ([A-Z0-9]+)/) ||
+      doc.match(/calibration-examples\.md[^\n]*?の ([A-Z0-9]+) セクション/);
+    out.set(file.replace(/\.md$/, ""), m ? m[1] : null);
+  }
+  return out;
+};
+
+// 参照先が消えても reviewer は黙って較正なしで走る。実行時に気づけないので突き合わせる。
+test("reviewer が参照するセクションが実在する", () => {
+  for (const [lang, { cal, rev }] of Object.entries(sides)) {
+    const sections = sectionsOf(cal);
+    for (const [reviewer, ref] of refsOf(rev)) {
+      if (ref === null || sections.has(ref)) continue;
+      // 不在を許すのは、reviewer 側が較正なしの振る舞いを決めているときだけ。
+      const doc = readFileSync(join(rev, `${reviewer}.md`), "utf8");
+      assert.match(
+        doc,
+        /pending_calibration/,
+        `${lang}: ${reviewer} が参照する ${ref} が無く、フォールバックの指定も無い`,
+      );
+    }
+  }
+});
+
+// セクションを書いても reviewer 側に Calibration 節が無ければ読まれない。CHX が
+// この状態で放置されていた。
+test("すべてのセクションに読み手がいる", () => {
+  for (const [lang, { cal, rev }] of Object.entries(sides)) {
+    const used = new Set([...refsOf(rev).values()].filter(Boolean));
+    for (const [symbol, owner] of sectionsOf(cal)) {
+      assert.ok(used.has(symbol), `${lang}: ${symbol} (${owner}) を読む reviewer がいない`);
+    }
+  }
+});
+
+// 例の中の見出しが code fence の外に出ると、トップレベル見出しとして浮く。DOC
+// セクションはこの壊れ方をしていて、セクション自体が検出できなくなっていた。
+test("トップレベル見出しがセクション見出しだけである", () => {
+  for (const [lang, { cal }] of Object.entries(sides)) {
+    const doc = readFileSync(cal, "utf8").replace(/^```[a-z]*\n.*?^```/gms, "");
+    const strays = [...doc.matchAll(/^## (.+)$/gm)]
+      .map((m) => m[1])
+      .filter((h) => !/^[A-Z0-9]+ \(reviewer-[a-z-]+\)$/.test(h));
+    assert.deepEqual(strays, [], `${lang}: セクション見出し以外が浮いている`);
+  }
+});
+
+// コード例は翻訳対象外。ja と en で内容が割れると、同じ較正を与えたつもりで別の
+// コードを見せることになる。
+test("コード例が ja と en で一致する", () => {
+  const blocks = (p) => readFileSync(p, "utf8").match(/^```[a-z]*\n[\s\S]*?^```/gm) || [];
+  const ja = blocks(sides.ja.cal);
+  const en = blocks(sides.en.cal);
+  assert.equal(ja.length, en.length, "コードブロックの個数が一致する");
+  ja.forEach((block, i) => assert.equal(block, en[i], `${i + 1} 番目のコードブロックが一致する`));
+});

--- a/agents/reviewers/reviewer-resilience.md
+++ b/agents/reviewers/reviewer-resilience.md
@@ -36,9 +36,9 @@ Failure-driven, not pattern-driven. Start from "what could break?" then trace to
 | ---------- | -------------------------------------------- | -------------------------------------------------- |
 | silence    | Per-block catch/promise/fallback pattern     | Aggregates into failure scenario with blast radius |
 | operations | Per-component boundary/log/loading presence  | Cascade impact when boundaries themselves fail     |
-| causation  | Backward 5 Whys from observed symptom         | Forward projection from hypothetical trigger       |
-| efficiency | TOCTOU as correctness or perf bug             | TOCTOU as failure mode with user impact            |
-| security   | Threat actor and attack vector (incl. AuthZ)  | Incident scenario without actor (DB timeout, OOM)  |
+| causation  | Backward 5 Whys from observed symptom        | Forward projection from hypothetical trigger       |
+| efficiency | TOCTOU as correctness or perf bug            | TOCTOU as failure mode with user impact            |
+| security   | Threat actor and attack vector (incl. AuthZ) | Incident scenario without actor (DB timeout, OOM)  |
 
 ## Blast Radius Scoring
 
@@ -49,9 +49,13 @@ Failure-driven, not pattern-driven. Start from "what could break?" then trace to
 | medium   | Degraded experience, recoverable              |
 | low      | Edge case, minimal user impact                |
 
+## Calibration
+
+See `~/.claude/agents/_lib/calibration-examples.md` section CHX.
+
 ## Output
 
-Follow ~/.claude/agents/_lib/finding-schema.md. When no code is found, report "No code to review". Common guards (glob empty, tool error) follow ~/.claude/agents/_lib/finding-schema.md defaults.
+Follow ~/.claude/agents/\_lib/finding-schema.md. When no code is found, report "No code to review". Common guards (glob empty, tool error) follow ~/.claude/agents/\_lib/finding-schema.md defaults.
 
 | Field        | Value                                                     |
 | ------------ | --------------------------------------------------------- |


### PR DESCRIPTION
## What & Why

較正例の参照関係に 3 件のずれが残っていた。DOC セクションは読む reviewer が存在せず、しかも code fence が壊れて例の中身がトップレベル見出しとして浮いていた。CHX セクションは reviewer 側に Calibration 節が無く読まれていなかった。どちらもファイルを読んでも気づけない形なので、直したうえで照合テストで固定する。

#212 の本来の問い (較正例が interface で代替できるか) の答えは「代替できない」で、そちらでは 1 行も削っていない。

## Review focus

- 照合テスト 4 本が実際に効くか。mutation 2 件で確認済み (CHX の配線を外す、見出しを 1 つ足す)
- DOC を消してよいと判断した根拠。`reviewer-document.md` が存在せず、delete test で挙動が変わらない
- `reviewer-rust` の RU 参照を残した判断。同じ行に `pending_calibration` のフォールバックがある

## Changes

- DOC セクション (23 行) を削除した。reviewer が存在せず、見出しと ` ```markdown ` の fence も欠落していた
- CHX セクションに読み手を配線した。`reviewer-resilience` に他 reviewer と同じ形の Calibration 節を追加
- 照合テストを追加した。参照先の実在、読み手のいないセクションの不在、トップレベル見出しの異物の不在、コード例の ja/en 一致
- formatter が en 側のコード例を prettier 整形した。`.ja` は元から整形済みで、36 コードブロックすべてが一致するようになった

## Scope

- Not included: 較正例の内容そのものの削減。interface (`finding-schema.md`) の抽象フィルタでは代替できないと判定した
- Not included: RU セクションの新規作成。較正内容を書き起こす作業で、判定の軸が別
- Not included: reviewer ごとのファイル分割 (#246)

## Design Decisions

削除がゲートを緩めないことを delete test で確認した。#212 の Constraints は「ゲートを緩める削除は false positive の実例まで残す」としているが、DOC も CHX も読み手がおらずゲートとして機能していなかった。挙動は変わらない。

テストは値を一元化するのでなく、両側から抽出して突き合わせる形にした。reviewer 定義とセクション見出しは独立に読まれるので、値そのものを共有できない。今回のずれがまさにその非対称から生まれている。

root の階層数だけ ja と en で違う (`code.sourcing.test.js` と同じ形)。テスト本体は両側で同一内容。

## How to Test

1. `node --test agents/_lib/tests/calibration-wiring.test.js .ja/agents/_lib/tests/calibration-wiring.test.js` で 8 tests が pass する
2. `agents/reviewers/reviewer-resilience.md` の `## Calibration` 節を消すと「すべてのセクションに読み手がいる」が落ちる
3. `agents/_lib/calibration-examples.md` に `## Foo` を足すと「トップレベル見出しがセクション見出しだけである」が落ちる
4. 全体は `ADR0085_MANUAL_ACCEPTANCE=pass node --test $(find workflows .ja/workflows agents .ja/agents skills .ja/skills -name "*.test.js" -not -path "*/node_modules/*")` で 264 pass

## Related

- Closes #212
