### PR TITLE
fix(build): scope 逸脱した追跡済み変更を Ship の never-stage に渡す

### DIFF
--- a/.ja/skills/research/tests/report-template.test.js
+++ b/.ja/skills/research/tests/report-template.test.js
@@ -80,7 +80,7 @@ test("SKILL.md が名前で指す verification.md の見出しが実在する", 
   }
 });
 
-// Phase 2 が代わりにスクリプトを呼ぶ (ADR: .ja/skills/outcome/SKILL.md の呼び出し形に倣う)。
+// Phase 2 が代わりにスクリプトを呼ぶ (.ja/skills/outcome/SKILL.md の呼び出し形に倣う)。
 // 名指しされたスクリプトが実在せず実行もできなければ、Phase 2 の指示は絵に描いた餅になる。
 function extractPhase(skillText, n) {
   const re = new RegExp(`^## Phase ${n}[\\s\\S]*?(?=^## Phase ${n + 1})`, "m");

--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -941,6 +941,11 @@ const SHIP_SCHEMA = obj(["committed", "pr_url"], {
   },
   pr_url: { type: "string" },
   notes: { type: "string" },
+  unstaged: {
+    type: "array",
+    items: { type: "string" },
+    description: "stage しなかったパス。build 以前からの未追跡ファイルと、スコープ外の追跡済み変更",
+  },
 });
 
 // unit が既に履歴にあるとき、残余ゼロは正常な結末。空コミットを強いると Ship が
@@ -949,12 +954,17 @@ const commitInstruction = perUnitCommits
   ? `この build は既に実装 unit ごとに commit 済み (${unitCommits.length} 件)。未 commit のまま残っているもの — cleanup の編集と unit commit が残したもの — を 1 つの Conventional Commits commit にまとめる。commit メッセージは自分で書く。下の stage 規則を適用して stage されるものが残らなければ commit 自体を skip して push へ進む。これは異常でなく正常な結末。`
   : `この build の変更を 1 つの Conventional Commits commit にまとめる。commit メッセージは自分で書く (diff を要約する)。`;
 
+// Verify が plan スコープ外と判定した追跡済み変更。並行セッションの編集や build 以前の
+// 作業が混ざるので、Ship はこれを commit に巻き込まない。diff 一覧を取れなかったときの
+// センチネル文字列はパスでないため never-stage 集合から外す。
+const outOfScopeTracked = diff && Array.isArray(diff.files) ? scopeDeviations : [];
+
 const ship = await agent(
   anchor(
     commitInstruction +
-      `stage する範囲は自分で絞る。\`git add -A\` と \`git add .\` は使わない。追跡済みファイルの変更はそのまま stage してよいが、` +
+      `stage する範囲は自分で絞る。\`git add -A\` と \`git add .\` は使わない。追跡済みファイルの変更はそのまま stage してよいが、次の never-stage 集合は追跡済みでも stage しない。${JSON.stringify(outOfScopeTracked)}。Verify が plan スコープ外と判定した変更で、この build の成果ではない。` +
       `未追跡ファイル (\`git status --porcelain --untracked-files=all\` の "??" 行。ディレクトリ単位に畳まずファイル単位で判定する) は、plan の files ${JSON.stringify([...planFiles])} に含まれるか、この run で自分が作成したものだけを stage する。` +
-      `それ以外の未追跡ファイルは build 以前から作業ツリーにあったものなので stage しない (仕様書・調査メモ・ローカル設定が PR に混入する)。stage しなかった未追跡パスは結果に列挙する。\n` +
+      `それ以外の未追跡ファイルは build 以前から作業ツリーにあったものなので stage しない (仕様書・調査メモ・ローカル設定が PR に混入する)。stage しなかったパスは、未追跡か追跡済みかを問わず結果に列挙する。\n` +
       `ブランチを push し、draft pull request を開く。本文は PR テンプレートから自分で書く人間向けパートと、データから決定論レンダリングされる fact セクションで構成する (fact セクションを手書きしない)。手順は以下。\n` +
       `(1) \`$HOME/.claude/settings.json\` から \`language\` を読み (未設定なら英語)、その言語で人間向け本文を書く。コード / 識別子 / 専門用語は翻訳しない。PR テンプレートはリポジトリのものがあれば使う (大文字小文字の区別なし、優先順 \`.github/pull_request_template.md\` > \`pull_request_template.md\` > \`docs/pull_request_template.md\` > \`PULL_REQUEST_TEMPLATE/\` ディレクトリ)。無ければ同梱の \`${bundled("skills/pr/templates/pr.md")}\` を使う。骨格を読んで body ファイルへ折り込む。人間向けセクションだけを、レビュアーが速く掴める順で埋める。先頭に解決する問題と到達する成果 (${JSON.stringify(plan.outcome)})、次に変更内容とアプローチ、最後にレビューの注目点。レビューの注目点は、骨格の該当節か、無ければ \`## Review focus\` 節として書く。Changes に書くのは diff が理由を運ばない変更だけで、ファイルの目録は書かない。埋め草と事実の捏造をしない。Related / Closes は書かない (tail が \`Closes #\` を出す)。Scope / Backlog も書かない。スコープ外候補は PR に載せない。Design Decisions は plan の decisions (${JSON.stringify(plan.decisions || [])}) と実 diff から埋め、空なら節ごと省略する。\n` +
       `(2) この JSON をそのまま一時ファイルに書く。\n${JSON.stringify(shipPayload)}\n` +

--- a/.ja/workflows/build/tests/build.behavior.test.js
+++ b/.ja/workflows/build/tests/build.behavior.test.js
@@ -698,7 +698,32 @@ test("Verify のスコープ検査が plan 外の diff file を surface し、.c
     shipCalls[0].prompt.includes('"scope_deviations":["extra.js"]'),
     "scope_deviations が ship prompt (PR body payload) に載る",
   );
+  // 検出しても staging 判断に繋いでいなければ、Ship が追跡済みの逸脱を commit へ巻き込む。
+  const neverStage = shipCalls[0].prompt.slice(shipCalls[0].prompt.indexOf("never-stage"));
+  assert.ok(
+    neverStage.startsWith("never-stage") && neverStage.includes('["extra.js"]'),
+    "scope_deviations が ship prompt の never-stage 集合に載る",
+  );
   assert.ok(calls.phase.includes("Ship"), "スコープ逸脱があっても fail-open で Ship まで進む");
+});
+
+test("diff 一覧が取れないとき never-stage 集合は空になり、診断文字列がパスとして渡らない", async () => {
+  const { calls, result } = await runWorkflow(buildJs, {
+    args,
+    stubs: makeStubs({ diff: { files: null } }),
+  });
+  // 診断文字列の文面は言語ごとに違うので、件数だけを見る。
+  assert.equal(
+    result.scope_deviations.length,
+    1,
+    "diff 一覧が無いとき scope_deviations は診断行を 1 件持つ",
+  );
+  const shipCalls = agentCallsOf(calls, "ship");
+  const neverStage = shipCalls[0].prompt.slice(shipCalls[0].prompt.indexOf("never-stage"));
+  assert.ok(
+    neverStage.startsWith("never-stage") && neverStage.includes("[]"),
+    "診断文字列は never-stage 集合に入らない",
+  );
 });
 
 test("Verify の T-NNN 照合が見つからない言明を surface し、verifier への relay prompt に checks JSON が載る", async () => {

--- a/skills/research/tests/report-template.test.js
+++ b/skills/research/tests/report-template.test.js
@@ -80,7 +80,7 @@ test("SKILL.md が名前で指す verification.md の見出しが実在する", 
   }
 });
 
-// Phase 2 が代わりにスクリプトを呼ぶ (ADR: .ja/skills/outcome/SKILL.md の呼び出し形に倣う)。
+// Phase 2 が代わりにスクリプトを呼ぶ (.ja/skills/outcome/SKILL.md の呼び出し形に倣う)。
 // 名指しされたスクリプトが実在せず実行もできなければ、Phase 2 の指示は絵に描いた餅になる。
 function extractPhase(skillText, n) {
   const re = new RegExp(`^## Phase ${n}[\\s\\S]*?(?=^## Phase ${n + 1})`, "m");

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -975,6 +975,12 @@ const SHIP_SCHEMA = obj(["committed", "pr_url"], {
   },
   pr_url: { type: "string" },
   notes: { type: "string" },
+  unstaged: {
+    type: "array",
+    items: { type: "string" },
+    description:
+      "Paths left unstaged: untracked paths that predate the build, and out-of-scope tracked modifications",
+  },
 });
 
 // With the units already in history, an empty remainder is a normal outcome. Forcing a
@@ -983,11 +989,17 @@ const commitInstruction = perUnitCommits
   ? `This build already committed each implementation unit (${unitCommits.length} commit(s)). Commit whatever is still uncommitted - the cleanup edits and anything the unit commits left behind - as one Conventional Commits commit; you write the commit message. If applying the staging rules below leaves nothing staged, skip the commit entirely and go straight to the push; that is a normal outcome, not an error. `
   : `Turn this build's changes into a single Conventional Commits commit; you write the commit message (summarize the diff). `;
 
+// Tracked modifications Verify judged outside the plan's scope. They carry a concurrent
+// session's edits or work that predates this build, so Ship must not sweep them into the
+// commit. The sentinel string from an unavailable diff listing is not a path, so it stays
+// out of the never-stage set.
+const outOfScopeTracked = diff && Array.isArray(diff.files) ? scopeDeviations : [];
+
 const ship = await agent(
   anchor(
     commitInstruction +
-      `Scope what you stage yourself; never use \`git add -A\` or \`git add .\`. Modifications to tracked files may be staged as they are, but stage an untracked path (a "??" line in \`git status --porcelain --untracked-files=all\`, judged per file, never per directory) only when it appears in the plan's files ${JSON.stringify([...planFiles])} or you created it during this run. ` +
-      `Every other untracked path predates this build and must stay unstaged, otherwise specification documents, research notes, and local config leak into the PR. List any untracked path you left unstaged in your result.\n` +
+      `Scope what you stage yourself; never use \`git add -A\` or \`git add .\`. Modifications to tracked files may be staged as they are, except for the never-stage set below, which stays unstaged even though those paths are tracked: ${JSON.stringify(outOfScopeTracked)}. Verify judged them outside the plan's scope, so they are not this build's work. Stage an untracked path (a "??" line in \`git status --porcelain --untracked-files=all\`, judged per file, never per directory) only when it appears in the plan's files ${JSON.stringify([...planFiles])} or you created it during this run. ` +
+      `Every other untracked path predates this build and must stay unstaged, otherwise specification documents, research notes, and local config leak into the PR. List every path you left unstaged in your result, tracked and untracked alike.\n` +
       `Push the branch, then open a draft pull request. Its body is a human-facing part you write from a PR template, followed by deterministic fact sections rendered from data (do not hand-write the fact sections). The steps are as follows.\n` +
       `(1) Read \`language\` from \`$HOME/.claude/settings.json\` (default English if unset) and write the human-facing body in that language, keeping code, identifiers, and technical terms untranslated. Choose the PR template: the repository's if present (case-insensitive, priority \`.github/pull_request_template.md\` > \`pull_request_template.md\` > \`docs/pull_request_template.md\` > a \`PULL_REQUEST_TEMPLATE/\` directory), otherwise the bundled \`${bundled("skills/pr/templates/pr.md")}\`; read the skeleton and fold it into the body file. Fill only the human-facing sections, ordered so a reviewer grasps it fast: lead with the problem this solves and the outcome it reaches (${JSON.stringify(plan.outcome)}), then what changed and the approach, then where to focus review. Put the review-focus content under the skeleton's nearest section, or as a \`## Review focus\` section when it has none. A change belongs in Changes only when the diff does not carry its rationale, never as an inventory of files. No filler, no invented facts. Skip Related / Closes; the tail emits \`Closes #\`. Skip Scope / Backlog too; out-of-scope candidates do not go in the PR. Fill Design Decisions from the plan decisions (${JSON.stringify(plan.decisions || [])}) and the actual diff; omit the section if empty rather than inventing.\n` +
       `(2) write this exact JSON to a temp file.\n${JSON.stringify(shipPayload)}\n` +

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -698,7 +698,32 @@ test("Verify のスコープ検査が plan 外の diff file を surface し、.c
     shipCalls[0].prompt.includes('"scope_deviations":["extra.js"]'),
     "scope_deviations が ship prompt (PR body payload) に載る",
   );
+  // 検出しても staging 判断に繋いでいなければ、Ship が追跡済みの逸脱を commit へ巻き込む。
+  const neverStage = shipCalls[0].prompt.slice(shipCalls[0].prompt.indexOf("never-stage"));
+  assert.ok(
+    neverStage.startsWith("never-stage") && neverStage.includes('["extra.js"]'),
+    "scope_deviations が ship prompt の never-stage 集合に載る",
+  );
   assert.ok(calls.phase.includes("Ship"), "スコープ逸脱があっても fail-open で Ship まで進む");
+});
+
+test("diff 一覧が取れないとき never-stage 集合は空になり、診断文字列がパスとして渡らない", async () => {
+  const { calls, result } = await runWorkflow(buildJs, {
+    args,
+    stubs: makeStubs({ diff: { files: null } }),
+  });
+  // 診断文字列の文面は言語ごとに違うので、件数だけを見る。
+  assert.equal(
+    result.scope_deviations.length,
+    1,
+    "diff 一覧が無いとき scope_deviations は診断行を 1 件持つ",
+  );
+  const shipCalls = agentCallsOf(calls, "ship");
+  const neverStage = shipCalls[0].prompt.slice(shipCalls[0].prompt.indexOf("never-stage"));
+  assert.ok(
+    neverStage.startsWith("never-stage") && neverStage.includes("[]"),
+    "診断文字列は never-stage 集合に入らない",
+  );
 });
 
 test("Verify の T-NNN 照合が見つからない言明を surface し、verifier への relay prompt に checks JSON が載る", async () => {


### PR DESCRIPTION
## What & Why

Verify は plan スコープ外の変更を `scopeDeviations` として検出し、log と戻り値に載せていたが、Ship の指示には渡していなかった。Ship の staging 規則は「追跡済みファイルの変更はそのまま stage してよい」なので、検出した逸脱がそのまま commit へ入る。検出と staging 判断が繋がっていなかった。

実害が出ている。#259 の実行では、並行セッションが編集した `rules/conventions/` の 4 ファイルを Verify が逸脱として検出したうえで、Ship が 96aab143 に巻き込んだ。人手で revert して #261 に切り出すことになった。保存済み 28 run のうち 18 が非空の `scope_deviations` を持つ。

## Changes

- `scopeDeviations` を Ship の never-stage 集合として prompt に渡した。追跡済みでも stage しない
- `SHIP_SCHEMA` に `unstaged` を足し、stage しなかったパスを追跡済み・未追跡を問わず列挙させる
- diff 一覧を取れなかったときの診断文字列はパスでないため never-stage 集合から外した

## Design Decisions

DR-0088 は Cleanup の編集を Ship が拾う必要から、追跡済みファイルの staging を load-bearing としている。そのため allow-list を狭めるのではなく、untracked に対して既にある never-stage 集合と同じ形を追跡済みにも足した。Cleanup の編集は plan の files 内で行われるので `scopeDeviations` に入らず、従来どおり stage される。

never-stage の literal を日英どちらの prompt にも入れてある。`build.behavior.test.js` は自側の `build.js` を読むため、言語非依存に assert する必要があった。

## Review focus

- `outOfScopeTracked` の算出が `diff && Array.isArray(diff.files)` の分岐で診断文字列を除いている点。この分岐が無いと「diff listing unavailable」がパスとして never-stage に載る

## How to Test

```
node --test workflows/tests/ .ja/workflows/build/tests/build.behavior.test.js
```

追加した 2 件は、逸脱が never-stage 集合に載ること、diff 一覧が無いとき集合が空になることを検証する。実行済みの結果は英語側 33 件、`.ja` 側 33 件、workflows 全体 77 件がすべて green。

## 同梱した修正

`skills/research/tests/report-template.test.js:83` のコメントが `ADR:` を出典ラベルとして使っており、`skills/dr/tests/script-contract.test.js` の旧称チェックが main で失敗していた。#260 のマージ時点から赤い。ラベルを外して参照だけ残した (8a2b327d)。

これで skills 54 件、`.ja` skills 54 件、workflows 77 件がすべて green。

Closes #263

