### PR TITLE
docs: COMMANDS.md を build workflow 中心の開発フロー文書に書き換える

### DIFF
--- a/.ja/docs/COMMANDS.md
+++ b/.ja/docs/COMMANDS.md
@@ -1,97 +1,103 @@
-# Commands Design
+# Commands & Workflows
 
-コマンドの設計と関係。
+コマンドと workflow の関係、および build workflow を中心とした開発フロー。
 
 📌 [English version](../../docs/COMMANDS.md)
 
-## アーキテクチャ
+## 開発フロー全体
+
+計画は人間が対話で練り、実装は build workflow が headless で進め、重い担保は draft PR に対して人間が起動する。
 
 ```mermaid
-graph TD
-    subgraph User["User Interface"]
-        CMD["/command"]
+flowchart LR
+    subgraph Plan["計画 (対話)"]
+        R["/research"] --> T["/think"] --> I["/issue"] --> Q["/qualify"]
     end
-
-    subgraph Orchestration["Command Layer"]
-        CMD --> SKILL[Skills]
-        CMD --> AGENT[Agents]
-        CMD --> PLUGIN[External Plugins]
+    subgraph Build["実装 (headless)"]
+        B["build workflow"]
     end
-
-    subgraph Execution["Execution Layer"]
-        SKILL --> FORK[Fork Context]
-        AGENT --> TASK[Task Tool]
+    subgraph Assure["担保 (人間起動)"]
+        PR["draft PR"] --> A["/audit · /polish"]
     end
+    Q --> B --> PR
 ```
 
-## 設計原則
+1〜3 ファイルで済む修正は、この列を通らず `/fix <issue 番号>` で直接完結する。4 ファイル以上か新機能は `/think` で plan を書き、`/issue` で issue の `## Plan` 節へ転記してから build に渡す。`/qualify` は任意の事前点検で、build が止まる条件を発行前に検出する。
 
-### 1. Thin Wrapper パターン
+## build workflow
 
-コマンドはオーケストレータ。実装詳細は持たない。
+`Workflow({name: "build", args: {issue, repo, base?}})` で起動する。Plan 節付き issue を入力に、7 stage を決定論 script として実行する。判断の分担は「抽出と実装は LLM、検証と進行は script」で、LLM の出力は毎回 script 側の照合を通る。
 
-```markdown
-# Good: /code
+| Stage      | 内容                                                                                                      |
+| ---------- | --------------------------------------------------------------------------------------------------------- |
+| Load       | issue 本文を逐語 fetch し、`## Plan` の U-NNN / T-NNN id を決定論収集。LLM 抽出の結果と id クロスチェック |
+| Revalidate | plan の Preconditions (パス + anchor) を現在のコードベースへ再検証                                        |
+| Branch     | fresh checkout と分岐点 sha の捕捉。以降の Verify / Ship はこの sha を基準にする                          |
+| Code       | `workflow("code")` へ委譲。unit ごとに Red → Green で実装し、plan の指示を trailer に載せて個別コミット   |
+| Cleanup    | simplify skill による整理と test 検証。テストが落ちたら編集を stash で巻き戻す                            |
+| Verify     | 決定論チェック (diff スコープ + T-NNN 照合) と並行して conformance / structure review                     |
+| Ship       | 残余 commit + draft PR。PR 本文の fact 節はデータから決定論レンダリングする                               |
 
-- Skills: use-workflow-tdd-cycle (RGRC cycle definition)
-- Native: /goal (optional autonomous iteration)
+正しさの確認は plan 自身のアンカー (Preconditions、files スコープ、T-NNN 言明、conformance) との比較であり、開放的な欠陥探索ではない。欠陥探索は draft PR への `/audit` が担う。
 
-# Bad
+### 停止条件
 
-- TDD ステップをコマンド内にハードコード
-```
+build は壊れた入力をその場で直さず、stop して差し戻す。代表的な stopped 値 (網羅ではない)。
 
-### 2. 条件付きコンテキスト ロード
+| stopped             | 意味                                               | 差し戻し先                     |
+| ------------------- | -------------------------------------------------- | ------------------------------ |
+| no-repo             | args に repo が無い                                | 起動引数を直す                 |
+| no-plan             | issue に `## Plan` 節が無い                        | `/think` + `/issue` で plan 化 |
+| extraction-mismatch | LLM 抽出の id 集合が本文と食い違う                 | plan の書式を直す              |
+| oversized-unit      | 非 seam unit が UNIT_CAPS (3 files / 4 tests) 超過 | unit を分割する                |
+| revalidate-failed   | Preconditions が現在のコードに存在しない           | plan の前提を書き直す          |
+| code-failed         | code workflow が unit を完了できない               | plan の contract を見直す      |
 
-必要なときにのみ skill をロードする。
+### staging ガード
 
-```markdown
-/code (フラグなし) → 追加 skill なし
-```
+Ship は `git add -A` を使わず、2 つの never-stage 集合で PR への混入を防ぐ。
 
-### 3. Graceful Degradation
+- build 以前から存在する未追跡ファイル (Revalidate で採取した baseline)
+- Verify が plan スコープ外と判定した追跡済み変更 (並行セッションの編集など)
 
-外部プラグインなしでもコマンドが動く。
+### 統治する DR
 
-```markdown
-/goal ラップあり → 自律反復; なし → gates 自動リトライ + 手動確認 (同機能)
-```
+| DR                                                                                                     | 決定                                                       |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| [DR-0084](../../docs/decisions/0084-retire-issue-gate-and-hand-issue-flow-orchestration-to-human.md)   | build は人間の `## Plan` 節を再計画しない                  |
+| [DR-0085](../../docs/decisions/0085-replace-builds-audit-fan-out-with-selection-based-verification.md) | 重い担保 (`/audit`、`/polish`) は draft PR に人間が起動    |
+| [DR-0088](../../docs/decisions/0088-commit-each-unit-in-build-with-plan-anchors-as-trailers.md)        | unit ごとにコミットし、Verify / Ship は分岐点 sha を基準   |
+| [DR-0089](../../docs/decisions/0089-retire-build-plan-drafting-and-hand-plan-less-issues-back.md)      | plan なし issue は no-plan で停止し精緻化に差し戻す        |
+| [DR-0090](../../docs/decisions/0090-unify-workspace-and-history-storage-locations.md)                  | 成果物は `.claude/workspace/`、履歴は `~/.claude/history/` |
 
-## Command → Skill/Agent マッピング
+## Workflow 一覧
 
-| コマンド  | 実装                       | 使用 Agent / nested call                                                                  |
-| --------- | -------------------------- | ----------------------------------------------------------------------------------------- |
-| `/think`  | `skills/think/SKILL.md`    | critic-design                                                                             |
-| `/code`   | `workflows/code.js`        | general-purpose の実装・検証 agent                                                        |
-| `/audit`  | `workflows/audit.js`       | file-routed reviewer、critic-audit、critic-evidence、enhancer-integration                 |
-| `/fix`    | `skills/fix/SKILL.md`      | generator-test、resolver-build                                                            |
-| `/polish` | `workflows/polish.js`      | general-purpose、critic-audit、enhancer-code                                               |
-| `/build`  | `workflows/build.js`       | nested workflow は code のみ。audit / polish は人間が個別起動し、fix は連鎖しない        |
+build が入れ子で呼ぶのは code のみ。他は単体起動する。
 
-## ファイル構造
+| Workflow | 役割                                                      | 主な nested agent                                   |
+| -------- | --------------------------------------------------------- | --------------------------------------------------- |
+| build    | Plan 付き issue の end-to-end 実装                        | code (入れ子)、reviewer-conformance、reviewer-reuse |
+| code     | 構造化 plan の TDD 実装 (Implement / Verify)              | 実装 agent (既定 sonnet)、独立 verify agent         |
+| audit    | diff への adversarial review fan-out                      | file-routed reviewer、critic-audit、critic-evidence |
+| polish   | Codex 外部レンズの review + cleanup                       | critic-audit、enhancer-code                         |
+| assert   | merge readiness の独立判定 (Codex を隔離 worktree で並走) | codex、critic 層                                    |
+| shake    | flaky テストの 4 次元検出と根本修正                       | 実行 agent、静的 smell scan                         |
+| adrift   | DR と現行コードの乖離スキャン                             | manifest-routed reviewer                            |
 
-```text
-skills/
-├── fix/SKILL.md       # YAML frontmatter + 実行ステップ
-├── think/SKILL.md
-└── ...
-workflows/
-├── code.js
-├── audit.js
-├── polish.js
-├── build.js
-└── ...
-```
+## Command → 実装マッピング
 
-### Frontmatter フィールド
+| コマンド  | 実装                    | 形態                                    |
+| --------- | ----------------------- | --------------------------------------- |
+| `/think`  | `skills/think/SKILL.md` | skill (critic-design を起動)            |
+| `/fix`    | `skills/fix/SKILL.md`   | skill (generator-test、resolver-build)  |
+| `/build`  | `workflows/build.js`    | workflow                                |
+| `/code`   | `workflows/code.js`     | workflow (build から入れ子でも呼ばれる) |
+| `/audit`  | `workflows/audit.js`    | workflow                                |
+| `/polish` | `workflows/polish.js`   | workflow                                |
 
-| フィールド      | 必須 | 用途                             |
-| --------------- | ---- | -------------------------------- |
-| `description`   | Yes  | コマンド説明 (Skill picker 表示) |
-| `allowed-tools` | No   | 許可ツール                       |
-| `model`         | No   | 使用モデル (opus/sonnet/haiku)   |
-| `argument-hint` | No   | 引数入力時に表示するヒント       |
+skill は SKILL.md の手順を会話 context で実行し、workflow は script が進行を強制する。fan-out・ループ・gate を持つ処理は workflow に置き、LLM の裁量で skip できない形にする ([WORKFLOWS](../rules/conventions/WORKFLOWS.md))。
 
 ## 関連
 
 - [SKILLS_AGENTS.md](./SKILLS_AGENTS.md). Skill とエージェントのリファレンス
+- [DESIGN.md](./DESIGN.md). レイヤー構造と設計哲学

--- a/.ja/docs/DESIGN.md
+++ b/.ja/docs/DESIGN.md
@@ -139,9 +139,11 @@ flowchart LR
         R1["/research"] --> F2["/fix"]
     end
     subgraph Feature["Feature Development"]
-        R2["/research"] --> T["/think"] --> C["/code"] --> A["/audit"]
+        R2["/research"] --> T["/think"] --> I["/issue"] --> B["build workflow"] --> A["/audit · /polish"]
     end
 ```
+
+Feature Development の詳細 (build の 7 stage、停止条件、統治 DR) は[COMMANDS](./COMMANDS.md)が持つ。
 
 ## 根底の哲学
 
@@ -160,13 +162,13 @@ flowchart LR
 
 ## 詳細ドキュメント
 
-| ドキュメント                        | 内容                             |
-| ----------------------------------- | -------------------------------- |
-| [COMMANDS](./COMMANDS.md)           | コマンドの設計と関係             |
-| [SKILLS_AGENTS](./SKILLS_AGENTS.md) | Skill/agent の仕組みと利用       |
-| [HOOKS](./HOOKS.md)                 | Hook システムと Quality Pipeline |
-| [GLOSSARY](./GLOSSARY.md)           | ユビキタス言語辞書               |
+| ドキュメント                        | 内容                                               |
+| ----------------------------------- | -------------------------------------------------- |
+| [COMMANDS](./COMMANDS.md)           | コマンドと workflow の関係、build 中心の開発フロー |
+| [SKILLS_AGENTS](./SKILLS_AGENTS.md) | Skill/agent の仕組みと利用                         |
+| [HOOKS](./HOOKS.md)                 | Hook システムと Quality Pipeline                   |
+| [GLOSSARY](./GLOSSARY.md)           | ユビキタス言語辞書                                 |
 
 ---
 
-_設定の「なぜ」を説明する。「使い方」については [README.md](../README.md) を参照。_
+_設定の「なぜ」を説明する。「使い方」については[README.md](../README.md)を参照。_

--- a/.ja/docs/SKILLS_AGENTS.md
+++ b/.ja/docs/SKILLS_AGENTS.md
@@ -171,6 +171,6 @@ SKILL.md → reference.md (1 階層のみ)
 
 ## 関連
 
-- [COMMANDS.md](./COMMANDS.md). コマンド設計
+- [COMMANDS.md](./COMMANDS.md). コマンドと workflow の関係、build 中心の開発フロー
 - [SKILLS](../rules/conventions/SKILLS.md). Skill 定義書式
 - [SUBAGENT](../rules/conventions/SUBAGENT.md). サブエージェント定義書式

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,98 +1,103 @@
-# Commands Design
+# Commands & Workflows
 
-Command design and relationships.
+How commands and workflows relate, and the development flow centered on the build workflow.
 
-📌 **[日本語版](../.ja/docs/COMMANDS.md)**
+📌 [日本語版](../.ja/docs/COMMANDS.md)
 
-## Architecture
+## The Development Flow
+
+Humans refine the plan interactively, the build workflow implements it headlessly, and heavy assurance is human-invoked on the draft PR.
 
 ```mermaid
-graph TD
-    subgraph User["User Interface"]
-        CMD["/command"]
+flowchart LR
+    subgraph Plan["Planning (interactive)"]
+        R["/research"] --> T["/think"] --> I["/issue"] --> Q["/qualify"]
     end
-
-    subgraph Orchestration["Command Layer"]
-        CMD --> SKILL[Skills]
-        CMD --> AGENT[Agents]
-        CMD --> PLUGIN[External Plugins]
+    subgraph Build["Implementation (headless)"]
+        B["build workflow"]
     end
-
-    subgraph Execution["Execution Layer"]
-        SKILL --> FORK[Fork Context]
-        AGENT --> TASK[Task Tool]
+    subgraph Assure["Assurance (human-invoked)"]
+        PR["draft PR"] --> A["/audit · /polish"]
     end
+    Q --> B --> PR
 ```
 
-## Design Principles
+A fix confined to 1-3 files skips this column and completes directly via `/fix <issue number>`. Work spanning 4+ files or a new feature gets its plan written via `/think`, transferred into the issue's `## Plan` section via `/issue`, and then handed to build. `/qualify` is an optional pre-flight that detects build-stopping conditions before launch.
 
-### 1. Thin Wrapper Pattern
+## The build Workflow
 
-Commands are orchestrators, no implementation details.
+Launched via `Workflow({name: "build", args: {issue, repo, base?}})`. Taking a plan-backed issue as input, it runs 7 stages as a deterministic script. The division of labor is "extraction and implementation go to the LLM, verification and progression stay in the script": every LLM output passes a script-side cross-check.
 
-```markdown
-# Good: /code
+| Stage      | What it does                                                                                                         |
+| ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| Load       | Fetch the issue body verbatim, collect `## Plan` U-NNN / T-NNN ids deterministically, cross-check the LLM extraction |
+| Revalidate | Re-verify the plan's Preconditions (path + anchor) against the current codebase                                      |
+| Branch     | Fresh checkout and capture of the branch-point sha. Verify / Ship use this sha as their baseline                     |
+| Code       | Delegate to `workflow("code")`. Each unit is implemented Red → Green and committed separately with plan trailers     |
+| Cleanup    | A simplify-skill pass with test validation. Failing tests roll the edits back via stash                              |
+| Verify     | Deterministic checks (diff scope + T-NNN matching) alongside conformance / structure reviews                         |
+| Ship       | Remainder commit + draft PR. The PR body's fact sections are rendered deterministically from data                    |
 
-- Skills: use-workflow-tdd-cycle (RGRC cycle definition)
-- Native: /goal (optional autonomous iteration)
+Correctness checking is a comparison against the plan's own anchors (Preconditions, files scope, T-NNN statements, conformance), not an open-ended defect hunt. Defect hunting belongs to `/audit` on the draft PR.
 
-# Bad
+### Stop Conditions
 
-- Hardcoding TDD steps inside the command
-```
+build does not repair broken input in place; it stops and hands it back. Representative stopped values (not exhaustive).
 
-### 2. Conditional Context Loading
+| stopped             | Meaning                                               | Hand-back                         |
+| ------------------- | ----------------------------------------------------- | --------------------------------- |
+| no-repo             | args carries no repo                                  | Fix the launch args               |
+| no-plan             | The issue has no `## Plan` section                    | Write one via `/think` + `/issue` |
+| extraction-mismatch | The LLM extraction's id sets diverge from the body    | Fix the plan's format             |
+| oversized-unit      | A non-seam unit exceeds UNIT_CAPS (3 files / 4 tests) | Split the unit                    |
+| revalidate-failed   | A Precondition does not exist in the current code     | Rewrite the plan's premises       |
+| code-failed         | The code workflow could not complete a unit           | Revisit the plan's contract       |
 
-Load skills only when needed.
+### Staging Guards
 
-```markdown
-/code (no flags) → no additional skills
-```
+Ship never uses `git add -A`; two never-stage sets keep foreign work out of the PR.
 
-### 3. Graceful Degradation
+- Untracked files that predate the build (the baseline captured at Revalidate)
+- Tracked modifications Verify judged outside the plan's scope (such as a concurrent session's edits)
 
-Commands work without external plugins:
+### Governing DRs
 
-```markdown
-/goal wrapping → autonomous iteration; absent → gates auto-retry + manual
-confirmation (same functionality)
-```
+| DR                                                                                          | Decision                                                                    |
+| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [DR-0084](decisions/0084-retire-issue-gate-and-hand-issue-flow-orchestration-to-human.md)   | build never re-plans a human's `## Plan` section                            |
+| [DR-0085](decisions/0085-replace-builds-audit-fan-out-with-selection-based-verification.md) | Heavy assurance (`/audit`, `/polish`) is human-invoked on the draft PR      |
+| [DR-0088](decisions/0088-commit-each-unit-in-build-with-plan-anchors-as-trailers.md)        | Commit per unit; Verify / Ship baseline on the branch-point sha             |
+| [DR-0089](decisions/0089-retire-build-plan-drafting-and-hand-plan-less-issues-back.md)      | A plan-less issue stops as no-plan and goes back for refinement             |
+| [DR-0090](decisions/0090-unify-workspace-and-history-storage-locations.md)                  | Work products live in `.claude/workspace/`, records in `~/.claude/history/` |
 
-## Command → Skill/Agent Mapping
+## Workflow Roster
 
-| Command   | Implementation             | Agents / nested calls                                                                  |
-| --------- | -------------------------- | -------------------------------------------------------------------------------------- |
-| `/think`  | `skills/think/SKILL.md`    | critic-design                                                                          |
-| `/code`   | `workflows/code.js`        | general-purpose implementation and verification agents                                 |
-| `/audit`  | `workflows/audit.js`       | file-routed reviewers, critic-audit, critic-evidence, enhancer-integration              |
-| `/fix`    | `skills/fix/SKILL.md`      | generator-test, resolver-build                                                         |
-| `/polish` | `workflows/polish.js`      | general-purpose, critic-audit, enhancer-code                                            |
-| `/build`  | `workflows/build.js`       | Nests only code. Humans invoke audit and polish separately; fix is not chained          |
+build nests only code. The others launch standalone.
 
-## File Structure
+| Workflow | Role                                                                | Main nested agents                                               |
+| -------- | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| build    | End-to-end implementation of a plan-backed issue                    | code (nested), reviewer-conformance, reviewer-reuse              |
+| code     | TDD implementation of a structured plan (Implement / Verify)        | Implementation agents (default sonnet), independent verify agent |
+| audit    | Adversarial review fan-out over a diff                              | File-routed reviewers, critic-audit, critic-evidence             |
+| polish   | External-lens (Codex) review + cleanup                              | critic-audit, enhancer-code                                      |
+| assert   | Independent merge-readiness verdict (Codex in an isolated worktree) | codex, critic layer                                              |
+| shake    | 4-dimension flaky-test detection and root-cause fix                 | Runner agents, static smell scan                                 |
+| adrift   | Drift scan between DRs and current code                             | Manifest-routed reviewers                                        |
 
-```text
-skills/
-├── fix/SKILL.md       # YAML front matter + execution steps
-├── think/SKILL.md
-└── ...
-workflows/
-├── code.js
-├── audit.js
-├── polish.js
-├── build.js
-└── ...
-```
+## Command → Implementation Mapping
 
-### Front Matter Fields
+| Command   | Implementation          | Form                                   |
+| --------- | ----------------------- | -------------------------------------- |
+| `/think`  | `skills/think/SKILL.md` | Skill (launches critic-design)         |
+| `/fix`    | `skills/fix/SKILL.md`   | Skill (generator-test, resolver-build) |
+| `/build`  | `workflows/build.js`    | Workflow                               |
+| `/code`   | `workflows/code.js`     | Workflow (also nested from build)      |
+| `/audit`  | `workflows/audit.js`    | Workflow                               |
+| `/polish` | `workflows/polish.js`   | Workflow                               |
 
-| Field           | Required | Purpose                                    |
-| --------------- | -------- | ------------------------------------------ |
-| `description`   | Yes      | Command description (Skill picker display) |
-| `allowed-tools` | No       | Permitted tools                            |
-| `model`         | No       | Model to use (opus/sonnet/haiku)           |
-| `argument-hint` | No       | Hint shown for argument input              |
+A skill executes its SKILL.md procedure in the conversation context; a workflow's script enforces progression. Processing that carries fan-out, loops, or gates goes into a workflow, in a shape the LLM cannot skip at its discretion ([WORKFLOWS](../rules/conventions/WORKFLOWS.md)).
 
 ## Related
 
-- [SKILLS_AGENTS.md](./SKILLS_AGENTS.md) - Skills and agents reference
+- [SKILLS_AGENTS.md](./SKILLS_AGENTS.md). Skill and agent reference
+- [DESIGN.md](./DESIGN.md). Layer structure and design philosophy

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -140,9 +140,11 @@ flowchart LR
         R1["/research"] --> F2["/fix"]
     end
     subgraph Feature["Feature Development"]
-        R2["/research"] --> T["/think"] --> C["/code"] --> A["/audit"]
+        R2["/research"] --> T["/think"] --> I["/issue"] --> B["build workflow"] --> A["/audit · /polish"]
     end
 ```
+
+The Feature Development detail (build's 7 stages, stop conditions, governing DRs) lives in [COMMANDS](./COMMANDS.md).
 
 ## Underlying Philosophy
 
@@ -163,12 +165,12 @@ Built on the premise that "**AI makes mistakes**":
 
 Refer to:
 
-| Document                            | Content                          |
-| ----------------------------------- | -------------------------------- |
-| [COMMANDS](./COMMANDS.md)           | Command design and relationships |
-| [SKILLS_AGENTS](./SKILLS_AGENTS.md) | Skill/agent mechanisms and usage |
-| [HOOKS](./HOOKS.md)                 | Hook system and Quality Pipeline |
-| [GLOSSARY](./GLOSSARY.md)           | Ubiquitous language dictionary   |
+| Document                            | Content                                                      |
+| ----------------------------------- | ------------------------------------------------------------ |
+| [COMMANDS](./COMMANDS.md)           | Commands, workflows, and the build-centered development flow |
+| [SKILLS_AGENTS](./SKILLS_AGENTS.md) | Skill/agent mechanisms and usage                             |
+| [HOOKS](./HOOKS.md)                 | Hook system and Quality Pipeline                             |
+| [GLOSSARY](./GLOSSARY.md)           | Ubiquitous language dictionary                               |
 
 ---
 

--- a/docs/SKILLS_AGENTS.md
+++ b/docs/SKILLS_AGENTS.md
@@ -175,6 +175,6 @@ Reason: Claude truncates deep nesting with `head -100`, causing information loss
 
 ## Related
 
-- [COMMANDS.md](./COMMANDS.md) - Command design
+- [COMMANDS.md](./COMMANDS.md) - Commands, workflows, and the build-centered development flow
 - [SKILLS](../rules/conventions/SKILLS.md) - Skill definition format
 - [SUBAGENT](../rules/conventions/SUBAGENT.md) - Sub-agent definition format


### PR DESCRIPTION
## What & Why

COMMANDS.md は thin wrapper パターンの解説と /goal 連携など、現行に存在しない構成を説明していた。DESIGN.md §5 のフロー図も `/research → /think → /code → /audit` のままで、build workflow 導入後の実フローと食い違っていた。build を中心とした現行フローを、既存ファイルの書き換えで文書化する。

## Changes

COMMANDS.md (両側) を以下の構成で書き直した。

- 開発フロー全体。計画は対話、実装は headless、担保は人間起動という 3 区分
- build の 7 stage 表と「抽出と実装は LLM、検証と進行は script」の分担
- 代表的な停止条件 6 つと差し戻し先
- Ship の never-stage 2 集合 (baseline untracked + scope 逸脱 tracked)
- 統治する DR (0084 / 0085 / 0088 / 0089 / 0090) への実ファイルリンク
- workflow 7 本の一覧と command マッピング

DESIGN.md §5 の Feature Development を issue → build workflow 経由へ更新し、詳細は COMMANDS.md へ委ねた。SKILLS_AGENTS.md の参照文言も新しい範囲に合わせた。

## 検証

- 両側 COMMANDS.md の markdown link 9 本すべてが実ファイルに解決することを確認済み
- stage 一覧・停止条件・never-stage は build.js の meta / stopped 値 / Ship prompt から転記
- テスト 132 件 green (docs は走査対象外、回帰なしの確認)

## Review focus

- 停止条件表は 13 種のうち代表 6 つに絞った。網羅でないことは本文に明記してあるが、絞り方が妥当か
- COMMANDS.md というファイル名のまま内容を Commands & Workflows に広げた。改名は参照 5 箇所の書き換えを伴うため見送った

Closes なし (issue を経ない直接依頼)
