### PR TITLE
fix(conventions): 記号表と実挙動の噛み合わせを直しパス統一に回帰テストを足す

### DIFF
--- a/.ja/rules/conventions/MARKDOWN.md
+++ b/.ja/rules/conventions/MARKDOWN.md
@@ -8,7 +8,6 @@ paths:
   - "docs/**/*.md"
   - "rules/**/*.md"
   - "skills/**/*.md"
-  - ".claude/workspace/**/*.md"
 ---
 
 # Markdown Conventions
@@ -28,15 +27,15 @@ paths:
 
 `.ja` の散文では textlint hook が `/` の前後を詰める。詰めた形で英字どうしの列挙が path と読めてしまうときは読点で並べ、`CI/CD` や `try/catch` のような定着した複合語は `/` のままにする。`/fix` のようなスラッシュコマンドは、素で書くとその hook が直前の空白を落として前の語と繋がるため、inline code で囲む。
 
-| 記号 | 用途                            | 例                                    |
-| ---- | ------------------------------- | ------------------------------------- |
-| `/`  | AND 並列列挙                    | `Safety First / Output Verifiability` |
-| `.`  | 独立したルールのセパレータ      | `Check scope. Do not skip`            |
-| `()` | 補足条件のみ                    | `Skip for follow-up (same session)`   |
-| `>`  | 優先順位 (左を優先、不可なら右) | `CLI tool > built-in equivalent`      |
-| `→`  | ステップ列挙                    | `Observe → analyze → conclude`        |
-| `§`  | セクション参照                  | `phase.md § Gate ルール`              |
-| `+`  | 構成要素の合成                  | `root causes + Gate decision`         |
+| 記号 | 用途                            | 例                                  |
+| ---- | ------------------------------- | ----------------------------------- |
+| `/`  | AND 並列列挙                    | `Safety First/Output Verifiability` |
+| `.`  | 独立したルールのセパレータ      | `Check scope. Do not skip`          |
+| `()` | 補足条件のみ                    | `Skip for follow-up (same session)` |
+| `>`  | 優先順位 (左を優先、不可なら右) | `CLI tool > built-in equivalent`    |
+| `→`  | ステップ列挙                    | `Observe → analyze → conclude`      |
+| `§`  | セクション参照                  | `phase.md § Gate ルール`            |
+| `+`  | 構成要素の合成                  | `root causes + Gate decision`       |
 
 ## インラインコード
 

--- a/.ja/skills/dr/tests/script-contract.test.js
+++ b/.ja/skills/dr/tests/script-contract.test.js
@@ -94,6 +94,36 @@ test("live な指示と規約に旧称 ADR が残っていない", () => {
   assert.doesNotMatch(readFileSync(join(root, "README.md"), "utf8"), /\bADRs?\b/, "README.md");
 });
 
+// DR-0090 の Confirmation を機械化する。作業成果物は .claude/workspace/ に統一したので、
+// 他プロジェクトのルート直下に無い workspace/ を live な指示が指すと参照が解決しない。
+// 走査形は上の旧称チェックと同じで、置き場所もそれに揃えた。
+test("live な指示と規約が .claude/ を伴わない workspace/ を指していない", () => {
+  const BARE_WORKSPACE = /(?<!\.claude\/)(?<![\w/.])workspace\//;
+  const scanned = [];
+  for (const prefix of ["", ".ja"]) {
+    for (const dir of ["skills", "agents", "rules", "workflows"]) {
+      const base = join(root, prefix, dir);
+      if (!existsSync(base)) continue;
+      for (const entry of readdirSync(base, { recursive: true, withFileTypes: true })) {
+        if (!entry.isFile() || !/\.(md|js|py)$/.test(entry.name)) continue;
+        const full = join(entry.parentPath ?? entry.path, entry.name);
+        const rel = full.slice(join(root, prefix).length + 1);
+        // このテスト自身が bare workspace/ を negative assert に使う。
+        if (rel.includes("__pycache__") || rel === "skills/dr/tests/script-contract.test.js") {
+          continue;
+        }
+        scanned.push(rel);
+        assert.doesNotMatch(
+          readFileSync(full, "utf8"),
+          BARE_WORKSPACE,
+          `${prefix || "en"}: ${rel} が .claude/ を伴わない workspace/ を指す`,
+        );
+      }
+    }
+  }
+  assert.ok(scanned.length > 100, `走査した件数 (${scanned.length})`);
+});
+
 // MADR は v4 で名称が Architectural に戻った外部仕様。この skill が対象を広げていることを
 // 書いておかないと、名称を読んだ書き手がアーキテクチャ決定だけに絞る。
 test("madr-format がアーキテクチャに限らない旨を述べる", () => {

--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -1,6 +1,6 @@
 # candidates
 
-ページ化前の候補置き場。「内容 1 行 + 根拠」。根拠は PR/issue 由来なら #番号、.claude/workspace/research/由来なら (research) と書き、research のファイルパスは書かない。2 件目の根拠が現れたらページへ昇格して行を消す。
+ページ化前の候補置き場。「内容 1 行 + 根拠」。根拠は PR、issue 由来なら #番号、`.claude/workspace/research/` 由来なら (research) と書き、research のファイルパスは書かない。2 件目の根拠が現れたらページへ昇格して行を消す。
 「昇格待ち」は根拠 2 件以上あるが 1 run 3 ページの cap を超えて持ち越した項目。次回 run で優先的にページ化する。
 
 ## 昇格待ち (根拠2件以上、cap 超過持ち越し)
@@ -11,12 +11,12 @@
 - 成果物が gitignore 配下 (output-styles/、.claude/workspace/) の作業は PR にせず手動 close する #33 #37 #38 #42
 - 根本原因が Claude Code runtime 側のバグは repo 側 wontfix + upstream 起票 + guard 文言で close する #132 #133 #177
 - 横展開の要否は ugrep 全ツリー確認で確定してから scope を固定する #49 #50 #53 #57
-- reviewer 系の新設・再構築は Recall/FP baseline を計測して close する #24 #28 #43
+- reviewer 系の新設・再構築は Recall、FP baseline を計測して close する #24 #28 #43
 - 外部発想の issue には source:<origin> ラベルを付ける #30 #31 #32 #33 #39 #40 #41
 - 軽量バックログ複数件は 1 PR に束ねて複数 Closes する #44 #45
-- script/agent 出力は JSON stdout/error stderr/banner なしの機械可読形式にする #13 #54
+- script/agent 出力は JSON stdout、error stderr、banner なしの機械可読形式にする #13 #54
 - audit report 命名は <YYYY-MM-DD>-<HHMMSS>-<slug>.md、slug は skill 名一致 #47 #51 #52 #53
-- 翻訳は情報系 prose のみ、file:line/severity/Closes 等の構造化フィールドは verbatim #175 #176
+- 翻訳は情報系 prose のみ、file:line、severity、Closes 等の構造化フィールドは verbatim #175 #176
 - policy 値 (effort/model) は per-file 定数でなく behavioral capture テストで固定する #191 #192 #199 #223 #224
 - hook payload の形状は smoke test で実測確定し fixture 化してから gate を作る #150 #154
 - 挙動が実 run で観測できるまで PR は draft に据え置く #143 #159 #162 #163 #226
@@ -26,12 +26,12 @@
 - 出力パスの変更前に、予測可能な名前で読む consumer の有無を再確認する #40 #52
 - サイズ/形式の判定は script の決定論チェックに置き、内容の判断だけを agent に渡す #210 #220 #222 #230
 - 閾値・tier・スコープは印象でなく実測値を根拠に決める #219 #220 #224 #225
-- 前提が harness/upstream の更新で消滅した issue は not planned で close し、消滅した前提を close コメントに残す #136 #184 #210
+- 前提が harness、upstream の更新で消滅した issue は not planned で close し、消滅した前提を close コメントに残す #136 #184 #210
 - 未検証の推測は inferred と明記する。実機検証で棄却されうる (research) #210
 
 ## 単発 (根拠1件)
 
-- anchorless な .gitignore ルール (plans/等) が同名 test fixture dir を任意深さで飲む #169
+- anchorless な .gitignore ルール (`plans/` 等) が同名 test fixture dir を任意深さで飲む #169
 - 公開リポの issue body は未信頼入力として BEGIN/END データフェンスで囲んで LLM に渡す #189
 - user rule の paths frontmatter は originalCwd 相対評価のため直下相対 glob が必要 #59
 - plugin source "./" は gitignore を無視して working tree 全体を copy し install cache が肥大する #182

--- a/rules/conventions/MARKDOWN.md
+++ b/rules/conventions/MARKDOWN.md
@@ -8,7 +8,6 @@ paths:
   - "docs/**/*.md"
   - "rules/**/*.md"
   - "skills/**/*.md"
-  - ".claude/workspace/**/*.md"
 ---
 
 # Markdown Conventions
@@ -28,15 +27,15 @@ Which conventions apply depends on the reader. Scope is judged by the path witho
 
 In `.ja` prose the textlint hook collapses the spaces around `/`. When a collapsed enumeration of Latin-letter words would read as a path, list it with commas instead, and keep established compounds like `CI/CD` and `try/catch` as they are. Wrap slash commands like `/fix` in inline code, so that hook cannot glue them to the preceding word.
 
-| Symbol | Use                                           | Example                               |
-| ------ | --------------------------------------------- | ------------------------------------- |
-| `/`    | AND parallel enumeration                      | `Safety First / Output Verifiability` |
-| `.`    | Separator between independent rules           | `Check scope. Do not skip`            |
-| `()`   | Supplementary condition only                  | `Skip for follow-up (same session)`   |
-| `>`    | Priority order (prefer left, fall back right) | `CLI tool > built-in equivalent`      |
-| `→`    | Step sequence                                 | `Observe → analyze → conclude`        |
-| `§`    | Section reference                             | `phase.md § Gate rule`                |
-| `+`    | Composition of components                     | `root causes + Gate decision`         |
+| Symbol | Use                                           | Example                             |
+| ------ | --------------------------------------------- | ----------------------------------- |
+| `/`    | AND parallel enumeration                      | `Safety First/Output Verifiability` |
+| `.`    | Separator between independent rules           | `Check scope. Do not skip`          |
+| `()`   | Supplementary condition only                  | `Skip for follow-up (same session)` |
+| `>`    | Priority order (prefer left, fall back right) | `CLI tool > built-in equivalent`    |
+| `→`    | Step sequence                                 | `Observe → analyze → conclude`      |
+| `§`    | Section reference                             | `phase.md § Gate rule`              |
+| `+`    | Composition of components                     | `root causes + Gate decision`       |
 
 ## Inline code
 

--- a/skills/dr/tests/script-contract.test.js
+++ b/skills/dr/tests/script-contract.test.js
@@ -94,6 +94,36 @@ test("live な指示と規約に旧称 ADR が残っていない", () => {
   assert.doesNotMatch(readFileSync(join(root, "README.md"), "utf8"), /\bADRs?\b/, "README.md");
 });
 
+// DR-0090 の Confirmation を機械化する。作業成果物は .claude/workspace/ に統一したので、
+// 他プロジェクトのルート直下に無い workspace/ を live な指示が指すと参照が解決しない。
+// 走査形は上の旧称チェックと同じで、置き場所もそれに揃えた。
+test("live な指示と規約が .claude/ を伴わない workspace/ を指していない", () => {
+  const BARE_WORKSPACE = /(?<!\.claude\/)(?<![\w/.])workspace\//;
+  const scanned = [];
+  for (const prefix of ["", ".ja"]) {
+    for (const dir of ["skills", "agents", "rules", "workflows"]) {
+      const base = join(root, prefix, dir);
+      if (!existsSync(base)) continue;
+      for (const entry of readdirSync(base, { recursive: true, withFileTypes: true })) {
+        if (!entry.isFile() || !/\.(md|js|py)$/.test(entry.name)) continue;
+        const full = join(entry.parentPath ?? entry.path, entry.name);
+        const rel = full.slice(join(root, prefix).length + 1);
+        // このテスト自身が bare workspace/ を negative assert に使う。
+        if (rel.includes("__pycache__") || rel === "skills/dr/tests/script-contract.test.js") {
+          continue;
+        }
+        scanned.push(rel);
+        assert.doesNotMatch(
+          readFileSync(full, "utf8"),
+          BARE_WORKSPACE,
+          `${prefix || "en"}: ${rel} が .claude/ を伴わない workspace/ を指す`,
+        );
+      }
+    }
+  }
+  assert.ok(scanned.length > 100, `走査した件数 (${scanned.length})`);
+});
+
 // MADR は v4 で名称が Architectural に戻った外部仕様。この skill が対象を広げていることを
 // 書いておかないと、名称を読んだ書き手がアーキテクチャ決定だけに絞る。
 test("madr-format がアーキテクチャに限らない旨を述べる", () => {


### PR DESCRIPTION
## What & Why

今回の一連 (#259 から #263) で触った資産の整合性をチェックし、見つかった 4 件を直す。うち 3 件は私がこのセッションで作り込んだもの。

## Changes

### 1. 記号表の例が実挙動と噛み合っていなかった

`rules/conventions/MARKDOWN.md` の記号表は `/` の例を `Safety First / Output Verifiability` とスペース付きで示していた。地の文でそう書くと textlint hook が `Safety First/Output Verifiability` に詰めるので、例のとおりには書けない。詰めた形に直して導入文の警告と噛み合わせた。

#264 で導入文だけ直し、表を見ていなかった。

### 2. paths の冗長行

同ファイルの frontmatter で、1 行目の `.claude/**/*.md` が `.claude/workspace/**/*.md` を包含していた。#266 のパス統一で包含関係が生まれたのを見落としていた。削った。

### 3. wiki の 7 箇所が path に見える形になっていた

`docs/wiki/_candidates.md` を 2 行直したところ、hook がファイル全体の `/` を詰めた。

```
Recall / FP baseline          → Recall/FP baseline
JSON stdout / error stderr    → JSON stdout/error stderr
file:line / severity / Closes → file:line/severity/Closes
```

MARKDOWN.md の「詰めた形が path と読めるときは読点で並べる」に従い、読点と inline code へ直した。日本語が絡む `サイズ/形式` などは規約の対象外なので触っていない。

### 4. パス統一に回帰テストが無かった

#266 は 19 ファイルの文字列置換だったが、再び `workspace/` と `.claude/workspace/` が混ざっても検出されない。DR-0090 の Confirmation を機械化し、`skills` / `agents` / `rules` / `workflows` を横断して bare `workspace/` 参照が無いことを検証する。

走査形と置き場所は既存の旧称 ADR チェックに揃えた。同じファイルに置いたのは、リポジトリ横断の表記チェックが現状そこにしか無いため。

## Review focus

- 4 のテストを `skills/dr/tests/script-contract.test.js` に置いた判断。DR-0090 の Confirmation を機械化するものだが、DR skill 固有ではない

## How to Test

```
node --test skills/*/tests/*.test.js .ja/skills/*/tests/*.test.js workflows/tests/
```

実行済みの結果は 187 件すべて green。
